### PR TITLE
feat: refresh home page design

### DIFF
--- a/app/(site)/components/Community.tsx
+++ b/app/(site)/components/Community.tsx
@@ -2,7 +2,7 @@ export default function Community(){
   return(<section id="community" className="py-4"><div className="container"><h2 className="text-lg font-bold mb-2">🤝 Community & Links</h2>
     <p className="text-[var(--muted)] text-sm">Join the community and follow updates.</p>
     <h3 className="text-sm text-[var(--muted)] mt-2">Partners</h3>
-    <div className="flex flex-wrap gap-2 mt-1">{['A','B','C','D'].map(x=><span key={x} className="w-12 h-12 rounded-xl border border-white/15 bg-white/5 grid place-items-center font-black">{x}</span>)}</div>
+    <div className="flex flex-wrap gap-2 mt-1">{['A','B','C','D'].map(x=><span key={x} className="w-12 h-12 rounded-xl border border-[var(--line)] bg-black/5 grid place-items-center font-black">{x}</span>)}</div>
     <div className="flex flex-wrap gap-2 mt-3">
       <a className="btn btn-primary" target="_blank" href="https://t.me/eltx_official">Telegram Channel</a>
       <a className="btn btn-primary" target="_blank" href="https://t.me/eltx_chat">Telegram Chat</a>

--- a/app/(site)/components/Features.tsx
+++ b/app/(site)/components/Features.tsx
@@ -1,9 +1,9 @@
 export default function Features(){
   const Card=({icon,title,text,pills}:{icon:string,title:string,text:string,pills:string[]})=>(
-    <article className="panel p-4 bg-gradient-to-br from-white/5 to-white/0">
-      <div className="w-16 h-16 rounded-full bg-gradient-to-br from-[var(--brand1)]/30 to-[var(--brand2)]/20 border border-white/20 grid place-items-center text-2xl mb-2 shadow-lg">{icon}</div>
+    <article className="panel p-4 bg-gradient-to-br from-black/5 to-black/0">
+      <div className="w-16 h-16 rounded-full bg-gradient-to-br from-[var(--brand1)]/30 to-[var(--brand2)]/20 border border-[var(--line)] grid place-items-center text-2xl mb-2 shadow-lg">{icon}</div>
       <h3 className="font-bold">{title}</h3><p className="text-[var(--muted)] text-sm">{text}</p>
-      <div className="flex flex-wrap gap-2 mt-2">{pills.map(p=><span key={p} className="px-3 py-1 rounded-full border border-white/15 text-xs bg-white/5">{p}</span>)}</div>
+      <div className="flex flex-wrap gap-2 mt-2">{pills.map(p=><span key={p} className="px-3 py-1 rounded-full border border-[var(--line)] text-xs bg-black/5">{p}</span>)}</div>
     </article>);
   return(<section id="features" className="py-4"><div className="container"><h2 className="text-lg font-bold mb-2">⚡ Features</h2>
     <div className="grid grid-cols-1 gap-3 md:grid-cols-4">

--- a/app/(site)/components/Header.tsx
+++ b/app/(site)/components/Header.tsx
@@ -9,7 +9,7 @@ export default function Header(){
   const [open,setOpen]=useState(false);
   return(<header className="header"><div className="container flex items-center justify-between py-2">
     <a href="#" className="flex items-center gap-2 no-underline">
-      <span className="block w-11 h-11 rounded-xl overflow-hidden border border-white/15"><img src="/assets/img/logo.jpeg" alt="ELTX" /></span>
+      <span className="block w-11 h-11 rounded-xl overflow-hidden border border-[var(--line)]"><img src="/assets/img/logo.jpeg" alt="ELTX" /></span>
       <span className="font-black tracking-wide">{t.site_title}</span>
     </a>
     <button className="nav-toggle" onClick={()=>setOpen(v=>!v)}>☰</button>

--- a/app/(site)/components/Tokenomics.tsx
+++ b/app/(site)/components/Tokenomics.tsx
@@ -11,7 +11,7 @@ export default function Tokenomics(){
       <div className="donut" style={{['--donut' as any]:gradient} as any}><div className="hole"><div className="font-black">ELTX</div><div className="text-xs text-[var(--muted)]">Total 1B</div></div></div>
       <ul className="grid gap-2">{TOKENS.map(t=>(<li key={t.k} className="grid items-center gap-2" style={{gridTemplateColumns:'16px 1fr 1fr auto'}}>
         <span className="w-2.5 h-2.5 rounded-full" style={{background:t.c}}/><b>{t.k}</b>
-        <span className="h-2 bg-white/10 rounded-full overflow-hidden"><i className="block h-full" style={{width:`${t.p}%`,background:t.c}}/></span>
+        <span className="h-2 bg-black/10 rounded-full overflow-hidden"><i className="block h-full" style={{width:`${t.p}%`,background:t.c}}/></span>
         <span className="font-black">{t.p}%</span></li>))}</ul>
     </div></div></section>);
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,36 +3,36 @@
 @tailwind utilities;
 
 :root{
-  --bg:#090c17; --bg2:#090e22; --line:rgba(255,255,255,.12);
-  --text:#fff; --muted:#b8c4d7;
+  --bg:#fdfdfd; --bg2:#f7f9fc; --line:rgba(0,0,0,.1);
+  --text:#111; --muted:#4b5563;
   --brand1:#ff5a3c; --brand2:#ffc34d;
 }
 html,body{height:100%}
 body{color:var(--text);background:
- radial-gradient(1200px 600px at 50% -200px,rgba(255,90,60,.18),transparent),
+ radial-gradient(1200px 600px at 50% -200px,rgba(255,90,60,.05),transparent),
  linear-gradient(180deg,var(--bg),var(--bg2));}
 .container{max-width:1040px;margin:0 auto;padding:0 14px}
 a{color:inherit}
-.ticker{position:sticky;top:0;z-index:50;background:#0a0f22cc;border-bottom:1px solid var(--line);backdrop-filter:blur(8px);overflow:hidden}
+.ticker{position:sticky;top:0;z-index:50;background:#ffffffcc;border-bottom:1px solid var(--line);backdrop-filter:blur(8px);overflow:hidden}
 .ticker .track{display:flex;gap:32px;white-space:nowrap;animation:marquee 26s linear infinite;padding:8px 14px;font-size:13px}
 @keyframes marquee{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
 .header{position:sticky;top:32px;z-index:40}
 .nav-toggle{border:1px solid var(--line);border-radius:10px;padding:7px 10px}
-.nav{display:none;position:fixed;left:10px;right:10px;top:90px;border:1px solid var(--line);background:rgba(12,16,36,.95);backdrop-filter:blur(8px);padding:10px;border-radius:14px}
+.nav{display:none;position:fixed;left:10px;right:10px;top:90px;border:1px solid var(--line);background:rgba(255,255,255,.95);backdrop-filter:blur(8px);padding:10px;border-radius:14px}
 .nav.open{display:flex;flex-direction:column;gap:8px}
 .nav a{padding:10px;border-radius:10px}
-.nav a:hover{background:rgba(255,255,255,.06)}
-.hero .ring{width:190px;height:190px;border-radius:50%;background:linear-gradient(180deg,rgba(255,90,60,.28),rgba(255,195,77,.18));border:1px solid rgba(255,255,255,.18);display:grid;place-items:center;position:relative;box-shadow:0 30px 80px rgba(255,90,60,.25);animation:float 4s ease-in-out infinite, pulse 6s ease-in-out infinite}
-.hero .ring img{width:68%;height:68%;border-radius:50%;border:2px solid rgba(255,255,255,.6);background:#fff}
+.nav a:hover{background:rgba(0,0,0,.06)}
+.hero .ring{width:190px;height:190px;border-radius:50%;background:linear-gradient(180deg,rgba(255,90,60,.28),rgba(255,195,77,.18));border:1px solid rgba(0,0,0,.1);display:grid;place-items:center;position:relative;box-shadow:0 30px 80px rgba(255,90,60,.25);animation:float 4s ease-in-out infinite, pulse 6s ease-in-out infinite}
+.hero .ring img{width:68%;height:68%;border-radius:50%;border:2px solid rgba(0,0,0,.1);background:#fff}
 @keyframes pulse {0%,100%{transform:scale(1)}50%{transform:scale(1.03)}}
 @keyframes float {0%,100%{transform:translateY(0)}50%{transform:translateY(-4px)}
 }
 .btn{display:inline-flex;align-items:center;gap:8px;padding:10px 14px;border-radius:12px;text-decoration:none;font-weight:900;transition:transform .15s ease, box-shadow .2s ease}
 .btn:hover{transform:translateY(-1px);box-shadow:0 8px 24px rgba(0,0,0,.35)}
 .btn:active{transform:translateY(1px)}
-.btn-primary{background:linear-gradient(90deg,var(--brand1),var(--brand2));color:#2b1800;border:1px solid rgba(255,255,255,.15)}
-.btn-ghost{border:1px solid rgba(255,255,255,.25);color:var(--text);background:rgba(255,255,255,.02)}
-.panel{background:rgba(255,255,255,.06);border:1px solid var(--line);border-radius:16px;box-shadow:0 12px 40px rgba(0,0,0,.45)}
+.btn-primary{background:linear-gradient(90deg,var(--brand1),var(--brand2));color:#2b1800;border:1px solid rgba(0,0,0,.1)}
+.btn-ghost{border:1px solid rgba(0,0,0,.15);color:var(--text);background:rgba(0,0,0,.02)}
+.panel{background:rgba(0,0,0,.03);border:1px solid var(--line);border-radius:16px;box-shadow:0 12px 40px rgba(0,0,0,.1)}
 .donut{--size:230px; width:var(--size);height:var(--size);border-radius:50%;margin:0 auto;background:var(--donut);position:relative}
-.donut .hole{position:relative;width:calc(var(--size) - 44px);height:calc(var(--size) - 44px);margin:22px auto;border-radius:50%;background:rgba(0,0,0,.25);display:flex;align-items:center;justify-content:center;flex-direction:column}
-.bottom-nav{position:sticky;bottom:0;display:flex;justify-content:space-around;gap:6px;padding:10px;border-top:1px solid var(--line);background:#0a1024cc;backdrop-filter:blur(8px)}
+.donut .hole{position:relative;width:calc(var(--size) - 44px);height:calc(var(--size) - 44px);margin:22px auto;border-radius:50%;background:rgba(255,255,255,.9);display:flex;align-items:center;justify-content:center;flex-direction:column}
+.bottom-nav{position:sticky;bottom:0;display:flex;justify-content:space-around;gap:6px;padding:10px;border-top:1px solid var(--line);background:#ffffffcc;backdrop-filter:blur(8px)}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,7 +10,7 @@ import BottomNav from './(site)/components/BottomNav';
 export default function Page(){
   return(<main>
     <Ticker/><Header/><Hero/><Features/><Tokenomics/><Roadmap/><Community/><BottomNav/>
-    <footer className="container py-4 text-white/70 text-sm border-t border-white/10 mt-4 flex items-center justify-between">
+    <footer className="container py-4 text-[var(--muted)] text-sm border-t border-[var(--line)] mt-4 flex items-center justify-between">
       <div>© {new Date().getFullYear()} ELTX</div>
       <div className="flex gap-2"><a href="#">Privacy</a><span>·</span><a href="#">Terms</a></div>
     </footer>


### PR DESCRIPTION
## Summary
- modernize layout with a light theme and brighter components
- update feature cards, community badges, and token bars for new palette
- refine footer styling to use theme variables

## Testing
- `npm install`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b48163b654832bad18038d341d84dd