### PR TITLE
Refactor api fetch typing and clean hooks

### DIFF
--- a/app/(app)/earn/page.tsx
+++ b/app/(app)/earn/page.tsx
@@ -1,27 +1,44 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from '../../lib/auth';
 import { useRouter } from 'next/navigation';
 import { apiFetch } from '../../lib/api';
 import PlanCard from '../../../components/earn/PlanCard';
 
+type Plan = {
+  id: number | string;
+  name?: string;
+  title?: string;
+  duration_days?: number;
+  apr?: string;
+  daily_rate?: string;
+  min_deposit_wei: string;
+};
+
 export default function EarnPage() {
   const { user } = useAuth();
   const router = useRouter();
-  const [plans, setPlans] = useState<any[]>([]);
+  const [plans, setPlans] = useState<Plan[]>([]);
 
   useEffect(() => {
     if (user === null) router.replace('/login');
   }, [user, router]);
 
-  useEffect(() => {
-    const load = async () => {
-      const res = await apiFetch('/staking/plans');
-      if (!res.error) setPlans(res);
-    };
-    load();
+  const load = useCallback(async () => {
+    const res = await apiFetch<Plan[]>('/staking/plans');
+    if (res.ok && Array.isArray(res.data)) {
+      setPlans(res.data);
+    } else {
+      setPlans([]);
+    }
   }, []);
+
+  useEffect(() => {
+    (async () => {
+      await load();
+    })();
+  }, [load]);
 
   return (
     <div className="p-4 space-y-6 max-w-xl mx-auto">

--- a/app/(app)/staking/new/page.tsx
+++ b/app/(app)/staking/new/page.tsx
@@ -17,11 +17,11 @@ export default function NewStakePage() {
   useEffect(() => {
     if (user === null) router.replace('/login');
     if (user) {
-      apiFetch('/staking/plans').then((res) => {
-        if (res.error) {
-          if (res.error.status === 401) router.replace('/login');
-          else setError('Failed to load plans');
-        } else if (res.data) {
+      apiFetch<{ plans: any[] }>('/staking/plans').then((res) => {
+        if (!res.ok) {
+          if (res.status === 401) router.replace('/login');
+          else setError(res.error || 'Failed to load plans');
+        } else {
           setPlans(res.data.plans);
           const qs = new URLSearchParams(window.location.search);
           const p = qs.get('plan');
@@ -44,13 +44,13 @@ export default function NewStakePage() {
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
-    const res = await apiFetch('/staking/positions', {
+    const res = await apiFetch<any>('/staking/positions', {
       method: 'POST',
       body: JSON.stringify({ planId, amount }),
     });
-    if (res.error) {
-      setError('Failed to stake');
-    } else if (res.data) {
+    if (!res.ok) {
+      setError(res.error || 'Failed to stake');
+    } else {
       router.push('/earn/staking/positions');
     }
   };

--- a/app/(app)/staking/page.tsx
+++ b/app/(app)/staking/page.tsx
@@ -18,8 +18,8 @@ export default function StakingPlansPage() {
     }
 
     const fetchPlans = async () => {
-      const res = await apiFetch('/staking/plans');
-      if (res.data) setPlans(res.data.plans);
+      const res = await apiFetch<{ plans: any[] }>('/staking/plans');
+      if (res.ok) setPlans(res.data.plans);
     };
 
     if (user) fetchPlans();

--- a/app/(app)/staking/positions/page.tsx
+++ b/app/(app)/staking/positions/page.tsx
@@ -14,8 +14,8 @@ export default function PositionsPage() {
     if (user === null) router.replace('/login');
     if (user) {
       (async () => {
-        const res = await apiFetch('/staking/positions');
-        if (res.data) setPositions(res.data.positions);
+        const res = await apiFetch<{ positions: any[] }>('/staking/positions');
+        if (res.ok && res.data.positions) setPositions(res.data.positions);
       })();
     }
   }, [user, router]);

--- a/app/(app)/transactions/page.tsx
+++ b/app/(app)/transactions/page.tsx
@@ -29,10 +29,10 @@ export default function TransactionsPage() {
   }, [user, router]);
 
   useEffect(() => {
-    apiFetch('/wallet/transactions').then(res => {
-      if (res.error) {
-        if (res.error.status === 401) router.replace('/login');
-      } else if (res.data) {
+    apiFetch<{ transactions: Deposit[] }>('/wallet/transactions').then(res => {
+      if (!res.ok) {
+        if (res.status === 401) router.replace('/login');
+      } else {
         setDeposits(res.data.transactions || []);
       }
     });

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -1,17 +1,11 @@
 'use client';
 
-interface ApiError {
-  status: number;
-  code?: string;
-  message?: string;
-  [key: string]: any;
-}
-
-interface ApiResponse<T> {
-  data?: T;
-  error?: ApiError;
-}
-
+export type ApiResponse<T> = {
+  ok: boolean;
+  data: T;
+  status?: number;
+  error?: string | null;
+};
 export async function apiFetch<T = any>(path: string, options: RequestInit = {}): Promise<ApiResponse<T>> {
   const base = process.env.NEXT_PUBLIC_API_BASE;
   if (!base) throw new Error('NEXT_PUBLIC_API_BASE is not defined');
@@ -29,16 +23,15 @@ export async function apiFetch<T = any>(path: string, options: RequestInit = {})
     if (!res.ok) {
       if (res.status >= 500) console.error('API request failed', { url, status: res.status, body: data });
       return {
-        error: {
-          status: res.status,
-          ...(data?.error || {}),
-          message: data?.error?.message || data?.message || res.statusText,
-        },
+        ok: false,
+        data: data as T,
+        status: res.status,
+        error: data?.error?.message || data?.message || res.statusText,
       };
     }
-    return { data };
+    return { ok: true, data: data as T, status: res.status, error: null };
   } catch (err) {
     console.error('API request failed', err);
-    return { error: { status: 0, message: 'Network error' } };
+    return { ok: false, data: null as T, status: 0, error: 'Network error' };
   }
 }

--- a/app/lib/auth.tsx
+++ b/app/lib/auth.tsx
@@ -14,8 +14,8 @@ const AuthContext = createContext<AuthContextType>({ user: undefined, refresh: a
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<any | null | undefined>(undefined);
   const refresh = async () => {
-    const { data } = await apiFetch('/auth/me');
-    setUser(data || null);
+    const res = await apiFetch<any>('/auth/me');
+    setUser(res.ok ? res.data : null);
   };
   useEffect(() => {
     refresh();

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -32,15 +32,15 @@ export default function LoginPage() {
     setError('');
     setLoading(true);
     const body = identifier.includes('@') ? { email: identifier, password } : { username: identifier, password };
-    const res = await apiFetch('/auth/login', { method: 'POST', body: JSON.stringify(body) });
-    if (res.error) {
-      const err = res.error;
-      if (err.code === 'INVALID_CREDENTIALS') {
+    const res = await apiFetch<any>('/auth/login', { method: 'POST', body: JSON.stringify(body) });
+    if (!res.ok) {
+      const err = (res.data as any)?.error;
+      if (err?.code === 'INVALID_CREDENTIALS') {
         setError(t.auth.login.invalid);
-      } else if (err.details?.missing) {
+      } else if (err?.details?.missing) {
         setError(err.details.missing.join(', '));
       } else {
-        setError(t.auth.login.genericError);
+        setError(res.error || t.auth.login.genericError);
       }
     } else {
       await refresh();

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -21,15 +21,15 @@ export default function SignupPage() {
     e.preventDefault();
     setError('');
     setLoading(true);
-    const res = await apiFetch('/auth/signup', {
+    const res = await apiFetch<any>('/auth/signup', {
       method: 'POST',
       body: JSON.stringify({ email, username, password }),
     });
-    if (res.error) {
-      const err = res.error;
-      if (err.code === 'USER_EXISTS') setError(t.auth.signup.exists);
-      else if (err.details?.missing) setError(err.details.missing.join(', '));
-      else setError(t.auth.signup.genericError);
+    if (!res.ok) {
+      const err = (res.data as any)?.error;
+      if (err?.code === 'USER_EXISTS') setError(t.auth.signup.exists);
+      else if (err?.details?.missing) setError(err.details.missing.join(', '));
+      else setError(res.error || t.auth.signup.genericError);
     } else {
       toast(t.auth.signup.success);
       router.push('/login?registered=1');

--- a/components/earn/PlanCard.tsx
+++ b/components/earn/PlanCard.tsx
@@ -3,8 +3,8 @@
 import { formatUnits } from 'ethers';
 
 interface Plan {
-  id: number;
-  name: string;
+  id: number | string;
+  name?: string;
   duration_days?: number;
   duration_months?: number;
   apr?: string;


### PR DESCRIPTION
## Summary
- add `ok`-based `ApiResponse` helper and update `apiFetch`
- load earn plans with typed data and stable hooks
- standardize wallet page data loading and handle API errors

## Testing
- `npm run lint --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb1ac96fe0832ba3c3d6bb7d49f1ba