### PR TITLE
Resolve merge remnants in signup page

### DIFF
--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -11,15 +11,18 @@ export default function SignupPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const res = await fetch('http://localhost:4000/auth/signup', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ email, username, password })
-
-    });
-    const data = await res.json().catch(() => ({}));
-    setMessage(data.message || (res.ok ? 'Account created' : 'Signup failed'));
+    try {
+      const res = await fetch('http://localhost:4000/auth/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ email, username, password }),
+      });
+      const data = await res.json().catch(() => ({}));
+      setMessage(data.message || (res.ok ? 'Account created' : 'Signup failed'));
+    } catch {
+      setMessage('Signup failed');
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- clean up merge conflict remnants in signup page and add basic fetch error handling
- preserve header import and email/username/password fields for signup form

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b5048b9874832b9e7b1cde2602828b