### PR TITLE
feat(worker): robust env bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,11 @@ DATABASE_URL=mysql://user:pass@localhost/eltx
 # PORT=4000
 
 NEXT_PUBLIC_API_BASE=https://api.eltx.online
-BSC_RPC_URL=
-RPC_WS=
+CHAIN=bsc
 CHAIN_ID=56
+RPC_HTTP=https://bsc-dataseed.binance.org
+RPC_WS=wss://bsc-ws-node.nariox.org:443
+CONFIRMATIONS=12
 SCAN_INTERVAL_MS=15000
 BACKFILL_BLOCKS=5000
 # optional: force worker to start scanning from a specific block

--- a/apps/shared/wallet/addresses.ts
+++ b/apps/shared/wallet/addresses.ts
@@ -13,7 +13,7 @@ export async function getDepositAddressesBatch(
     cursor = 0,
   }: { limit: number; cursor?: number }
 ): Promise<{ rows: AddressRow[]; nextCursor: number | null }> {
-  const chainId = Number(process.env.CHAIN_ID || 56);
+  const chainId = Number(process.env.CHAIN_ID);
   const [rows] = await db.query(
     'SELECT id, address, user_id FROM wallet_addresses WHERE chain_id=? AND id>? ORDER BY id ASC LIMIT ?',
     [chainId, cursor, limit]

--- a/apps/worker/.env.example
+++ b/apps/worker/.env.example
@@ -1,12 +1,6 @@
-CHAIN=bsc-mainnet
+CHAIN=bsc
 CHAIN_ID=56
-RPC_HTTP=
-RPC_WS=
+RPC_HTTP=https://bsc-dataseed.binance.org
+RPC_WS=wss://bsc-ws-node.nariox.org:443
 CONFIRMATIONS=12
-ADDR_REFRESH_MINUTES=15
-
-MASTER_MNEMONIC=
-OMNIBUS_ADDRESS=
-OMNIBUS_PK=
-
-DATABASE_URL=
+DATABASE_URL=mysql://user:pass@localhost:3306/eltx

--- a/apps/worker/bootstrap/loadEnv.ts
+++ b/apps/worker/bootstrap/loadEnv.ts
@@ -1,0 +1,35 @@
+import { config as dotenv } from 'dotenv';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = dirname(__filename);
+
+// 1) load worker-local env first (if exists)
+const workerEnvPath = resolve(__dirname, '..', '.env');
+dotenv({ path: workerEnvPath, override: false });
+
+// 2) then try project root .env (if missing or keys incomplete)
+const rootEnvPath = resolve(__dirname, '..', '..', '..', '.env');
+dotenv({ path: rootEnvPath, override: false });
+
+// verification function required on each run
+export function assertRequiredEnv() {
+  const required = [
+    'CHAIN', 'CHAIN_ID', 'RPC_HTTP', 'RPC_WS',
+    'CONFIRMATIONS', 'DATABASE_URL'
+  ];
+  const missing = required.filter(k => !process.env[k] || String(process.env[k]).trim() === '');
+  if (missing.length) {
+    const hint = `
+[ENV ERROR] Missing required vars: ${missing.join(', ')}
+- Ensure apps/worker/.env exists OR create a symlink to project root .env.
+- README instructs copying: "cp apps/worker/.env.example apps/worker/.env".
+- Current lookup order:
+    1) ${workerEnvPath}
+    2) ${rootEnvPath}
+- Example: RPC_HTTP should be set.`;
+    throw new Error(hint);
+  }
+}
+

--- a/apps/worker/index.ts
+++ b/apps/worker/index.ts
@@ -1,3 +1,13 @@
+import './bootstrap/loadEnv.ts';
+import { assertRequiredEnv } from './bootstrap/loadEnv.ts';
+
+try {
+  assertRequiredEnv();
+} catch (e) {
+  console.error(e instanceof Error ? e.message : e);
+  process.exit(1);
+}
+
 import { createPool } from 'mysql2/promise';
 import { getDepositAddressesBatch } from '../shared/wallet/addresses.ts';
 import { scanAddress } from './scanAddress.ts';

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "index.ts",
   "scripts": {
-    "worker": "ts-node index.ts",
+    "worker": "ts-node --transpile-only index.ts",
     "start": "npm run worker"
   },
   "dependencies": {

--- a/apps/worker/scanAddress.ts
+++ b/apps/worker/scanAddress.ts
@@ -6,11 +6,11 @@ import type { Pool } from 'mysql2/promise';
 import { ethers } from 'ethers';
 
 const RECENT_WINDOW = 1000;
-const CONFIRMATIONS = Number(process.env.CONFIRMATIONS || 12);
+const CONFIRMATIONS = Number(process.env.CONFIRMATIONS);
 
 export async function scanAddress(db: Pool, address: string, userId: number) {
   const addr = address.toLowerCase();
-  const chainId = Number(process.env.CHAIN_ID || 56);
+  const chainId = Number(process.env.CHAIN_ID);
 
   const toBlock = await getLatestBlockNumber();
   const progress = await getAddressProgress(db, addr);

--- a/apps/worker/services/bscRpc.ts
+++ b/apps/worker/services/bscRpc.ts
@@ -1,8 +1,13 @@
 import { ethers } from 'ethers';
 
-const RPC_HTTP = process.env.RPC_HTTP || process.env.BSC_RPC_URL;
-if (!RPC_HTTP) throw new Error('RPC_HTTP missing');
-const CHAIN_ID = Number(process.env.CHAIN_ID || 56);
+const RPC_HTTP = process.env.RPC_HTTP?.trim();
+if (!RPC_HTTP) {
+  throw new Error(
+    'RPC_HTTP missing. Make sure apps/worker/.env or project .env is loaded before imports. ' +
+      'See README for required ENV and copy command for apps/worker/.env.'
+  );
+}
+const CHAIN_ID = Number(process.env.CHAIN_ID);
 
 export const rpcProvider = new ethers.JsonRpcProvider(RPC_HTTP, CHAIN_ID);
 


### PR DESCRIPTION
## Summary
- load environment from worker/.env then root .env with clear missing-var errors
- ensure worker imports env before other modules and uses deterministic config
- improve RPC client messaging and document required variables in examples

## Testing
- `npm run worker` *(fails: RPC_HTTP missing. Make sure apps/worker/.env or project .env is loaded before imports.)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd8aeecd70832b95af0062179bfec5