### PR TITLE
Enhance navigation and auth feedback

### DIFF
--- a/app/(site)/components/Audience.tsx
+++ b/app/(site)/components/Audience.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Building2, Briefcase, Users } from 'lucide-react';
+import { dict, useLang } from '../../lib/i18n';
+
+export default function Audience() {
+  const { lang } = useLang();
+  const t = dict[lang];
+  const items = [
+    { icon: Building2, title: t.audience.governments.title, desc: t.audience.governments.desc },
+    { icon: Briefcase, title: t.audience.companies.title, desc: t.audience.companies.desc },
+    { icon: Users, title: t.audience.individuals.title, desc: t.audience.individuals.desc },
+  ];
+  return (
+    <section className="py-16">
+      <h2 className="text-3xl font-bold text-center mb-8">{t.audience.title}</h2>
+      <div className="grid gap-6 sm:grid-cols-3">
+        {items.map((item) => (
+          <div
+            key={item.title}
+            className="p-6 border border-white/10 rounded-lg text-center hover:bg-white/5 transition"
+          >
+            <item.icon className="h-10 w-10 mx-auto mb-4" />
+            <h3 className="text-xl font-semibold mb-2">{item.title}</h3>
+            <p className="text-sm text-[var(--muted)]">{item.desc}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/(site)/components/Header.tsx
+++ b/app/(site)/components/Header.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Menu, X } from 'lucide-react';
 import { useAuth } from '../../lib/auth';
 import { dict, useLang } from '../../lib/i18n';
@@ -13,6 +13,15 @@ export default function Header() {
   const { lang, setLang } = useLang();
   const t = dict[lang];
   const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
 
   const guestLinks = [
     { href: '/', label: t.nav.home },
@@ -75,9 +84,16 @@ export default function Header() {
         {open ? <X /> : <Menu />}
       </button>
       {open && (
-        <nav className="absolute top-full left-0 w-full bg-black p-4 flex flex-col gap-4 sm:hidden">
-          <NavLinks />
-        </nav>
+        <>
+          <div
+            className="fixed inset-0 bg-black/50 z-40"
+            onClick={() => setOpen(false)}
+            aria-hidden="true"
+          />
+          <nav className="absolute top-full left-0 w-full bg-black p-4 flex flex-col gap-4 sm:hidden z-50">
+            <NavLinks />
+          </nav>
+        </>
       )}
     </header>
   );

--- a/app/lib/i18n.tsx
+++ b/app/lib/i18n.tsx
@@ -74,6 +74,21 @@ export const dict = {
       logout: 'Logout',
       language: 'Language',
     },
+    audience: {
+      title: 'Who we serve',
+      governments: {
+        title: 'Governments',
+        desc: 'Secure infrastructure for public services.',
+      },
+      companies: {
+        title: 'Companies',
+        desc: 'Tools for enterprises and startups.',
+      },
+      individuals: {
+        title: 'Individuals',
+        desc: 'Simple payments for everyone.',
+      },
+    },
     common: {
       soon: 'Soon',
       genericError: 'Something went wrong. Please try again.',
@@ -154,6 +169,21 @@ export const dict = {
       settings: 'الإعدادات',
       logout: 'تسجيل الخروج',
       language: 'اللغة',
+    },
+    audience: {
+      title: 'الفئات المستهدفة',
+      governments: {
+        title: 'الحكومات',
+        desc: 'بنية آمنة للخدمات العامة.',
+      },
+      companies: {
+        title: 'الشركات',
+        desc: 'أدوات للمؤسسات والشركات الناشئة.',
+      },
+      individuals: {
+        title: 'الأفراد',
+        desc: 'مدفوعات سهلة للجميع.',
+      },
     },
     common: {
       soon: 'قريبًا',

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -11,6 +11,7 @@ export default function LoginPage() {
   const [identifier, setIdentifier] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
   const { lang } = useLang();
   const t = dict[lang];
   const toast = useToast();
@@ -28,6 +29,7 @@ export default function LoginPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setError('');
     setLoading(true);
     const body = identifier.includes('@') ? { email: identifier, password } : { username: identifier, password };
     try {
@@ -37,11 +39,11 @@ export default function LoginPage() {
       router.push('/dashboard');
     } catch (err: any) {
       if (err?.error?.code === 'INVALID_CREDENTIALS') {
-        toast(t.auth.login.invalid);
+        setError(t.auth.login.invalid);
       } else if (err?.error?.details?.missing) {
-        toast(err.error.details.missing.join(', '));
+        setError(err.error.details.missing.join(', '));
       } else {
-        toast(t.auth.login.genericError);
+        setError(t.auth.login.genericError);
       }
     } finally {
       setLoading(false);
@@ -55,6 +57,11 @@ export default function LoginPage() {
         className="bg-white/5 border border-white/10 rounded-lg p-6 w-full max-w-sm flex flex-col gap-4"
       >
         <h1 className="text-2xl font-bold text-center mb-2">{t.auth.login.title}</h1>
+        {error && (
+          <div role="alert" className="text-red-500 text-sm text-center">
+            {error}
+          </div>
+        )}
         <input
           className="p-2 rounded bg-black/20 border border-white/20"
           placeholder="Email or Username"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import Ticker from './(site)/components/Ticker';
 import Hero from './(site)/components/Hero';
+import Audience from './(site)/components/Audience';
 import Features from './(site)/components/Features';
 import Tokenomics from './(site)/components/Tokenomics';
 import Roadmap from './(site)/components/Roadmap';
@@ -9,7 +10,7 @@ import BottomNav from './(site)/components/BottomNav';
 export default function Page(){
   return(
     <main>
-      <Ticker/><Hero/><Features/><Tokenomics/><Roadmap/><Community/><BottomNav/>
+      <Ticker/><Hero/><Audience/><Features/><Tokenomics/><Roadmap/><Community/><BottomNav/>
       <footer className="container py-4 text-[var(--muted)] text-sm border-t border-[var(--line)] mt-4 flex items-center justify-between">
         <div>© {new Date().getFullYear()} ELTX</div>
         <div className="flex gap-2"><a href="#">Privacy</a><span>·</span><a href="#">Terms</a></div>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -11,6 +11,7 @@ export default function SignupPage() {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
   const { lang } = useLang();
   const t = dict[lang];
   const toast = useToast();
@@ -18,6 +19,7 @@ export default function SignupPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setError('');
     setLoading(true);
     try {
       await apiFetch('/auth/signup', {
@@ -28,11 +30,11 @@ export default function SignupPage() {
       router.push('/login?registered=1');
     } catch (err: any) {
       if (err?.error?.code === 'USER_EXISTS') {
-        toast(t.auth.signup.exists);
+        setError(t.auth.signup.exists);
       } else if (err?.error?.details?.missing) {
-        toast(err.error.details.missing.join(', '));
+        setError(err.error.details.missing.join(', '));
       } else {
-        toast(t.auth.signup.genericError);
+        setError(t.auth.signup.genericError);
       }
     } finally {
       setLoading(false);
@@ -46,6 +48,11 @@ export default function SignupPage() {
         className="bg-white/5 border border-white/10 rounded-lg p-6 w-full max-w-sm flex flex-col gap-4"
       >
         <h1 className="text-2xl font-bold text-center mb-2">{t.auth.signup.title}</h1>
+        {error && (
+          <div role="alert" className="text-red-500 text-sm text-center">
+            {error}
+          </div>
+        )}
         <input
           className="p-2 rounded bg-black/20 border border-white/20"
           placeholder="Email"


### PR DESCRIPTION
## Summary
- improve mobile header overlay and allow ESC/overlay closing
- show inline error messages on login and signup
- add responsive audience section to homepage

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9c12b4dc8832b971c540e59866620