### PR TITLE
Use address column for deposit upserts

### DIFF
--- a/api/src/services/deposits.js
+++ b/api/src/services/deposits.js
@@ -1,13 +1,13 @@
 // Database helpers for wallet deposits
 
 async function upsertDeposit(db, row) {
-  const sql = `INSERT INTO wallet_deposits (user_id, chain_id, to_address, tx_hash, block_number, block_hash, token_address, amount_wei, confirmations, status, source, scanner_run_id)
+  const sql = `INSERT INTO wallet_deposits (user_id, chain_id, address, tx_hash, block_number, block_hash, token_address, amount_wei, confirmations, status, source, scanner_run_id)
                VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
                ON DUPLICATE KEY UPDATE block_number=VALUES(block_number), block_hash=VALUES(block_hash), amount_wei=VALUES(amount_wei), confirmations=VALUES(confirmations), status=VALUES(status), source=VALUES(source), scanner_run_id=VALUES(scanner_run_id), last_update_at=CURRENT_TIMESTAMP`;
   const params = [
     row.user_id,
     row.chain_id,
-    row.to_address,
+    row.address,
     row.tx_hash,
     row.block_number,
     row.block_hash,

--- a/api/src/services/userScanner.js
+++ b/api/src/services/userScanner.js
@@ -36,7 +36,7 @@ module.exports = function createUserScanner(db) {
           await upsertDeposit(db, {
             user_id: userId,
             chain_id: CHAIN_ID,
-            to_address: addr,
+            address: addr,
             tx_hash: log.transactionHash,
             block_number: log.blockNumber,
             block_hash: log.blockHash,
@@ -65,7 +65,7 @@ module.exports = function createUserScanner(db) {
         await upsertDeposit(db, {
           user_id: userId,
           chain_id: CHAIN_ID,
-          to_address: to,
+          address: to,
           tx_hash: tx.hash,
           block_number: block.number,
           block_hash: block.hash,


### PR DESCRIPTION
## Summary
- insert deposits using `address` column instead of `to_address`
- ensure user scanner passes `address` field when upserting deposits

## Testing
- `npm test`
- `npm run api` *(fails: MASTER_MNEMONIC is not set)*
- `npm run worker` *(fails: RPC_HTTP is required)*

------
https://chatgpt.com/codex/tasks/task_e_68bccef8fa88832bb9d486cd48676f87