### PR TITLE
Drop legacy wallet address indexes

### DIFF
--- a/db/wallet.sql
+++ b/db/wallet.sql
@@ -56,9 +56,12 @@ CREATE TABLE IF NOT EXISTS wallet_addresses (
 ALTER TABLE wallet_addresses
   ADD COLUMN IF NOT EXISTS chain_id INT UNSIGNED NOT NULL AFTER user_id,
   ADD COLUMN IF NOT EXISTS derivation_index INT UNSIGNED NOT NULL AFTER chain_id,
-  ADD UNIQUE KEY IF NOT EXISTS uniq_user_chain (user_id, chain_id),
-  ADD UNIQUE KEY IF NOT EXISTS uniq_addr (address),
-  ADD INDEX IF NOT EXISTS idx_user (user_id),
+  DROP INDEX IF EXISTS uniq_user_chain,
+  DROP INDEX IF EXISTS uniq_addr,
+  DROP INDEX IF EXISTS idx_user,
+  ADD UNIQUE KEY uniq_user_chain (user_id, chain_id),
+  ADD UNIQUE KEY uniq_addr (address),
+  ADD INDEX idx_user (user_id),
   DROP COLUMN IF EXISTS chain,
   DROP COLUMN IF EXISTS status;
 


### PR DESCRIPTION
## Summary
- drop legacy wallet_addresses indexes and recreate unique/index keys

## Testing
- `MASTER_MNEMONIC=test DATABASE_URL=mysql://root@localhost/eltx node api/server.js` *(fails: connect ECONNREFUSED)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8d332a0b4832bac371a4d55246fc5