### PR TITLE
Fix header overlay and restore logo

### DIFF
--- a/app/(site)/components/Header.tsx
+++ b/app/(site)/components/Header.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import Link from 'next/link';
+import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { Menu, X } from 'lucide-react';
 import { useAuth } from '../../lib/auth';
 import { dict, useLang } from '../../lib/i18n';
+import logo from '../../../public/assets/img/logo.jpeg';
 
 export default function Header() {
   const { user, logout } = useAuth();
@@ -92,8 +94,8 @@ export default function Header() {
   );
   return (
     <header className="p-4 border-b border-white/10 flex items-center justify-between relative">
-      <Link href="/" className="font-bold tracking-wide">
-        {t.site_title}
+      <Link href="/" className="flex items-center gap-2" aria-label={t.site_title}>
+        <Image src={logo} alt="ELTX" width={32} height={32} className="rounded" />
       </Link>
       <nav className="hidden sm:flex items-center gap-4">
         <NavLinks />


### PR DESCRIPTION
## Summary
- restore logo in site header
- fix mobile drawer overlay and sliding panel

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9df96d77c832b8474ca3b71150643