### PR TITLE
fix: use MySQL-compatible precision for amount_wei

### DIFF
--- a/db/wallet.sql
+++ b/db/wallet.sql
@@ -48,7 +48,7 @@ CREATE TABLE IF NOT EXISTS wallet_deposits (
   block_number BIGINT UNSIGNED NOT NULL,
   block_hash VARCHAR(80) NOT NULL,
   token_address VARCHAR(64) NULL,
-  amount_wei DECIMAL(78,0) NOT NULL,
+  amount_wei DECIMAL(65,0) NOT NULL,
   confirmations INT UNSIGNED NOT NULL DEFAULT 0,
   status ENUM('seen','confirmed','swept','orphaned') NOT NULL DEFAULT 'seen',
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
## Summary
- adjust `wallet_deposits.amount_wei` to `DECIMAL(65,0)` for MySQL compatibility

## Testing
- `mysql --socket=/tmp/mysql.sock -e "SHOW CREATE TABLE wallet_deposits\G" wallet_db`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b62ebb43c4832b9f09f2119ce8a86b