### PR TITLE
Detect deposits by scanning only addresses with balances

### DIFF
--- a/apps/worker/index.ts
+++ b/apps/worker/index.ts
@@ -1,8 +1,10 @@
 import { config as dotenv } from 'dotenv';
-import { resolve } from 'path';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
 
-dotenv({ path: resolve(process.cwd(), 'apps/worker/.env') });
-dotenv({ path: resolve(process.cwd(), '.env'), override: false });
+const __dirname = dirname(fileURLToPath(import.meta.url));
+dotenv({ path: resolve(__dirname, '.env') });
+dotenv({ path: resolve(__dirname, '../../.env'), override: false });
 
 import { getAllDepositAddresses } from './services/addresses.ts';
 import { scanOneAddress } from './services/addressScanner.ts';

--- a/apps/worker/services/addressScanner.ts
+++ b/apps/worker/services/addressScanner.ts
@@ -1,20 +1,47 @@
-import { getLatestBlockNumber, getLogs, getBlocksWithTxsBatch } from './bscRpc.ts';
+import {
+  getLatestBlockNumber,
+  getLogs,
+  getBlocksWithTxsBatch,
+  rpcProvider,
+} from './bscRpc.ts';
 import { getFromBlockForAddress } from './scanBounds.ts';
 import { upsertDeposit, markConfirmed } from './deposits.ts';
-import { getTokensInScope, TRANSFER_TOPIC, checksum, hexToDec } from './tokens.ts';
+import {
+  getTokensInScope,
+  TRANSFER_TOPIC,
+  checksum,
+  hexToDec,
+  TokenInfo,
+} from './tokens.ts';
+import { ethers } from 'ethers';
 
 const BATCH_BLOCKS = Number(process.env.WORKER_BATCH_BLOCKS || 50);
 const REQUIRED_CONF = Number(process.env.CONFIRMATIONS || 12);
+const ERC20_ABI = ['function balanceOf(address) view returns (uint256)'];
 
 export async function scanOneAddress(addr: string) {
+  const tokens = getTokensInScope();
+  const tokensWithBalance: TokenInfo[] = [];
+
+  for (const t of tokens) {
+    if (t.symbol === 'BNB') {
+      const bal = await rpcProvider.getBalance(addr);
+      if (bal > 0n) tokensWithBalance.push(t);
+    } else if (t.address) {
+      const contract = new ethers.Contract(t.address, ERC20_ABI, rpcProvider);
+      const bal: bigint = await contract.balanceOf(addr);
+      if (bal > 0n) tokensWithBalance.push(t);
+    }
+  }
+
+  if (tokensWithBalance.length === 0) return;
+
   const latest = await getLatestBlockNumber();
   const fromBlock = await getFromBlockForAddress(addr, latest);
   const toBlock = latest;
 
-  const tokens = getTokensInScope();
-
-  // ERC20 tokens
-  for (const t of tokens) {
+  // ERC20 tokens with balance
+  for (const t of tokensWithBalance) {
     if (t.symbol === 'BNB' || !t.address) continue;
     const paddedTo = '0x' + addr.toLowerCase().replace(/^0x/, '').padStart(64, '0');
     const logs = await getLogs({
@@ -48,33 +75,35 @@ export async function scanOneAddress(addr: string) {
     }
   }
 
-  // Native BNB transfers
-  for (let b = fromBlock; b <= toBlock; b += BATCH_BLOCKS) {
-    const end = Math.min(b + BATCH_BLOCKS - 1, toBlock);
-    const blocks = await getBlocksWithTxsBatch(
-      Array.from({ length: end - b + 1 }, (_, i) => b + i)
-    );
-    for (const block of blocks) {
-      for (const tx of block.transactions) {
-        if (!tx.to) continue;
-        if (tx.to.toLowerCase() !== addr.toLowerCase()) continue;
-        const conf = latest - block.number + 1;
-        const status = conf >= REQUIRED_CONF ? 'confirmed' : 'pending';
-        await upsertDeposit({
-          to_address: checksum(tx.to),
-          from_address: checksum(tx.from),
-          token_symbol: 'BNB',
-          token_address: null,
-          amount_wei: hexToDec(tx.value),
-          tx_hash: tx.hash,
-          block_number: block.number,
-          status,
-          confirmations: conf,
-          source: 'worker',
-        });
-        if (status === 'confirmed') await markConfirmed(tx.hash, block.number);
+  // Native BNB transfers when balance exists
+  if (tokensWithBalance.some((t) => t.symbol === 'BNB')) {
+    for (let b = fromBlock; b <= toBlock; b += BATCH_BLOCKS) {
+      const end = Math.min(b + BATCH_BLOCKS - 1, toBlock);
+      const blocks = await getBlocksWithTxsBatch(
+        Array.from({ length: end - b + 1 }, (_, i) => b + i)
+      );
+      for (const block of blocks as any[]) {
+        for (const tx of (block as any).transactions as any[]) {
+          if (!tx.to) continue;
+          if (tx.to.toLowerCase() !== addr.toLowerCase()) continue;
+          const conf = latest - block.number + 1;
+          const status = conf >= REQUIRED_CONF ? 'confirmed' : 'pending';
+          await upsertDeposit({
+            to_address: checksum(tx.to),
+            from_address: checksum(tx.from),
+            token_symbol: 'BNB',
+            token_address: null,
+            amount_wei: hexToDec(tx.value),
+            tx_hash: tx.hash,
+            block_number: block.number,
+            status,
+            confirmations: conf,
+            source: 'worker',
+          });
+          if (status === 'confirmed') await markConfirmed(tx.hash, block.number);
+        }
       }
+      await new Promise((r) => setImmediate(r));
     }
-    await new Promise((r) => setImmediate(r));
   }
 }

--- a/apps/worker/services/db.ts
+++ b/apps/worker/services/db.ts
@@ -1,4 +1,11 @@
 import { createPool } from 'mysql2/promise';
+import { config as dotenv } from 'dotenv';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+dotenv({ path: resolve(__dirname, '../.env') });
+dotenv({ path: resolve(__dirname, '../../../.env'), override: false });
 
 if (!process.env.DATABASE_URL) {
   throw new Error('DATABASE_URL missing');
@@ -6,13 +13,14 @@ if (!process.env.DATABASE_URL) {
 
 const pool = createPool(process.env.DATABASE_URL);
 
-export const sql = {
-  async query<T = any>(q: string, params: any[] = []): Promise<T[]> {
-    const [rows] = await pool.query(q, params);
-    return rows as T[];
-  },
-  async oneOrNone<T = any>(q: string, params: any[] = []): Promise<T | null> {
-    const rows = await this.query<T>(q, params);
-    return rows.length ? (rows[0] as T) : null;
-  },
-};
+async function query<T = any>(q: string, params: any[] = []): Promise<T[]> {
+  const [rows] = await pool.query(q, params);
+  return rows as T[];
+}
+
+async function oneOrNone<T = any>(q: string, params: any[] = []): Promise<T | null> {
+  const rows = await query<T>(q, params);
+  return rows.length ? (rows[0] as T) : null;
+}
+
+export const sql = { query, oneOrNone };


### PR DESCRIPTION
## Summary
- Skip heavy scans for addresses with zero balance
- Only fetch logs and transactions when funds exist to insert new deposits
- Export standalone DB query helpers for cleaner typings

## Testing
- `npm test`
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68bd947c8858832b9ef1c5f8ad7cd6aa