### PR TITLE
refactor: rename API env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@ DB_USER=root
 DB_PASS=password
 DB_NAME=eltx
 # PORT=4000
+
+NEXT_PUBLIC_API_URL=http://localhost:4000

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ npm run worker # starts the blockchain worker
 npm run dev:all
 ```
 
-Set `NEXT_PUBLIC_API_BASE` in `.env` to the base URL of the API, for example:
+Set `NEXT_PUBLIC_API_URL` in `.env` to the base URL of the API, for example:
 
 ```
-NEXT_PUBLIC_API_BASE=http://localhost:4000
+NEXT_PUBLIC_API_URL=http://localhost:4000
 ```
 
 The API uses a MySQL database. Create one and run `api/schema.sql` plus `db/wallet.sql` against it.

--- a/app/(app)/account/wallet/page.tsx
+++ b/app/(app)/account/wallet/page.tsx
@@ -10,7 +10,7 @@ export default function WalletPage() {
   const [deposits, setDeposits] = useState<Deposit[]>([]);
 
   useEffect(() => {
-    fetch(`${process.env.NEXT_PUBLIC_API_BASE}/wallet/me`, { credentials: 'include' })
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/wallet/me`, { credentials: 'include' })
       .then((r) => r.json())
       .then((d) => {
         setWallet(d.wallet);

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -8,7 +8,7 @@ export default function DashboardPage() {
   const [wallet, setWallet] = useState<WalletInfo | null>(null);
 
   useEffect(() => {
-    fetch(`${process.env.NEXT_PUBLIC_API_BASE}/wallet/me`, { credentials: 'include' })
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/wallet/me`, { credentials: 'include' })
       .then((r) => r.json())
       .then((d) => setWallet(d.wallet));
   }, []);

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -9,7 +9,7 @@ export default function LoginPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/auth/login`, {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -12,7 +12,7 @@ export default function SignupPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/auth/signup`, {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/signup`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',


### PR DESCRIPTION
## Summary
- replace NEXT_PUBLIC_API_BASE usage with NEXT_PUBLIC_API_URL
- document new NEXT_PUBLIC_API_URL env variable

## Testing
- `npm run lint`
- `npm run build`
- `pm2 restart eltx-next` *(fails: Process or Namespace eltx-next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7878cc060832b9f876660aec357dc