### PR TITLE
Use apiFetch for staking positions

### DIFF
--- a/app/(app)/staking/positions/page.tsx
+++ b/app/(app)/staking/positions/page.tsx
@@ -13,9 +13,10 @@ export default function PositionsPage() {
   useEffect(() => {
     if (user === null) router.replace('/login');
     if (user) {
-      apiFetch('/staking/positions').then((res) => {
+      (async () => {
+        const res = await apiFetch('/staking/positions');
         if (res.data) setPositions(res.data.positions);
-      });
+      })();
     }
   }, [user, router]);
 


### PR DESCRIPTION
## Summary
- use `apiFetch` to load staking positions and update state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9df959eac832bb5451e8773a2cc63