### PR TITLE
Log error code and table on credit failures

### DIFF
--- a/apps/worker/worker.js
+++ b/apps/worker/worker.js
@@ -71,7 +71,7 @@ async function handleBlock(pool, addrMap, block) {
       );
       await pool.query('UPDATE wallet_deposits SET credited=1 WHERE id=?', [dep.id]);
     } catch (e) {
-      console.error('credit failed', e);
+      console.error('credit failed', e.code, e.table, e);
     }
   }
 


### PR DESCRIPTION
## Summary
- improve deposit credit error logging by including database error code and table name

## Testing
- `npm test`
- `DATABASE_URL=mysql://user:pass@localhost/db RPC_HTTP=http://localhost:8545 npm run worker` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fc3a1490832b802241465d5b1d13