### PR TITLE
Fix CORS/auth flow and wallet provisioning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,4 +4,4 @@ DB_PASS=password
 DB_NAME=eltx
 # PORT=4000
 
-NEXT_PUBLIC_API_URL=http://localhost:4000
+NEXT_PUBLIC_API_BASE=

--- a/README.md
+++ b/README.md
@@ -6,18 +6,14 @@ npm i
 cp .env.example .env
 cp api/.env.example api/.env
 cp apps/worker/.env.example apps/worker/.env
-npm run api    # starts API on http://localhost:4000
-npm run dev    # starts Next.js on http://localhost:3000
+npm run api    # starts API on port 4000
+npm run dev    # starts Next.js dev server
 npm run worker # starts the blockchain worker
 # run API + Web together
 npm run dev:all
 ```
 
-Set `NEXT_PUBLIC_API_URL` in `.env` to the base URL of the API, for example:
-
-```
-NEXT_PUBLIC_API_URL=http://localhost:4000
-```
+Set `NEXT_PUBLIC_API_BASE` in `.env` to the base URL of the API.
 
 The API uses a MySQL database. Create one and run `api/schema.sql` plus `db/wallet.sql` against it.
 
@@ -37,7 +33,7 @@ SESSION_COOKIE_DOMAIN
 SESSION_COOKIE_NAME
 ```
 
-`CORS_ORIGIN` accepts a comma-separated list of allowed origins, e.g. `http://localhost:3000,https://eltx.online`.
+`CORS_ORIGIN` accepts a comma-separated list of allowed origins, e.g. `https://eltx.online`.
 
 If you see `Module not found: './globals.css'`, make sure the file exists at `app/globals.css`.
 

--- a/api/.env.example
+++ b/api/.env.example
@@ -10,6 +10,6 @@ OMNIBUS_ADDRESS=
 OMNIBUS_PK=
 
 DATABASE_URL=
-CORS_ORIGIN=http://localhost:3000,https://eltx.online
-SESSION_COOKIE_DOMAIN=localhost
+CORS_ORIGIN=https://eltx.online
+SESSION_COOKIE_DOMAIN=eltx.online
 SESSION_COOKIE_NAME=sid

--- a/api/server.js
+++ b/api/server.js
@@ -15,11 +15,22 @@ require('dotenv').config();
 });
 
 const app = express();
+app.set('trust proxy', 1);
 app.use(helmet());
-const allowedOrigins = process.env.CORS_ORIGIN
-  ? process.env.CORS_ORIGIN.split(',')
-  : ['http://localhost:3000', 'https://eltx.online'];
-app.use(cors({ origin: allowedOrigins, credentials: true }));
+const allowedOrigins = process.env.CORS_ORIGIN ? process.env.CORS_ORIGIN.split(',') : [];
+const corsOptions = {
+  origin: allowedOrigins,
+  credentials: true,
+  methods: ['GET', 'POST', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization'],
+};
+app.use(cors(corsOptions));
+app.options('*', cors(corsOptions));
+app.use((req, res, next) => {
+  req.requestId = req.headers['x-request-id'] || crypto.randomUUID();
+  res.setHeader('x-request-id', req.requestId);
+  next();
+});
 app.use(express.json());
 app.use(cookieParser());
 
@@ -38,9 +49,10 @@ const walletLimiter = rateLimit({ windowMs: 60 * 1000, max: 30 });
 const COOKIE_NAME = process.env.SESSION_COOKIE_NAME || 'sid';
 const sessionCookie = {
   httpOnly: true,
-  sameSite: 'lax',
-  secure: false,
-  domain: process.env.SESSION_COOKIE_DOMAIN || undefined,
+  sameSite: 'none',
+  secure: true,
+  domain: process.env.SESSION_COOKIE_DOMAIN,
+  path: '/',
   maxAge: 1000 * 60 * 60,
 };
 
@@ -51,12 +63,19 @@ const SignupSchema = z.object({
   language: z.string().optional(),
 });
 
-const LoginSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(8),
-});
+const LoginSchema = z
+  .object({
+    email: z.string().email().optional(),
+    username: z.string().min(3).optional(),
+    password: z.string().min(8),
+  })
+  .refine((d) => d.email || d.username, {
+    message: 'Email or username required',
+  });
 
-app.post('/auth/signup', async (req, res) => {
+const CHAIN_ID = Number(process.env.CHAIN_ID || 56);
+
+app.post('/auth/signup', async (req, res, next) => {
   let conn;
   try {
     const { email, password, username, language } = SignupSchema.parse(req.body);
@@ -68,31 +87,37 @@ app.post('/auth/signup', async (req, res) => {
     );
     const hash = await argon2.hash(password, { type: argon2.argon2id });
     await conn.query('INSERT INTO user_credentials (user_id, password_hash) VALUES (?, ?)', [u.insertId, hash]);
-    const wallet = await provisionUserAddress(conn, u.insertId);
+    const token = crypto.randomUUID();
+    await conn.query(
+      'INSERT INTO sessions (id, user_id, expires_at) VALUES (?, ?, DATE_ADD(NOW(), INTERVAL 1 HOUR))',
+      [token, u.insertId]
+    );
+    const wallet = await provisionUserAddress(conn, u.insertId, CHAIN_ID);
     await conn.commit();
+    res.cookie(COOKIE_NAME, token, sessionCookie);
     res.json({ ok: true, wallet });
   } catch (err) {
     if (conn) await conn.rollback();
-    console.error(err);
     if (err instanceof z.ZodError) {
-      return res.status(400).json({ message: 'Invalid input' });
+      return next({ status: 400, code: 'BAD_INPUT', message: 'Invalid input' });
     }
     if (err.code === 'ER_DUP_ENTRY') {
-      return res.status(409).json({ message: 'Email or username already exists' });
+      return next({ status: 409, code: 'USER_EXISTS', message: 'Email or username already exists' });
     }
-    res.status(500).json({ message: 'Error creating user' });
+    next(err);
   } finally {
     if (conn) conn.release();
   }
 });
 
-app.post('/auth/login', loginLimiter, async (req, res) => {
+app.post('/auth/login', loginLimiter, async (req, res, next) => {
   let userId = null;
   try {
-    const { email, password } = LoginSchema.parse(req.body);
+    const { email, username, password } = LoginSchema.parse(req.body);
+    const field = email ? 'email' : 'username';
     const [rows] = await pool.query(
-      'SELECT users.id, uc.password_hash FROM users JOIN user_credentials uc ON users.id=uc.user_id WHERE users.email=?',
-      [email]
+      `SELECT users.id, uc.password_hash FROM users JOIN user_credentials uc ON users.id=uc.user_id WHERE users.${field}=?`,
+      [email || username]
     );
     if (rows.length) {
       userId = rows[0].id;
@@ -104,19 +129,18 @@ app.post('/auth/login', loginLimiter, async (req, res) => {
           userId,
         ]);
         await pool.query('INSERT INTO login_attempts (user_id, ip, success) VALUES (?, ?, 1)', [userId, req.ip]);
-        const wallet = await provisionUserAddress(pool, userId);
+        const wallet = await provisionUserAddress(pool, userId, CHAIN_ID);
         res.cookie(COOKIE_NAME, token, sessionCookie);
         return res.json({ ok: true, wallet });
       }
     }
     await pool.query('INSERT INTO login_attempts (user_id, ip, success) VALUES (?, ?, 0)', [userId, req.ip]);
-    res.status(401).json({ message: 'Invalid credentials' });
+    return next({ status: 401, code: 'INVALID_CREDENTIALS', message: 'Invalid credentials' });
   } catch (err) {
-    console.error(err);
     if (err instanceof z.ZodError) {
-      return res.status(400).json({ message: 'Invalid input' });
+      return next({ status: 400, code: 'BAD_INPUT', message: 'Invalid input' });
     }
-    res.status(500).json({ message: 'Error logging in' });
+    next(err);
   }
 });
 
@@ -126,39 +150,38 @@ app.post('/auth/logout', async (req, res) => {
     await pool.query('DELETE FROM sessions WHERE id = ?', [token]);
   }
   res.clearCookie(COOKIE_NAME);
-  res.json({ message: 'Logged out' });
+  res.json({ ok: true });
 });
 
-app.get('/auth/me', async (req, res) => {
+app.get('/auth/me', async (req, res, next) => {
   const token = req.cookies[COOKIE_NAME];
-  if (!token) return res.status(401).json({ message: 'Not authenticated' });
+  if (!token) return next({ status: 401, code: 'UNAUTHENTICATED', message: 'Not authenticated' });
   try {
     const [rows] = await pool.query(
       'SELECT users.id, users.email FROM sessions JOIN users ON sessions.user_id = users.id WHERE sessions.id = ? AND sessions.expires_at > NOW()',
       [token]
     );
-    if (!rows.length) return res.status(401).json({ message: 'Not authenticated' });
+    if (!rows.length) return next({ status: 401, code: 'UNAUTHENTICATED', message: 'Not authenticated' });
     res.json(rows[0]);
   } catch (err) {
-    res.status(500).json({ message: 'Error' });
+    next(err);
   }
 });
 
-app.get('/wallet/me', walletLimiter, async (req, res) => {
+app.get('/wallet/me', walletLimiter, async (req, res, next) => {
   const token = req.cookies[COOKIE_NAME];
-  if (!token) return res.status(401).json({ ok: false, message: 'Not authenticated' });
+  if (!token) return next({ status: 401, code: 'UNAUTHENTICATED', message: 'Not authenticated' });
   try {
     const [rows] = await pool.query(
       'SELECT users.id FROM sessions JOIN users ON sessions.user_id = users.id WHERE sessions.id = ? AND sessions.expires_at > NOW()',
       [token]
     );
-    if (!rows.length) return res.status(401).json({ ok: false, message: 'Not authenticated' });
+    if (!rows.length) return next({ status: 401, code: 'UNAUTHENTICATED', message: 'Not authenticated' });
     const userId = rows[0].id;
-    const chain = process.env.CHAIN || 'bsc-mainnet';
-    const wallet = await provisionUserAddress(pool, userId, chain);
+    const wallet = await provisionUserAddress(pool, userId, CHAIN_ID);
     const [deps] = await pool.query(
-      'SELECT tx_hash, amount_wei, confirmations, status, created_at FROM wallet_deposits WHERE user_id=? AND chain=? ORDER BY created_at DESC LIMIT 50',
-      [userId, chain]
+      'SELECT tx_hash, amount_wei, confirmations, status, created_at FROM wallet_deposits WHERE user_id=? AND chain_id=? ORDER BY created_at DESC LIMIT 50',
+      [userId, CHAIN_ID]
     );
     const depositSchema = z.object({
       tx_hash: z.string(),
@@ -170,11 +193,22 @@ app.get('/wallet/me', walletLimiter, async (req, res) => {
     const deposits = z.array(depositSchema).parse(deps);
     res.json({ ok: true, wallet, deposits });
   } catch (err) {
-    res.status(500).json({ ok: false, message: 'Error' });
+    next(err);
   }
 });
 
 const port = process.env.PORT || 4000;
 app.listen(port, () => {
   console.log(`API running on port ${port}`);
+});
+
+app.use((err, req, res, next) => {
+  const id = req.requestId || crypto.randomUUID();
+  const status = err.status || 500;
+  const code = err.code || 'INTERNAL';
+  const message = err.message || 'Internal error';
+  const body = { ok: false, error: { code, message, id } };
+  if (err.details) body.error.details = err.details;
+  console.error(`[${id}]`, err);
+  res.status(status).json(body);
 });

--- a/api/src/services/wallet.js
+++ b/api/src/services/wallet.js
@@ -1,6 +1,6 @@
 const { ethers } = require('ethers');
 
-async function provisionUserAddress(db, userId, chain = 'bsc-mainnet') {
+async function provisionUserAddress(db, userId, chainId = Number(process.env.CHAIN_ID || 56)) {
   if (!process.env.MASTER_MNEMONIC) {
     throw new Error('MASTER_MNEMONIC not set');
   }
@@ -8,31 +8,31 @@ async function provisionUserAddress(db, userId, chain = 'bsc-mainnet') {
   const conn = isConn ? db : await db.getConnection();
   try {
     const [existing] = await conn.query(
-      'SELECT chain, address, derivation_index FROM wallet_addresses WHERE user_id=? AND chain=?',
-      [userId, chain]
+      'SELECT chain_id, address, derivation_index FROM wallet_addresses WHERE user_id=? AND chain_id=?',
+      [userId, chainId]
     );
     if (existing.length) {
       if (!isConn) conn.release();
-      return existing[0];
+      return { chain_id: existing[0].chain_id, address: existing[0].address };
     }
     if (!isConn) await conn.beginTransaction();
     const [rows] = await conn.query(
-      'SELECT last_index FROM wallet_index WHERE chain=? FOR UPDATE',
-      [chain]
+      'SELECT next_index FROM wallet_index WHERE chain_id=? FOR UPDATE',
+      [chainId]
     );
-    const nextIndex = rows[0].last_index + 1;
-    await conn.query('UPDATE wallet_index SET last_index=? WHERE chain=?', [nextIndex, chain]);
+    const nextIndex = rows[0].next_index;
+    await conn.query('UPDATE wallet_index SET next_index=? WHERE chain_id=?', [nextIndex + 1, chainId]);
     const wallet = ethers.Wallet.fromPhrase(
       process.env.MASTER_MNEMONIC,
       `m/44'/60'/0'/0/${nextIndex}`
     );
     const address = wallet.address.toLowerCase();
     await conn.query(
-      'INSERT INTO wallet_addresses (user_id, chain, derivation_index, address) VALUES (?,?,?,?)',
-      [userId, chain, nextIndex, address]
+      'INSERT INTO wallet_addresses (user_id, chain_id, derivation_index, address) VALUES (?,?,?,?)',
+      [userId, chainId, nextIndex, address]
     );
     if (!isConn) await conn.commit();
-    return { chain, address, derivation_index: nextIndex };
+    return { chain_id: chainId, address };
   } catch (err) {
     if (!isConn) await conn.rollback();
     throw err;

--- a/app/(app)/account/wallet/page.tsx
+++ b/app/(app)/account/wallet/page.tsx
@@ -1,24 +1,22 @@
 'use client';
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-
-const apiBase = process.env.NEXT_PUBLIC_API_URL;
-if (!apiBase) throw new Error('NEXT_PUBLIC_API_URL is not defined');
+import { apiFetch } from '../../../lib/api';
 
 type Deposit = { tx_hash: string; amount_wei: string; confirmations: number; status: string; created_at: string };
-type WalletInfo = { chain: string; address: string; derivation_index: number };
+type WalletInfo = { chain_id: number; address: string };
 
 export default function WalletPage() {
   const [wallet, setWallet] = useState<WalletInfo | null>(null);
   const [deposits, setDeposits] = useState<Deposit[]>([]);
 
   useEffect(() => {
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/wallet/me`, { credentials: 'include' })
-      .then((r) => r.json())
+    apiFetch('/wallet/me')
       .then((d) => {
         setWallet(d.wallet);
         setDeposits(d.deposits || []);
-      });
+      })
+      .catch(() => {});
   }, []);
 
   if (!wallet) return <div className="p-4">Loading...</div>;

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,19 +1,15 @@
 'use client';
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { apiFetch } from '../../lib/api';
 
-const apiBase = process.env.NEXT_PUBLIC_API_URL;
-if (!apiBase) throw new Error('NEXT_PUBLIC_API_URL is not defined');
-
-type WalletInfo = { chain: string; address: string; derivation_index: number };
+type WalletInfo = { chain_id: number; address: string };
 
 export default function DashboardPage() {
   const [wallet, setWallet] = useState<WalletInfo | null>(null);
 
   useEffect(() => {
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/wallet/me`, { credentials: 'include' })
-      .then((r) => r.json())
-      .then((d) => setWallet(d.wallet));
+    apiFetch('/wallet/me').then((d) => setWallet(d.wallet)).catch(() => {});
   }, []);
 
   return (

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -1,0 +1,27 @@
+'use client';
+
+export async function apiFetch(path: string, options: RequestInit = {}) {
+  const base = process.env.NEXT_PUBLIC_API_BASE;
+  if (!base) throw new Error('NEXT_PUBLIC_API_BASE is not defined');
+  const url = `${base}${path}`;
+  const res = await fetch(url, {
+    credentials: 'include',
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    const requestId = res.headers.get('x-request-id') || undefined;
+    console.error('API request failed', { url, status: res.status, body: text, requestId });
+    try {
+      const data = JSON.parse(text);
+      throw new Error(data.error?.message || 'Request failed');
+    } catch {
+      throw new Error('Request failed');
+    }
+  }
+  return res.json();
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,25 +1,27 @@
 'use client';
 import { useState } from 'react';
 import Header from '../(site)/components/Header';
-
-const apiBase = process.env.NEXT_PUBLIC_API_URL;
-if (!apiBase) throw new Error('NEXT_PUBLIC_API_URL is not defined');
+import { apiFetch } from '../lib/api';
 
 export default function LoginPage() {
-  const [email, setEmail] = useState('');
+  const [identifier, setIdentifier] = useState('');
   const [password, setPassword] = useState('');
   const [message, setMessage] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ email, password })
-    });
-    const data = await res.json().catch(() => ({}));
-    setMessage(data.message || (res.ok ? 'Logged in' : 'Login failed'));
+    const body = identifier.includes('@')
+      ? { email: identifier, password }
+      : { username: identifier, password };
+    try {
+      await apiFetch('/auth/login', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      });
+      setMessage('Logged in');
+    } catch (err: any) {
+      setMessage(err.message || 'Login failed');
+    }
   };
 
   return (
@@ -33,9 +35,9 @@ export default function LoginPage() {
           <h1 className="text-2xl font-bold text-center mb-2">Login</h1>
           <input
             className="p-2 rounded bg-black/20 border border-white/20"
-            placeholder="Email"
-            value={email}
-            onChange={e => setEmail(e.target.value)}
+            placeholder="Email or Username"
+            value={identifier}
+            onChange={e => setIdentifier(e.target.value)}
           />
           <input
             className="p-2 rounded bg-black/20 border border-white/20"

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,9 +1,7 @@
 'use client';
 import { useState } from 'react';
 import Header from '../(site)/components/Header';
-
-const apiBase = process.env.NEXT_PUBLIC_API_URL;
-if (!apiBase) throw new Error('NEXT_PUBLIC_API_URL is not defined');
+import { apiFetch } from '../lib/api';
 
 export default function SignupPage() {
   const [email, setEmail] = useState('');
@@ -15,16 +13,13 @@ export default function SignupPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/signup`, {
+      await apiFetch('/auth/signup', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
         body: JSON.stringify({ email, username, password }),
       });
-      const data = await res.json().catch(() => ({}));
-      setMessage(data.message || (res.ok ? 'Account created' : 'Signup failed'));
-    } catch {
-      setMessage('Signup failed');
+      setMessage('Account created');
+    } catch (err: any) {
+      setMessage(err.message || 'Signup failed');
     }
   };
 


### PR DESCRIPTION
## Summary
- use env-based CORS with request IDs and secure session cookies
- allow login with email or username and return structured JSON errors
- derive and store wallet addresses by chain id while exposing a unified client fetch layer

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7989072dc832b9c27d9bef7a40433