### PR TITLE
Validate NEXT_PUBLIC_API_URL before API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ npm run worker # starts the blockchain worker
 npm run dev:all
 ```
 
-Set `NEXT_PUBLIC_API_BASE` in `.env` to the base URL of the API, for example:
+Set `NEXT_PUBLIC_API_URL` in `.env` to the base URL of the API, for example:
 
 ```
-NEXT_PUBLIC_API_BASE=http://localhost:4000
+NEXT_PUBLIC_API_URL=http://localhost:4000
 ```
 
 The API uses a MySQL database. Create one and run `api/schema.sql` plus `db/wallet.sql` against it.

--- a/app/(app)/account/wallet/page.tsx
+++ b/app/(app)/account/wallet/page.tsx
@@ -2,6 +2,9 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 
+const apiBase = process.env.NEXT_PUBLIC_API_URL;
+if (!apiBase) throw new Error('NEXT_PUBLIC_API_URL is not defined');
+
 type Deposit = { tx_hash: string; amount_wei: string; confirmations: number; status: string; created_at: string };
 type WalletInfo = { chain: string; address: string; derivation_index: number };
 
@@ -10,7 +13,7 @@ export default function WalletPage() {
   const [deposits, setDeposits] = useState<Deposit[]>([]);
 
   useEffect(() => {
-    fetch(`${process.env.NEXT_PUBLIC_API_BASE}/wallet/me`, { credentials: 'include' })
+    fetch(`${apiBase}/wallet/me`, { credentials: 'include' })
       .then((r) => r.json())
       .then((d) => {
         setWallet(d.wallet);

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -2,13 +2,16 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 
+const apiBase = process.env.NEXT_PUBLIC_API_URL;
+if (!apiBase) throw new Error('NEXT_PUBLIC_API_URL is not defined');
+
 type WalletInfo = { chain: string; address: string; derivation_index: number };
 
 export default function DashboardPage() {
   const [wallet, setWallet] = useState<WalletInfo | null>(null);
 
   useEffect(() => {
-    fetch(`${process.env.NEXT_PUBLIC_API_BASE}/wallet/me`, { credentials: 'include' })
+    fetch(`${apiBase}/wallet/me`, { credentials: 'include' })
       .then((r) => r.json())
       .then((d) => setWallet(d.wallet));
   }, []);

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,6 +2,9 @@
 import { useState } from 'react';
 import Header from '../(site)/components/Header';
 
+const apiBase = process.env.NEXT_PUBLIC_API_URL;
+if (!apiBase) throw new Error('NEXT_PUBLIC_API_URL is not defined');
+
 export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -9,7 +12,7 @@ export default function LoginPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/auth/login`, {
+    const res = await fetch(`${apiBase}/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -2,6 +2,9 @@
 import { useState } from 'react';
 import Header from '../(site)/components/Header';
 
+const apiBase = process.env.NEXT_PUBLIC_API_URL;
+if (!apiBase) throw new Error('NEXT_PUBLIC_API_URL is not defined');
+
 export default function SignupPage() {
   const [email, setEmail] = useState('');
   const [username, setUsername] = useState('');
@@ -12,7 +15,7 @@ export default function SignupPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/auth/signup`, {
+      const res = await fetch(`${apiBase}/auth/signup`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',


### PR DESCRIPTION
## Summary
- Guard against missing `NEXT_PUBLIC_API_URL` and reuse checked value in client pages
- Document `NEXT_PUBLIC_API_URL` environment variable in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b787a8d740832ba3781d0c90246782