### PR TITLE
feat: add on-demand wallet scanner

### DIFF
--- a/api/background/runner.js
+++ b/api/background/runner.js
@@ -1,0 +1,18 @@
+const { leaseNextJob, runJob } = require('../src/services/scanJobs');
+const createUserScanner = require('../src/services/userScanner');
+
+module.exports = function startBackgroundRunner(db) {
+  const scanner = createUserScanner(db);
+  async function loop() {
+    try {
+      const job = await leaseNextJob(db);
+      if (job) {
+        await runJob(db, job, scanner);
+      }
+    } catch (e) {
+      console.error('[runner]', e.message);
+    }
+    setTimeout(loop, 1000);
+  }
+  loop();
+};

--- a/api/migrations/2025-09-07_on_demand_scanner.sql
+++ b/api/migrations/2025-09-07_on_demand_scanner.sql
@@ -1,0 +1,40 @@
+-- Migration: On-Demand Scanner tables and indexes
+
+-- A) wallet_deposits adjustments
+ALTER TABLE wallet_deposits
+  ADD COLUMN IF NOT EXISTS token_address_norm VARCHAR(42)
+    AS (IFNULL(token_address, '0x0000000000000000000000000000000000000000')) STORED;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_wallet_deposits_tx_token_to
+  ON wallet_deposits (tx_hash, token_address_norm, to_address);
+
+ALTER TABLE wallet_deposits
+  ADD COLUMN IF NOT EXISTS source ENUM('worker','on_demand') NOT NULL DEFAULT 'worker',
+  ADD COLUMN IF NOT EXISTS scanner_run_id VARCHAR(36) NULL,
+  ADD COLUMN IF NOT EXISTS last_update_at TIMESTAMP NULL
+    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS idx_wallet_deposits_user_created
+  ON wallet_deposits (user_id, created_at DESC);
+
+-- B) user_scan_progress table
+CREATE TABLE IF NOT EXISTS user_scan_progress (
+  user_id BIGINT NOT NULL PRIMARY KEY,
+  last_scanned_block BIGINT NULL,
+  updated_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- C) user_scan_jobs queue table
+CREATE TABLE IF NOT EXISTS user_scan_jobs (
+  id CHAR(36) NOT NULL PRIMARY KEY,   -- UUID
+  user_id BIGINT NOT NULL,
+  from_block BIGINT NOT NULL,
+  to_block BIGINT NOT NULL,
+  status ENUM('queued','running','done','failed','canceled') NOT NULL DEFAULT 'queued',
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  started_at TIMESTAMP NULL,
+  finished_at TIMESTAMP NULL,
+  error TEXT NULL,
+  KEY idx_jobs_user_status (user_id, status),
+  KEY idx_jobs_created (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/api/server.js
+++ b/api/server.js
@@ -46,6 +46,10 @@ const pool = mysql.createPool(
   }
 );
 
+// start background scanner runner
+const startRunner = require('./background/runner');
+startRunner(pool);
+
 // ensure wallet tables exist
 (async () => {
   try {
@@ -412,6 +416,58 @@ app.post('/wallet/refresh', walletLimiter, async (req, res, next) => {
       [userId, bal.toString()]
     );
     res.json({ ok: true, balance_wei: bal.toString(), balance: ethers.formatEther(bal) });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// On-demand wallet scan endpoints
+const { getLatestBlockNumber } = require('./src/services/bscRpc');
+const { enqueueUserScan, getJobStatus } = require('./src/services/scanJobs');
+const { getLastScannedBlock } = require('./src/services/userScanProgress');
+
+app.post('/api/wallet/refresh', walletLimiter, async (req, res, next) => {
+  try {
+    const userId = await requireUser(req);
+    const latest = await getLatestBlockNumber();
+    const N = Number(process.env.USER_SCAN_RECENT_BLOCKS) || 1000;
+    const baseline = latest - N + 1;
+    const last = await getLastScannedBlock(pool, userId);
+    const fromBlock = Math.max(baseline, last ? last + 1 : baseline);
+    const toBlock = latest;
+    const jobId = await enqueueUserScan(pool, userId, fromBlock, toBlock);
+    res.status(202).json({
+      ok: true,
+      status: 202,
+      jobId,
+      range: { from: fromBlock, to: toBlock },
+      message: 'Scanning recent blocks in background (snapshot)',
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.get('/api/wallet/refresh/:jobId', walletLimiter, async (req, res, next) => {
+  try {
+    const userId = await requireUser(req);
+    const job = await getJobStatus(pool, req.params.jobId, userId);
+    if (!job) return next({ status: 404, code: 'NOT_FOUND', message: 'Job not found' });
+    res.json({ ok: true, job });
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.get('/api/transactions', walletLimiter, async (req, res, next) => {
+  try {
+    const userId = await requireUser(req);
+    const limit = Math.min(Number(req.query.limit) || 50, 100);
+    const [rows] = await pool.query(
+      'SELECT * FROM wallet_deposits WHERE user_id=? ORDER BY block_number DESC, id DESC LIMIT ?',
+      [userId, limit]
+    );
+    res.json({ ok: true, transactions: rows });
   } catch (err) {
     next(err);
   }

--- a/api/src/services/bscRpc.js
+++ b/api/src/services/bscRpc.js
@@ -1,0 +1,25 @@
+const { ethers } = require('ethers');
+
+const RPC_HTTP = process.env.RPC_HTTP || process.env.BSC_RPC_URL;
+if (!RPC_HTTP) throw new Error('RPC_HTTP is not set');
+const CHAIN_ID = Number(process.env.CHAIN_ID || 56);
+const provider = new ethers.JsonRpcProvider(RPC_HTTP, CHAIN_ID);
+
+async function getLatestBlockNumber() {
+  return provider.getBlockNumber();
+}
+
+async function getLogs(params) {
+  return provider.getLogs(params);
+}
+
+async function getBlocksWithTxsBatch(blockNumbers = []) {
+  const blocks = [];
+  for (const num of blockNumbers) {
+    const block = await provider.getBlock(num, true);
+    if (block) blocks.push(block);
+  }
+  return blocks;
+}
+
+module.exports = { getLatestBlockNumber, getLogs, getBlocksWithTxsBatch };

--- a/api/src/services/deposits.js
+++ b/api/src/services/deposits.js
@@ -1,0 +1,39 @@
+// Database helpers for wallet deposits
+
+async function upsertDeposit(db, row) {
+  const sql = `INSERT INTO wallet_deposits (user_id, chain_id, to_address, tx_hash, block_number, block_hash, token_address, amount_wei, confirmations, status, source, scanner_run_id)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
+               ON DUPLICATE KEY UPDATE block_number=VALUES(block_number), block_hash=VALUES(block_hash), amount_wei=VALUES(amount_wei), confirmations=VALUES(confirmations), status=VALUES(status), source=VALUES(source), scanner_run_id=VALUES(scanner_run_id), last_update_at=CURRENT_TIMESTAMP`;
+  const params = [
+    row.user_id,
+    row.chain_id,
+    row.to_address,
+    row.tx_hash,
+    row.block_number,
+    row.block_hash,
+    row.token_address,
+    row.amount_wei,
+    row.confirmations,
+    row.status,
+    row.source || 'on_demand',
+    row.scanner_run_id
+  ];
+  await db.query(sql, params);
+}
+
+async function markConfirmed(db, txHash, blockNumber) {
+  await db.query(
+    'UPDATE wallet_deposits SET status="confirmed", confirmations=?-block_number, last_update_at=NOW() WHERE tx_hash=? AND block_number=?',
+    [blockNumber, txHash, blockNumber]
+  );
+}
+
+async function getConfirmedBalancesForUser(db, userId) {
+  const [rows] = await db.query(
+    'SELECT token_address, SUM(amount_wei) AS total FROM wallet_deposits WHERE user_id=? AND status="confirmed" GROUP BY token_address',
+    [userId]
+  );
+  return rows;
+}
+
+module.exports = { upsertDeposit, markConfirmed, getConfirmedBalancesForUser };

--- a/api/src/services/scanJobs.js
+++ b/api/src/services/scanJobs.js
@@ -1,0 +1,61 @@
+const crypto = require('crypto');
+const { updateLastScannedBlock } = require('./userScanProgress');
+
+async function enqueueUserScan(db, userId, from_block, to_block) {
+  const id = crypto.randomUUID();
+  await db.query(
+    'INSERT INTO user_scan_jobs (id, user_id, from_block, to_block) VALUES (?,?,?,?)',
+    [id, userId, from_block, to_block]
+  );
+  return id;
+}
+
+async function leaseNextJob(db) {
+  const conn = await db.getConnection();
+  try {
+    await conn.beginTransaction();
+    const [rows] = await conn.query(
+      'SELECT * FROM user_scan_jobs WHERE status="queued" ORDER BY created_at LIMIT 1 FOR UPDATE SKIP LOCKED'
+    );
+    if (!rows.length) {
+      await conn.rollback();
+      return null;
+    }
+    const job = rows[0];
+    await conn.query('UPDATE user_scan_jobs SET status="running", started_at=NOW() WHERE id=?', [job.id]);
+    await conn.commit();
+    return job;
+  } catch (e) {
+    await conn.rollback();
+    throw e;
+  } finally {
+    conn.release();
+  }
+}
+
+async function runJob(db, job, scanner) {
+  const BATCH_BLOCKS = 50;
+  let current = job.from_block;
+  while (current <= job.to_block) {
+    const to = Math.min(current + BATCH_BLOCKS - 1, job.to_block);
+    await scanner.scanRangeForUser({
+      userId: job.user_id,
+      fromBlock: current,
+      toBlock: to,
+      runId: job.id,
+    });
+    await updateLastScannedBlock(db, job.user_id, to);
+    current = to + 1;
+  }
+  await db.query('UPDATE user_scan_jobs SET status="done", finished_at=NOW() WHERE id=?', [job.id]);
+}
+
+async function getJobStatus(db, jobId, userId) {
+  const [rows] = await db.query(
+    'SELECT id,status,from_block,to_block,started_at,finished_at FROM user_scan_jobs WHERE id=? AND user_id=?',
+    [jobId, userId]
+  );
+  return rows[0] || null;
+}
+
+module.exports = { enqueueUserScan, leaseNextJob, runJob, getJobStatus };

--- a/api/src/services/shared/erc20.js
+++ b/api/src/services/shared/erc20.js
@@ -1,0 +1,14 @@
+const { ethers } = require('ethers');
+
+// Shared ERC20 utilities used by worker and on-demand scanner
+const TRANSFER_TOPIC = ethers.id('Transfer(address,address,uint256)');
+
+function decodeTransferLog(log) {
+  const iface = new ethers.Interface([
+    'event Transfer(address indexed from,address indexed to,uint256 value)'
+  ]);
+  const { from, to, value } = iface.decodeEventLog('Transfer', log.data, log.topics);
+  return { from: from.toLowerCase(), to: to.toLowerCase(), value };
+}
+
+module.exports = { TRANSFER_TOPIC, decodeTransferLog };

--- a/api/src/services/tokenMaps.js
+++ b/api/src/services/tokenMaps.js
@@ -1,0 +1,18 @@
+// Token metadata used for scanning
+const tokenMap = {
+  BNB: { symbol: 'BNB', address: null, decimals: 18 },
+  USDT: {
+    symbol: 'USDT',
+    address: (process.env.TOKEN_USDT || '0x55d398326f99059ff775485246999027b3197955').toLowerCase(),
+    decimals: Number(process.env.TOKEN_USDT_DECIMALS || 18)
+  },
+  USDC: {
+    symbol: 'USDC',
+    address: (process.env.TOKEN_USDC || '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d').toLowerCase(),
+    decimals: Number(process.env.TOKEN_USDC_DECIMALS || 18)
+  }
+};
+
+const TRANSFER_TOPIC = require('./shared/erc20').TRANSFER_TOPIC;
+
+module.exports = { tokenMap, TRANSFER_TOPIC };

--- a/api/src/services/userScanProgress.js
+++ b/api/src/services/userScanProgress.js
@@ -1,0 +1,15 @@
+// Track last scanned block per user
+
+async function getLastScannedBlock(db, userId) {
+  const [rows] = await db.query('SELECT last_scanned_block FROM user_scan_progress WHERE user_id=?', [userId]);
+  return rows.length ? rows[0].last_scanned_block : null;
+}
+
+async function updateLastScannedBlock(db, userId, blockNumber) {
+  await db.query(
+    'INSERT INTO user_scan_progress (user_id, last_scanned_block) VALUES (?, ?) ON DUPLICATE KEY UPDATE last_scanned_block=VALUES(last_scanned_block)',
+    [userId, blockNumber]
+  );
+}
+
+module.exports = { getLastScannedBlock, updateLastScannedBlock };

--- a/api/src/services/userScanner.js
+++ b/api/src/services/userScanner.js
@@ -1,0 +1,85 @@
+const { getLogs, getBlocksWithTxsBatch } = require('./bscRpc');
+const { tokenMap, TRANSFER_TOPIC } = require('./tokenMaps');
+const { upsertDeposit, markConfirmed } = require('./deposits');
+const { decodeTransferLog } = require('./shared/erc20');
+
+module.exports = function createUserScanner(db) {
+  const CHAIN_ID = Number(process.env.CHAIN_ID || 56);
+  const CONFIRMATIONS = Number(process.env.CONFIRMATIONS || 12);
+
+  async function getUserAddresses(userId) {
+    const [rows] = await db.query('SELECT address FROM wallet_addresses WHERE user_id=?', [userId]);
+    if (rows.length) return rows.map((r) => r.address.toLowerCase());
+    const [[u]] = await db.query('SELECT wallet_address FROM users WHERE id=?', [userId]);
+    return u && u.wallet_address ? [u.wallet_address.toLowerCase()] : [];
+  }
+
+  async function scanRangeForUser({ userId, fromBlock, toBlock, runId }) {
+    const addresses = await getUserAddresses(userId);
+    if (!addresses.length) return;
+    const addrSet = new Set(addresses.map((a) => a.toLowerCase()));
+    // Scan ERC20 transfers
+    for (const t of Object.values(tokenMap)) {
+      if (!t.address) continue;
+      for (const addr of addrSet) {
+        const logs = await getLogs({
+          address: t.address,
+          fromBlock,
+          toBlock,
+          topics: [TRANSFER_TOPIC, null, '0x' + addr.slice(2).padStart(64, '0')]
+        });
+        for (const log of logs) {
+          const { to, value } = decodeTransferLog(log);
+          if (to !== addr) continue;
+          const confirmations = toBlock - log.blockNumber + 1;
+          const status = confirmations >= CONFIRMATIONS ? 'confirmed' : 'pending';
+          await upsertDeposit(db, {
+            user_id: userId,
+            chain_id: CHAIN_ID,
+            to_address: addr,
+            tx_hash: log.transactionHash,
+            block_number: log.blockNumber,
+            block_hash: log.blockHash,
+            token_address: t.address,
+            amount_wei: value.toString(),
+            confirmations,
+            status,
+            source: 'on_demand',
+            scanner_run_id: runId,
+          });
+          if (status === 'confirmed') await markConfirmed(db, log.transactionHash, log.blockNumber);
+        }
+      }
+    }
+    // Native BNB deposits
+    const blockNums = [];
+    for (let n = fromBlock; n <= toBlock; n++) blockNums.push(n);
+    const blocks = await getBlocksWithTxsBatch(blockNums);
+    for (const block of blocks) {
+      for (const tx of block.transactions || []) {
+        const to = tx.to ? tx.to.toLowerCase() : null;
+        if (!to || !addrSet.has(to)) continue;
+        const value = tx.value || 0n;
+        const confirmations = toBlock - block.number + 1;
+        const status = confirmations >= CONFIRMATIONS ? 'confirmed' : 'pending';
+        await upsertDeposit(db, {
+          user_id: userId,
+          chain_id: CHAIN_ID,
+          to_address: to,
+          tx_hash: tx.hash,
+          block_number: block.number,
+          block_hash: block.hash,
+          token_address: null,
+          amount_wei: value.toString(),
+          confirmations,
+          status,
+          source: 'on_demand',
+          scanner_run_id: runId,
+        });
+        if (status === 'confirmed') await markConfirmed(db, tx.hash, block.number);
+      }
+    }
+  }
+
+  return { scanRangeForUser };
+};

--- a/apps/worker/worker.js
+++ b/apps/worker/worker.js
@@ -15,7 +15,7 @@ if (!RPC_HTTP) throw new Error('RPC_HTTP is required');
 
 const CONCURRENCY = 5;
 
-const TRANSFER_TOPIC = ethers.id('Transfer(address,address,uint256)');
+const { TRANSFER_TOPIC } = require('../../api/src/services/shared/erc20');
 const tokenMeta = [];
 function addToken(symbol, envKey) {
   const addr = process.env[envKey];


### PR DESCRIPTION
## Summary
- add SQL migration for on-demand scanner tables and indexes
- introduce background runner and scanning services
- expose REST endpoints to trigger and monitor scans

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcc60b4028832bbc11729ce898340b