### PR TITLE
chore: drop deprecated wallet columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Set `NEXT_PUBLIC_API_BASE` in `.env` to the base URL of the API.
 
 The API uses a MySQL database. Create one and run `api/schema.sql` plus `db/wallet.sql` against it.
 
+Re-run `db/wallet.sql` after updates to remove any legacy columns.
+
 ### ENV required (names only)
 ```
 CHAIN

--- a/db/wallet.sql
+++ b/db/wallet.sql
@@ -71,6 +71,11 @@ ALTER TABLE wallet_addresses
   ADD UNIQUE KEY IF NOT EXISTS uniq_addr (address),
   ADD INDEX IF NOT EXISTS idx_user (user_id);
 
+ALTER TABLE wallet_addresses
+  DROP COLUMN IF EXISTS chain,
+  DROP COLUMN IF EXISTS status,
+  DROP COLUMN IF EXISTS usd_balance;
+
 -- deposits
 CREATE TABLE IF NOT EXISTS wallet_deposits (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
@@ -97,6 +102,11 @@ ALTER TABLE wallet_deposits
   ADD INDEX IF NOT EXISTS idx_user_chain (user_id, chain_id),
   ADD INDEX IF NOT EXISTS idx_addr (address);
 
+ALTER TABLE wallet_deposits
+  DROP COLUMN IF EXISTS chain,
+  DROP COLUMN IF EXISTS status,
+  DROP COLUMN IF EXISTS usd_balance;
+
 -- user balances per asset
 CREATE TABLE IF NOT EXISTS user_balances (
   user_id BIGINT UNSIGNED NOT NULL,
@@ -107,4 +117,9 @@ CREATE TABLE IF NOT EXISTS user_balances (
   INDEX idx_user_balances_user (user_id),
   CONSTRAINT fk_user_balances_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE user_balances
+  DROP COLUMN IF EXISTS chain,
+  DROP COLUMN IF EXISTS status,
+  DROP COLUMN IF EXISTS usd_balance;
 


### PR DESCRIPTION
## Summary
- drop deprecated chain/status/usd_balance columns from wallet tables
- note to rerun db/wallet.sql after updates to remove legacy columns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8cb1dcba8832b804707ba4b9a8867