### PR TITLE
refactor: use env API base

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ npm run worker # starts the blockchain worker
 npm run dev:all
 ```
 
+Set `NEXT_PUBLIC_API_BASE` in `.env` to the base URL of the API, for example:
+
+```
+NEXT_PUBLIC_API_BASE=http://localhost:4000
+```
+
 The API uses a MySQL database. Create one and run `api/schema.sql` plus `db/wallet.sql` against it.
 
 ### ENV required (names only)

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -9,7 +9,7 @@ export default function LoginPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const res = await fetch('http://localhost:4000/auth/login', {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -12,7 +12,7 @@ export default function SignupPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await fetch('http://localhost:4000/auth/signup', {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/auth/signup`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',


### PR DESCRIPTION
## Summary
- use environment variable for signup & login API calls
- document NEXT_PUBLIC_API_BASE in README

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b76c68f4b0832ba425498b6ac47b5a