### PR TITLE
feat: unify navigation and refresh homepage

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,10 +1,3 @@
-import Footer from '../(site)/components/Footer';
-
 export default function AppLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="min-h-screen flex flex-col">
-      <main className="flex-1 container mx-auto p-4">{children}</main>
-      <Footer />
-    </div>
-  );
+  return <div className="container mx-auto p-4">{children}</div>;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -11,6 +11,8 @@ html,body{height:100%}
 body{color:var(--text);background:
  radial-gradient(1200px 600px at 50% -200px,rgba(255,90,60,.05),transparent),
  linear-gradient(180deg,var(--bg),var(--bg2));}
+
+body{background:#0a0a0a;color:#fff;}
 .container{max-width:1040px;margin:0 auto;padding:0 14px}
 a{color:inherit}
 .ticker{position:sticky;top:0;z-index:50;background:#ffffffcc;border-bottom:1px solid var(--line);backdrop-filter:blur(8px);overflow:hidden}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { LangProvider } from './lib/i18n';
 import { ToastProvider } from './lib/toast';
 import { AuthProvider } from './lib/auth';
 import NavBar from '../components/layout/NavBar';
+import Footer from '../components/layout/Footer';
 
 export const metadata = {
   title: 'ELTX — Next',
@@ -12,12 +13,13 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className="min-h-screen overflow-x-hidden">
+      <body className="min-h-screen flex flex-col overflow-x-hidden bg-neutral-950 text-white">
         <LangProvider>
           <AuthProvider>
             <ToastProvider>
               <NavBar />
-              {children}
+              <main className="flex-1">{children}</main>
+              <Footer />
             </ToastProvider>
           </AuthProvider>
         </LangProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,13 @@
 import Hero from '../components/home/Hero';
 import Industries from '../components/home/Industries';
+import Features from '../components/home/Features';
 
 export default function Page(){
   return(
     <main>
       <Hero />
       <Industries />
+      <Features />
     </main>
   );
 }

--- a/components/home/Features.tsx
+++ b/components/home/Features.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { Shield, Zap, Network, Coins } from 'lucide-react';
+
+const data = [
+  { icon: Shield, title: 'Secure', desc: 'Audited smart contracts keep your assets safe.' },
+  { icon: Zap, title: 'Fast', desc: 'Instant transactions with low fees.' },
+  { icon: Network, title: 'Cross-chain Ready', desc: 'Built for interoperability across blockchains.' },
+  { icon: Coins, title: 'Earn', desc: 'Stake and grow your holdings.' },
+];
+
+export default function Features() {
+  return (
+    <section className="py-16 px-4">
+      <h2 className="text-2xl font-bold text-center mb-8">Why ELTX?</h2>
+      <div className="grid gap-6 sm:grid-cols-2 max-w-4xl mx-auto">
+        {data.map((d) => {
+          const Icon = d.icon;
+          return (
+            <div
+              key={d.title}
+              className="p-6 rounded-2xl bg-white/5 text-center shadow hover:translate-y-0.5 transition-transform"
+            >
+              <Icon className="mx-auto mb-4 h-8 w-8" />
+              <h3 className="font-semibold mb-2">{d.title}</h3>
+              <p className="text-sm opacity-80">{d.desc}</p>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/components/home/Hero.tsx
+++ b/components/home/Hero.tsx
@@ -1,21 +1,59 @@
 'use client';
 
 import Link from 'next/link';
+import Image from 'next/image';
+import { motion } from 'framer-motion';
+import { useState } from 'react';
 import { useAuth } from '../../app/lib/auth';
 
 export default function Hero() {
   const { user } = useAuth();
   const primaryHref = user ? '/dashboard' : '/signup';
   const primaryLabel = user ? 'Dashboard' : 'Get Started';
+  const [logoError, setLogoError] = useState(false);
 
   return (
     <section className="relative overflow-hidden text-white py-24 text-center">
-      <div className="absolute inset-0 bg-gradient-to-br from-sky-500 to-violet-600" />
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.2),transparent)]" />
+      <div className="absolute inset-0 bg-gradient-to-br from-purple-600 to-cyan-500" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.1),transparent)]" />
+      <div className="absolute -top-20 -left-20 w-72 h-72 bg-purple-600/30 rounded-full blur-3xl animate-blob" />
+      <div className="absolute -bottom-24 -right-24 w-72 h-72 bg-cyan-600/30 rounded-full blur-3xl animate-blob animation-delay-2000" />
+      <div className="absolute top-1/2 -left-24 w-72 h-72 bg-indigo-500/20 rounded-full blur-3xl animate-blob animation-delay-4000" />
       <div className="relative z-10 max-w-2xl mx-auto px-4 space-y-6">
-        <h1 className="text-4xl font-bold">ELTX Platform</h1>
-        <p className="opacity-90">Secure, fast and cross-chain ready digital asset platform.</p>
-        <div className="flex justify-center gap-4">
+        {!logoError ? (
+          <Image
+            src="/assets/img/logo.jpeg"
+            alt="ELTX Logo"
+            width={96}
+            height={96}
+            className="mx-auto"
+            onError={() => setLogoError(true)}
+          />
+        ) : (
+          <div className="text-6xl font-bold">ELTX</div>
+        )}
+        <motion.h1
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
+          className="text-4xl font-bold"
+        >
+          ELTX Platform
+        </motion.h1>
+        <motion.p
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.1 }}
+          className="opacity-90"
+        >
+          Secure, fast and cross-chain ready digital asset platform.
+        </motion.p>
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.2 }}
+          className="flex justify-center gap-4"
+        >
           <Link
             href={primaryHref}
             className="px-6 py-2 rounded-full bg-white text-black font-semibold hover:opacity-90"
@@ -28,7 +66,7 @@ export default function Hero() {
           >
             Explore Earn
           </Link>
-        </div>
+        </motion.div>
         <div className="flex justify-center gap-2 text-xs opacity-80">
           <span>Secure</span>
           <span>•</span>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import Link from 'next/link';
+
+export default function Footer() {
+  return (
+    <footer className="border-t border-white/10 p-6 text-center text-sm bg-black/40 backdrop-blur-sm">
+      <div className="mb-3 font-semibold">ELTX</div>
+      <div className="opacity-80 mb-4">The utility token platform.</div>
+      <div className="flex flex-wrap justify-center gap-4">
+        <Link href="/about" className="hover:opacity-80">About</Link>
+        <Link href="/docs" className="hover:opacity-80">Docs</Link>
+        <Link href="/terms" className="hover:opacity-80">Terms</Link>
+        <Link href="/privacy" className="hover:opacity-80">Privacy</Link>
+        <Link href="/status" className="hover:opacity-80">Status</Link>
+      </div>
+    </footer>
+  );
+}

--- a/components/layout/MobileMenu.tsx
+++ b/components/layout/MobileMenu.tsx
@@ -37,13 +37,13 @@ export default function MobileMenu({
     <>
       <div
         data-open={open}
-        className="fixed inset-0 bg-black/40 backdrop-blur-sm opacity-0 pointer-events-none data-[open=true]:opacity-100 data-[open=true]:pointer-events-auto transition-opacity duration-200 z-40"
+        className="fixed inset-0 bg-black/40 backdrop-blur-sm opacity-0 pointer-events-none data-[open=true]:opacity-100 data-[open=true]:pointer-events-auto transition-opacity duration-200 z-[60]"
         onClick={() => setOpen(false)}
       />
       <nav
         ref={panelRef}
         data-open={open}
-        className="fixed top-0 right-0 h-full w-80 max-w-[85%] bg-neutral-900 text-white translate-x-full data-[open=true]:translate-x-0 transition-transform duration-200 z-50 p-6 flex flex-col gap-4"
+        className="fixed top-0 right-0 h-full w-80 max-w-[85%] bg-neutral-900 text-white translate-x-full data-[open=true]:translate-x-0 transition-transform duration-200 z-[70] p-6 flex flex-col gap-4"
         role="dialog"
         aria-modal="true"
       >

--- a/components/layout/NavBar.tsx
+++ b/components/layout/NavBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { Menu } from 'lucide-react';
@@ -13,6 +14,7 @@ export default function NavBar() {
   const { user, logout } = useAuth();
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
+  const [logoError, setLogoError] = useState(false);
 
   useEffect(() => {
     if (open) document.body.style.overflow = 'hidden';
@@ -30,7 +32,13 @@ export default function NavBar() {
 
   return (
     <header className="p-4 border-b border-white/10 flex items-center justify-between bg-black/40 backdrop-blur-sm sticky top-0 z-50">
-      <Link href="/" className="font-bold">ELTX</Link>
+      <Link href="/" className="flex items-center font-bold" aria-label="ELTX Home">
+        {logoError ? (
+          <span>ELTX</span>
+        ) : (
+          <Image src="/assets/img/logo.jpeg" alt="ELTX Logo" width={32} height={32} onError={() => setLogoError(true)} />
+        )}
+      </Link>
       <nav className="hidden sm:flex items-center gap-4">
         {links.map((l) => (
           <Link key={l.href} href={l.href} className={`hover:opacity-80 ${isActive(l.href)}`}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "ethers": "^6.11.1",
         "express": "^4.19.2",
         "express-rate-limit": "^7.0.0",
+        "framer-motion": "^11.0.0",
         "helmet": "^7.1.0",
         "lucide-react": "^0.379.0",
         "mysql2": "^3.9.7",
@@ -3585,6 +3586,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -4891,6 +4919,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "ethers": "^6.11.1",
     "lucide-react": "^0.379.0",
     "qrcode.react": "^3.1.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "framer-motion": "^11.0.0"
   },
   "devDependencies": {
     "@types/node": "24.3.0",


### PR DESCRIPTION
## Summary
- add responsive NavBar with logo image, mobile drawer, and z-index guard
- introduce Footer and dark theme layout used across all pages
- redesign homepage hero with motion and features grid

## Testing
- `npm run lint --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb27f25bec832baec4746733987ff0