### PR TITLE
fix: correct user_balances FK and API env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ npm run worker # starts the blockchain worker
 npm run dev:all
 ```
 
+Set `NEXT_PUBLIC_API_URL` in `.env` to the base URL of the API, for example:
+
+```
+NEXT_PUBLIC_API_URL=http://localhost:4000
+```
+
 The API uses a MySQL database. Create one and run `api/schema.sql` plus `db/wallet.sql` against it.
 
 ### ENV required (names only)
@@ -30,5 +36,7 @@ CORS_ORIGIN
 SESSION_COOKIE_DOMAIN
 SESSION_COOKIE_NAME
 ```
+
+`CORS_ORIGIN` accepts a comma-separated list of allowed origins, e.g. `http://localhost:3000,https://eltx.online`.
 
 If you see `Module not found: './globals.css'`, make sure the file exists at `app/globals.css`.

--- a/api/.env.example
+++ b/api/.env.example
@@ -10,6 +10,6 @@ OMNIBUS_ADDRESS=
 OMNIBUS_PK=
 
 DATABASE_URL=
-CORS_ORIGIN=http://localhost:3000
+CORS_ORIGIN=http://localhost:3000,https://eltx.online
 SESSION_COOKIE_DOMAIN=localhost
 SESSION_COOKIE_NAME=sid

--- a/api/server.js
+++ b/api/server.js
@@ -12,7 +12,10 @@ require('dotenv').config();
 
 const app = express();
 app.use(helmet());
-app.use(cors({ origin: process.env.CORS_ORIGIN || 'http://localhost:3000', credentials: true }));
+const allowedOrigins = process.env.CORS_ORIGIN
+  ? process.env.CORS_ORIGIN.split(',')
+  : ['http://localhost:3000', 'https://eltx.online'];
+app.use(cors({ origin: allowedOrigins, credentials: true }));
 app.use(express.json());
 app.use(cookieParser());
 

--- a/app/(app)/account/wallet/page.tsx
+++ b/app/(app)/account/wallet/page.tsx
@@ -10,7 +10,7 @@ export default function WalletPage() {
   const [deposits, setDeposits] = useState<Deposit[]>([]);
 
   useEffect(() => {
-    fetch(`${process.env.NEXT_PUBLIC_API_BASE}/wallet/me`, { credentials: 'include' })
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/wallet/me`, { credentials: 'include' })
       .then((r) => r.json())
       .then((d) => {
         setWallet(d.wallet);

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -8,7 +8,7 @@ export default function DashboardPage() {
   const [wallet, setWallet] = useState<WalletInfo | null>(null);
 
   useEffect(() => {
-    fetch(`${process.env.NEXT_PUBLIC_API_BASE}/wallet/me`, { credentials: 'include' })
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/wallet/me`, { credentials: 'include' })
       .then((r) => r.json())
       .then((d) => setWallet(d.wallet));
   }, []);

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -9,7 +9,7 @@ export default function LoginPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const res = await fetch('http://localhost:4000/auth/login', {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -12,7 +12,7 @@ export default function SignupPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await fetch('http://localhost:4000/auth/signup', {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/signup`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/db/wallet.sql
+++ b/db/wallet.sql
@@ -63,6 +63,8 @@ CREATE TABLE IF NOT EXISTS user_balances (
   user_id BIGINT UNSIGNED NOT NULL,
   asset VARCHAR(32) NOT NULL DEFAULT 'native',
   balance_wei DECIMAL(65,0) NOT NULL DEFAULT 0,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (user_id, asset),
-  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+  INDEX idx_user_balances_user (user_id),
+  CONSTRAINT fk_user_balances_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
- add created timestamp and user_id index in user_balances table
- name and fix foreign key reference to users table
- use NEXT_PUBLIC_API_URL env var for frontend API calls
- allow multiple CORS origins for the API with comma-separated env var

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b76c68f4b0832ba425498b6ac47b5a