### PR TITLE
Clean up Header navigation and remove merge markers

### DIFF
--- a/app/(site)/components/Header.tsx
+++ b/app/(site)/components/Header.tsx
@@ -5,6 +5,7 @@ import { dict, Lang } from '../i18n';
 
 export default function Header() {
   const [lang, setLang] = useState<Lang>('en');
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     const stored = localStorage.getItem('lang') as Lang | null;
@@ -18,22 +19,34 @@ export default function Header() {
   }, [lang]);
 
   const t = dict[lang];
-  const [open,setOpen]=useState(false);
-  return(<header className="header"><div className="container flex items-center justify-between py-2">
-    <a href="#" className="flex items-center gap-2 no-underline">
-      <span className="block w-11 h-11 rounded-xl overflow-hidden border border-[var(--line)]"><img src="/assets/img/logo.jpeg" alt="ELTX" /></span>
-      <span className="font-black tracking-wide">{t.site_title}</span>
-    </a>
-    <button className="nav-toggle" onClick={()=>setOpen(v=>!v)}>☰</button>
-    <nav className={`nav ${open?'open':''}`}>
-      <a href="#features">{t.features}</a>
-      <a href="#tokenomics">{t.tokenomics}</a>
-      <a href="#roadmap">{t.roadmap_title}</a>
-      <a href="#community">{t.community}</a>
-      <a href="/login">{t.login}</a>
-      <a href="/signup">{t.signup}</a>
-      <button className="nav-toggle" onClick={()=>setLang(lang==='en'?'ar':'en')}>{lang==='en'?'العربية':'English'}</button>
-    </nav>
-  </div></header>);
 
+  return (
+    <header className="header">
+      <div className="container flex items-center justify-between py-2">
+        <a href="#" className="flex items-center gap-2 no-underline">
+          <span className="block w-11 h-11 rounded-xl overflow-hidden border border-[var(--line)]">
+            <img src="/assets/img/logo.jpeg" alt="ELTX" />
+          </span>
+          <span className="font-black tracking-wide">{t.site_title}</span>
+        </a>
+        <button className="nav-toggle" onClick={() => setOpen(v => !v)}>
+          ☰
+        </button>
+        <nav className={`nav ${open ? 'open' : ''}`}>
+          <a href="#features">{t.features}</a>
+          <a href="#tokenomics">{t.tokenomics}</a>
+          <a href="#roadmap">{t.roadmap_title}</a>
+          <a href="#community">{t.community}</a>
+          <a href="/login">{t.login}</a>
+          <a href="/signup">{t.signup}</a>
+          <button
+            className="nav-toggle"
+            onClick={() => setLang(lang === 'en' ? 'ar' : 'en')}
+          >
+            {lang === 'en' ? 'العربية' : 'English'}
+          </button>
+        </nav>
+      </div>
+    </header>
+  );
 }


### PR DESCRIPTION
## Summary
- format Header component and ensure navigation links for features, tokenomics, roadmap, community, login, signup, and language toggle remain
- remove any leftover merge markers in Header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5049496cc832b8bb282789526581c