### PR TITLE
Handle optional index drops in schema setup

### DIFF
--- a/db/wallet.sql
+++ b/db/wallet.sql
@@ -55,10 +55,10 @@ CREATE TABLE IF NOT EXISTS wallet_addresses (
   INDEX idx_user (user_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+ALTER TABLE wallet_addresses DROP INDEX uniq_user_chain;
+ALTER TABLE wallet_addresses DROP INDEX uniq_addr;
+ALTER TABLE wallet_addresses DROP INDEX idx_user;
 ALTER TABLE wallet_addresses
-  DROP INDEX IF EXISTS uniq_user_chain,
-  DROP INDEX IF EXISTS uniq_addr,
-  DROP INDEX IF EXISTS idx_user,
   DROP COLUMN IF EXISTS chain,
   DROP COLUMN IF EXISTS status;
 ALTER TABLE wallet_addresses


### PR DESCRIPTION
## Summary
- support `DROP INDEX IF EXISTS` when applying wallet schema
- split index drop statements in `wallet.sql` for broader MySQL compatibility

## Testing
- `npm test`
- `MASTER_MNEMONIC=test DATABASE_URL=mysql://test:test@localhost/eltx node api/server.js`
- `mysql -u test -ptest -e "USE eltx; INSERT INTO wallet_deposits (...)"`


------
https://chatgpt.com/codex/tasks/task_e_68ba05c34f7c832ba01cc6b1add55a70