### PR TITLE
Use apiFetch to load staking plans

### DIFF
--- a/app/(app)/staking/page.tsx
+++ b/app/(app)/staking/page.tsx
@@ -12,12 +12,17 @@ export default function StakingPlansPage() {
   const [plans, setPlans] = useState<any[]>([]);
 
   useEffect(() => {
-    if (user === null) router.replace('/login');
-    if (user) {
-      apiFetch('/staking/plans').then((res) => {
-        if (res.data) setPlans(res.data.plans);
-      });
+    if (user === null) {
+      router.replace('/login');
+      return;
     }
+
+    const fetchPlans = async () => {
+      const res = await apiFetch('/staking/plans');
+      if (res.data) setPlans(res.data.plans);
+    };
+
+    if (user) fetchPlans();
   }, [user, router]);
 
   return (


### PR DESCRIPTION
## Summary
- fetch staking plans with `apiFetch('/staking/plans')`
- ensure centered container and styled plan cards remain

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9df929cc4832b80f1b7295f10ee4d