### PR TITLE
feat(worker): add env validation and start block override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
-DB_HOST=localhost
-DB_USER=root
-DB_PASS=password
-DB_NAME=eltx
+DATABASE_URL=mysql://user:pass@localhost/eltx
 # PORT=4000
 
 NEXT_PUBLIC_API_BASE=https://api.eltx.online
 BSC_RPC_URL=
+RPC_WS=
 CHAIN_ID=56
 SCAN_INTERVAL_MS=15000
 BACKFILL_BLOCKS=5000
+# optional: force worker to start scanning from a specific block
+START_BLOCK=


### PR DESCRIPTION
## Summary
- validate RPC env and support START_BLOCK override
- warn when no deposit addresses loaded
- update .env.example with database and RPC settings

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba1c75a6d0832badba04e2e94c5025