### PR TITLE
Drop deprecated usd_balance column from wallet schema

### DIFF
--- a/db/wallet.sql
+++ b/db/wallet.sql
@@ -107,4 +107,5 @@ CREATE TABLE IF NOT EXISTS user_balances (
   INDEX idx_user_balances_user (user_id),
   CONSTRAINT fk_user_balances_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+ALTER TABLE user_balances DROP COLUMN IF EXISTS usd_balance;
 


### PR DESCRIPTION
## Summary
- remove legacy `usd_balance` column from the `user_balances` table

## Testing
- `npm test`
- `mysql --socket=/tmp/mysql.sock -uroot -D eltx -e "DESCRIBE user_balances;"`

------
https://chatgpt.com/codex/tasks/task_e_68b8cb1add0c832b9f1f62c796f92f13