### PR TITLE
Detect deposits by scanning only addresses with balances

### DIFF
--- a/apps/worker/index.ts
+++ b/apps/worker/index.ts
@@ -1,42 +1,111 @@
 import { config as dotenv } from 'dotenv';
-import { resolve } from 'path';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { readFileSync } from 'fs';
+import { execSync } from 'child_process';
 
-dotenv({ path: resolve(process.cwd(), 'apps/worker/.env') });
-dotenv({ path: resolve(process.cwd(), '.env'), override: false });
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const workerEnv = resolve(__dirname, '.env');
+const rootEnv = resolve(__dirname, '../../.env');
+dotenv({ path: workerEnv });
+dotenv({ path: rootEnv, override: false });
 
 import { getAllDepositAddresses } from './services/addresses.ts';
 import { scanOneAddress } from './services/addressScanner.ts';
+import { getLatestBlockNumber } from './services/bscRpc.ts';
+import { logger, envPaths, SAMPLE_RATE, HEARTBEAT_MS, shortAddr } from './services/logger.ts';
+import { rpcCall } from './services/rpc.ts';
+
+const ENV_PATHS = [workerEnv, rootEnv];
 
 function assertRequiredEnv() {
-  const required = ['RPC_HTTP', 'RPC_WS', 'CONFIRMATIONS', 'DATABASE_URL'];
+  const required = ['RPC_HTTP', 'CONFIRMATIONS', 'DATABASE_URL', 'CHAIN_ID'];
   const missing = required.filter((k) => !process.env[k] || String(process.env[k]).trim() === '');
   if (missing.length) {
-    throw new Error(`Missing required env vars: ${missing.join(', ')}`);
+    logger.error('WRK', 'ENV', `missing ${missing.join(', ')}; searched ${ENV_PATHS.join(', ')}`);
+    process.exit(1);
   }
 }
 
 const SCAN_CONCURRENCY = Number(process.env.WORKER_CONCURRENCY || 3);
 const SLEEP_MS = Number(process.env.WORKER_SLEEP_MS || 1500);
+const RECENT = Number(process.env.USER_SCAN_RECENT_BLOCKS || 1000);
+const SAFETY = Number(process.env.USER_SCAN_SAFETY || 12);
+const BATCH_BLOCKS = Number(process.env.WORKER_BATCH_BLOCKS || 50);
+
+function startupBanner() {
+  const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url)).toString());
+  let git = '';
+  try { git = execSync('git rev-parse --short HEAD').toString().trim(); } catch {}
+  const tsNodeVer = (() => { try { return require('ts-node/package.json').version; } catch { return 'unknown'; } })();
+  const nodeVer = process.version;
+  const chainId = Number(process.env.CHAIN_ID);
+  const chainName = chainId === 56 ? 'bsc' : `chain-${chainId}`;
+  const rpcHost = (() => { try { return new URL(String(process.env.RPC_HTTP)).host; } catch { return 'unknown'; }})();
+  const envInfo = envPaths(ENV_PATHS);
+  logger.info('WRK', 'START', `v${pkg.version}${git ? ' sha=' + git : ''} node=${nodeVer} ts-node=${tsNodeVer} chain=${chainName}(${chainId}) rpc=${rpcHost} conf=${process.env.CONFIRMATIONS} recent=${RECENT} safety=${SAFETY} conc=${SCAN_CONCURRENCY} batch=${BATCH_BLOCKS} sleep=${SLEEP_MS}ms env=[${envInfo.loaded.join(', ')}]`);
+  if (envInfo.missing.length) {
+    logger.warn('WRK', 'ENV', `missing env files: ${envInfo.missing.join(', ')}`);
+  }
+}
+
+function heartbeat() {
+  let last = Date.now();
+  setInterval(() => {
+    const mem = process.memoryUsage();
+    const rss = Math.round(mem.rss / 1024 / 1024);
+    const heap = Math.round(mem.heapUsed / 1024 / 1024);
+    const now = Date.now();
+    const delay = now - last - HEARTBEAT_MS;
+    last = now;
+    const uptime = Math.round(process.uptime() / 60);
+    logger.info('HB', '', `rss=${rss}MB heap=${heap}MB evDelay≈${Math.round(delay)}ms uptime=${uptime}m`);
+  }, HEARTBEAT_MS).unref();
+}
 
 async function main() {
   assertRequiredEnv();
+  startupBanner();
+  heartbeat();
   while (true) {
+    const cycleStart = Date.now();
     const addrs = await getAllDepositAddresses();
+    const sampled = new Set<string>();
+    for (const a of addrs) if (Math.random() < SAMPLE_RATE) sampled.add(a);
+    logger.info('WRK', 'ADDR', `total=${addrs.length}, sample=${sampled.size} (rate=${SAMPLE_RATE.toFixed(2)})`);
+    if (logger.isDebug() && sampled.size) {
+      const sampleList = Array.from(sampled).slice(0, 10).map(shortAddr).join(',');
+      logger.debug('WRK', 'ADDR', `sample=${sampleList}`);
+    }
+    const tipRes = await rpcCall('getLatestBlockNumber', () => getLatestBlockNumber());
+    const tip = tipRes.result;
+    logger.info('WRK', 'SNAPSHOT', `latest=${tip} took=${tipRes.took}ms`);
+
+    const totals = { new: 0, updated: 0, confirmed: 0, errors: 0 };
     for (let i = 0; i < addrs.length; i += SCAN_CONCURRENCY) {
       const chunk = addrs.slice(i, i + SCAN_CONCURRENCY);
-      await Promise.allSettled(
-        chunk.map((a) =>
-          scanOneAddress(a).catch((e) => {
-            console.error('[ERR][scan]', e?.message || e);
-          })
-        )
+      const results = await Promise.allSettled(
+        chunk.map((a) => scanOneAddress(a, tip, sampled.has(a)))
       );
+      results.forEach((r) => {
+        if (r.status === 'fulfilled') {
+          totals.new += r.value.new;
+          totals.updated += r.value.updated;
+          totals.confirmed += r.value.confirmed;
+          totals.errors += r.value.errors;
+        } else {
+          totals.errors += 1;
+          logger.error('SCAN', 'ADDR', r.reason?.message || String(r.reason));
+        }
+      });
     }
+    const totalTook = (Date.now() - cycleStart) / 1000;
+    logger.info('SUM', 'CYCLE', `addrs=${addrs.length} new=${totals.new} updated=${totals.updated} confirmed=${totals.confirmed} errors=${totals.errors} totalTook=${totalTook.toFixed(1)}s`);
     await new Promise((r) => setTimeout(r, SLEEP_MS));
   }
 }
 
 main().catch((err) => {
-  console.error('[FATAL]', err);
+  logger.error('FATAL', '', err?.message || String(err));
   process.exit(1);
 });

--- a/apps/worker/services/addressScanner.ts
+++ b/apps/worker/services/addressScanner.ts
@@ -1,80 +1,195 @@
-import { getLatestBlockNumber, getLogs, getBlocksWithTxsBatch } from './bscRpc.ts';
-import { getFromBlockForAddress } from './scanBounds.ts';
+import { getLogs, getBlocksWithTxsBatch, rpcProvider } from './bscRpc.ts';
+import { getScanBounds } from './scanBounds.ts';
 import { upsertDeposit, markConfirmed } from './deposits.ts';
-import { getTokensInScope, TRANSFER_TOPIC, checksum, hexToDec } from './tokens.ts';
+import {
+  getTokensInScope,
+  TRANSFER_TOPIC,
+  checksum,
+  hexToDec,
+  decodeTransfer,
+} from './tokens.ts';
+import type { TokenInfo } from './tokens.ts';
+import { ethers } from 'ethers';
+import { rpcCall } from './rpc.ts';
+import { logger, shortAddr } from './logger.ts';
 
 const BATCH_BLOCKS = Number(process.env.WORKER_BATCH_BLOCKS || 50);
 const REQUIRED_CONF = Number(process.env.CONFIRMATIONS || 12);
+const ERC20_ABI = ['function balanceOf(address) view returns (uint256)'];
 
-export async function scanOneAddress(addr: string) {
-  const latest = await getLatestBlockNumber();
-  const fromBlock = await getFromBlockForAddress(addr, latest);
-  const toBlock = latest;
-
-  const tokens = getTokensInScope();
-
-  // ERC20 tokens
-  for (const t of tokens) {
-    if (t.symbol === 'BNB' || !t.address) continue;
-    const paddedTo = '0x' + addr.toLowerCase().replace(/^0x/, '').padStart(64, '0');
-    const logs = await getLogs({
-      fromBlock: '0x' + fromBlock.toString(16),
-      toBlock: '0x' + toBlock.toString(16),
-      address: t.address,
-      topics: [TRANSFER_TOPIC, null, paddedTo],
-    } as any);
-
-    for (const log of logs) {
-      const txHash = log.transactionHash;
-      const blockNumber = Number(log.blockNumber);
-      const from = '0x' + log.topics[1].slice(26);
-      const to = '0x' + log.topics[2].slice(26);
-      const amountWei = hexToDec(log.data);
-      const conf = latest - blockNumber + 1;
-      const status = conf >= REQUIRED_CONF ? 'confirmed' : 'pending';
-      await upsertDeposit({
-        to_address: checksum(to),
-        from_address: checksum(from),
-        token_symbol: t.symbol,
-        token_address: t.address,
-        amount_wei: amountWei,
-        tx_hash: txHash,
-        block_number: blockNumber,
-        status,
-        confirmations: conf,
-        source: 'worker',
-      });
-      if (status === 'confirmed') await markConfirmed(txHash, blockNumber);
+export async function scanOneAddress(addr: string, latest: number, verbose: boolean) {
+  const start = Date.now();
+  const stats = { new: 0, updated: 0, confirmed: 0, errors: 0 };
+  try {
+    const tokens = getTokensInScope();
+    const tokensWithBalance: TokenInfo[] = [];
+    for (const t of tokens) {
+      try {
+        if (t.symbol === 'BNB') {
+          const bal = await rpcProvider.getBalance(addr);
+          if (bal > 0n) tokensWithBalance.push(t);
+        } else if (t.address) {
+          const contract = new ethers.Contract(t.address, ERC20_ABI, rpcProvider);
+          const bal: bigint = await contract.balanceOf(addr);
+          if (bal > 0n) tokensWithBalance.push(t);
+        }
+      } catch (e) {
+        logger.warn('RPC', 'BAL', `addr=${shortAddr(addr)} token=${t.symbol} err=${e?.message || e}`);
+      }
     }
-  }
+    if (tokensWithBalance.length === 0) {
+      return stats;
+    }
 
-  // Native BNB transfers
-  for (let b = fromBlock; b <= toBlock; b += BATCH_BLOCKS) {
-    const end = Math.min(b + BATCH_BLOCKS - 1, toBlock);
-    const blocks = await getBlocksWithTxsBatch(
-      Array.from({ length: end - b + 1 }, (_, i) => b + i)
-    );
-    for (const block of blocks) {
-      for (const tx of block.transactions) {
-        if (!tx.to) continue;
-        if (tx.to.toLowerCase() !== addr.toLowerCase()) continue;
-        const conf = latest - block.number + 1;
+    const { fromBlock, toBlock } = await getScanBounds(addr, latest);
+    if (verbose) {
+      logger.info(
+        'SCAN',
+        'ADDR',
+        `${shortAddr(addr)} from=${fromBlock} to=${toBlock} tokens=[${tokensWithBalance
+          .map((t) => t.symbol)
+          .join(',')}]`
+      );
+    }
+
+    // ERC20 tokens
+    for (const t of tokensWithBalance) {
+      if (t.symbol === 'BNB' || !t.address) continue;
+      const paddedTo = '0x' + addr.toLowerCase().replace(/^0x/, '').padStart(64, '0');
+      let logs: any[] = [];
+      let logRes;
+      try {
+        logRes = await rpcCall('getLogs', () =>
+          getLogs({
+            fromBlock: '0x' + fromBlock.toString(16),
+            toBlock: '0x' + toBlock.toString(16),
+            address: t.address,
+            topics: [TRANSFER_TOPIC, null, paddedTo],
+          } as any)
+        , { token: t.symbol, to: addr });
+        logs = logRes.result;
+      } catch {
+        stats.errors++;
+        continue;
+      }
+      if (verbose || logs.length) {
+        logger.info('SCAN', 'ERC20', `token=${t.symbol} addr=${shortAddr(addr)} from=${fromBlock} to=${toBlock} logs=${logs.length} took=${logRes.took}ms`);
+      }
+      if (logger.isDebug() && logs.length) {
+        const ex = logs.slice(0, 3).map((l) => `${l.transactionHash.slice(0,10)}@${Number(l.blockNumber)}`);
+        logger.debug('SCAN', 'ERC20', `examples=${ex.join(',')}`);
+      }
+      for (const log of logs) {
+        const { from, to, amount } = decodeTransfer(log);
+        const txHash = log.transactionHash;
+        const blockNumber = Number(log.blockNumber);
+        const conf = latest - blockNumber + 1;
         const status = conf >= REQUIRED_CONF ? 'confirmed' : 'pending';
-        await upsertDeposit({
-          to_address: checksum(tx.to),
-          from_address: checksum(tx.from),
-          token_symbol: 'BNB',
-          token_address: null,
-          amount_wei: hexToDec(tx.value),
-          tx_hash: tx.hash,
-          block_number: block.number,
+        const kind = await upsertDeposit({
+          to_address: checksum(to),
+          from_address: checksum(from),
+          token_symbol: t.symbol,
+          token_address: t.address,
+          amount_wei: amount,
+          tx_hash: txHash,
+          block_number: blockNumber,
           status,
           confirmations: conf,
           source: 'worker',
         });
-        if (status === 'confirmed') await markConfirmed(tx.hash, block.number);
+        if (kind === 'new') {
+          logger.info('DB', 'NEW', `addr=${shortAddr(addr)} token=${t.symbol} amount=${amount} tx=${txHash} block=${blockNumber} conf=${conf} status=${status}`);
+          stats.new++;
+        } else if (kind === 'updated') {
+          logger.info('DB', 'UPD', `addr=${shortAddr(addr)} token=${t.symbol} tx=${txHash} conf=${conf} status=${status}`);
+          stats.updated++;
+        } else {
+          logger.info('DB', 'DUP', `addr=${shortAddr(addr)} token=${t.symbol} tx=${txHash}`);
+        }
+        if (status === 'confirmed') {
+          const changed = await markConfirmed(txHash, blockNumber);
+          if (changed) {
+            logger.info('DB', 'CONFIRM', `addr=${shortAddr(addr)} token=${t.symbol} tx=${txHash} block=${blockNumber} conf=${conf}`);
+            stats.confirmed++;
+          }
+        }
       }
     }
-    await new Promise((r) => setImmediate(r));
+
+    // Native BNB
+    if (tokensWithBalance.some((t) => t.symbol === 'BNB')) {
+      for (let b = fromBlock; b <= toBlock; b += BATCH_BLOCKS) {
+        const end = Math.min(b + BATCH_BLOCKS - 1, toBlock);
+        let blocks: any[] = [];
+        let batchRes;
+        try {
+          batchRes = await rpcCall('getBlocksWithTxsBatch', () =>
+            getBlocksWithTxsBatch(Array.from({ length: end - b + 1 }, (_, i) => b + i))
+          , { addr, range: `[${b}..${end}]` });
+          blocks = batchRes.result;
+        } catch {
+          stats.errors++;
+          continue;
+        }
+        let checked = 0;
+        let match = 0;
+        const matches: any[] = [];
+        for (const block of blocks as any[]) {
+          for (const tx of (block as any).transactions as any[]) {
+            checked++;
+            if (!tx.to) continue;
+            if (tx.to.toLowerCase() !== addr.toLowerCase()) continue;
+            match++;
+            matches.push(tx);
+            const conf = latest - block.number + 1;
+            const status = conf >= REQUIRED_CONF ? 'confirmed' : 'pending';
+            const amount = hexToDec(tx.value);
+            const kind = await upsertDeposit({
+              to_address: checksum(tx.to),
+              from_address: checksum(tx.from),
+              token_symbol: 'BNB',
+              token_address: null,
+              amount_wei: amount,
+              tx_hash: tx.hash,
+              block_number: block.number,
+              status,
+              confirmations: conf,
+              source: 'worker',
+            });
+            if (kind === 'new') {
+              logger.info('DB', 'NEW', `addr=${shortAddr(addr)} token=BNB amount=${amount} tx=${tx.hash} block=${block.number} conf=${conf} status=${status}`);
+              stats.new++;
+            } else if (kind === 'updated') {
+              logger.info('DB', 'UPD', `addr=${shortAddr(addr)} token=BNB tx=${tx.hash} conf=${conf} status=${status}`);
+              stats.updated++;
+            } else {
+              logger.info('DB', 'DUP', `addr=${shortAddr(addr)} token=BNB tx=${tx.hash}`);
+            }
+            if (status === 'confirmed') {
+              const changed = await markConfirmed(tx.hash, block.number);
+              if (changed) {
+                logger.info('DB', 'CONFIRM', `addr=${shortAddr(addr)} token=BNB tx=${tx.hash} block=${block.number} conf=${conf}`);
+                stats.confirmed++;
+              }
+            }
+          }
+        }
+        if (verbose || match) {
+          logger.info('SCAN', 'BNB', `addr=${shortAddr(addr)} range=[${b}..${end}] blocks=${blocks.length} txsChecked=${checked} match=${match} took=${batchRes.took}ms`);
+        }
+        if (logger.isDebug() && match) {
+          const ex = matches.slice(0, 2).map((tx: any) => `${tx.hash.slice(0,10)}@${tx.blockNumber}`);
+          logger.debug('SCAN', 'BNB', `examples=${ex.join(',')}`);
+        }
+        await new Promise((r) => setImmediate(r));
+      }
+    }
+  } catch (e) {
+    logger.error('SCAN', 'ADDR', `addr=${shortAddr(addr)} err=${e?.message || e}`);
+    stats.errors++;
+  } finally {
+    const took = Date.now() - start;
+    logger.info('SUM', 'ADDR', `addr=${shortAddr(addr)} new=${stats.new} updated=${stats.updated} confirmed=${stats.confirmed} errors=${stats.errors} took=${took}ms`);
   }
+  return stats;
 }

--- a/apps/worker/services/db.ts
+++ b/apps/worker/services/db.ts
@@ -4,15 +4,16 @@ if (!process.env.DATABASE_URL) {
   throw new Error('DATABASE_URL missing');
 }
 
-const pool = createPool(process.env.DATABASE_URL);
+export const pool = createPool(process.env.DATABASE_URL);
 
-export const sql = {
-  async query<T = any>(q: string, params: any[] = []): Promise<T[]> {
-    const [rows] = await pool.query(q, params);
-    return rows as T[];
-  },
-  async oneOrNone<T = any>(q: string, params: any[] = []): Promise<T | null> {
-    const rows = await this.query<T>(q, params);
-    return rows.length ? (rows[0] as T) : null;
-  },
-};
+async function query<T = any>(q: string, params: any[] = []): Promise<T[]> {
+  const [rows] = await pool.query(q, params);
+  return rows as T[];
+}
+
+async function oneOrNone<T = any>(q: string, params: any[] = []): Promise<T | null> {
+  const rows = await query<T>(q, params);
+  return rows.length ? (rows[0] as T) : null;
+}
+
+export const sql = { query, oneOrNone };

--- a/apps/worker/services/deposits.ts
+++ b/apps/worker/services/deposits.ts
@@ -1,4 +1,4 @@
-import { sql } from './db.ts';
+import { sql, pool } from './db.ts';
 
 export async function upsertDeposit(row: {
   to_address: string;
@@ -11,8 +11,8 @@ export async function upsertDeposit(row: {
   status: 'pending' | 'confirmed';
   confirmations: number;
   source: string;
-}) {
-  await sql.query(
+}): Promise<'new' | 'updated' | 'duplicate'> {
+  const [res]: any = await pool.query(
     `INSERT INTO wallet_deposits (
       to_address, from_address, token_symbol, token_address, amount_wei,
       tx_hash, block_number, status, confirmations, source
@@ -31,11 +31,15 @@ export async function upsertDeposit(row: {
       row.source,
     ]
   );
+  if (res.affectedRows === 1) return 'new';
+  if (res.affectedRows === 2) return 'updated';
+  return 'duplicate';
 }
 
-export async function markConfirmed(txHash: string, blockNumber: number) {
-  await sql.query(
-    `UPDATE wallet_deposits SET status='confirmed', block_number=?, last_update_at=CURRENT_TIMESTAMP WHERE tx_hash=?`,
+export async function markConfirmed(txHash: string, blockNumber: number): Promise<boolean> {
+  const [res]: any = await sql.query(
+    `UPDATE wallet_deposits SET status='confirmed', block_number=?, last_update_at=CURRENT_TIMESTAMP WHERE tx_hash=? AND status<>'confirmed'`,
     [blockNumber, txHash.toLowerCase()]
   );
+  return res.affectedRows > 0;
 }

--- a/apps/worker/services/logger.ts
+++ b/apps/worker/services/logger.ts
@@ -1,0 +1,45 @@
+import fs from 'fs';
+
+const levelMap = { silent:0, error:1, warn:2, info:3, debug:4 } as const;
+export type LogLevel = keyof typeof levelMap;
+const envLevel = (process.env.WORKER_LOG_LEVEL || 'info').toLowerCase() as LogLevel;
+const currentLevel = levelMap[envLevel] ?? levelMap.info;
+const jsonMode = String(process.env.WORKER_LOG_JSON || 'false').toLowerCase() === 'true';
+
+function emit(level: LogLevel, tag: string, sub: string, message: string, meta: Record<string, any> = {}) {
+  if (levelMap[level] > currentLevel) return;
+  if (jsonMode) {
+    const entry = { ts: new Date().toISOString(), level, tag, subtag: sub, msg: message, ...meta };
+    console.log(JSON.stringify(entry));
+    return;
+  }
+  const line = sub ? `[${tag}][${sub}] ${message}` : `[${tag}] ${message}`;
+  if (level === 'error') console.error(line);
+  else if (level === 'warn') console.warn(line);
+  else console.log(line);
+}
+
+export const logger = {
+  error: (tag: string, sub: string, msg: string, meta?: Record<string, any>) => emit('error', tag, sub, msg, meta),
+  warn: (tag: string, sub: string, msg: string, meta?: Record<string, any>) => emit('warn', tag, sub, msg, meta),
+  info: (tag: string, sub: string, msg: string, meta?: Record<string, any>) => emit('info', tag, sub, msg, meta),
+  debug: (tag: string, sub: string, msg: string, meta?: Record<string, any>) => emit('debug', tag, sub, msg, meta),
+  level: envLevel,
+  isDebug: () => currentLevel >= levelMap.debug,
+};
+
+export function shortAddr(addr: string) {
+  return addr.slice(0, 6) + '...' + addr.slice(-4);
+}
+
+export function envPaths(paths: string[]): { loaded: string[]; missing: string[] } {
+  const loaded: string[] = [];
+  const missing: string[] = [];
+  for (const p of paths) {
+    if (fs.existsSync(p)) loaded.push(p); else missing.push(p);
+  }
+  return { loaded, missing };
+}
+
+export const SAMPLE_RATE = Number(process.env.WORKER_LOG_SAMPLE_RATE || 0.1);
+export const HEARTBEAT_MS = Number(process.env.WORKER_LOG_HEARTBEAT_MS || 30000);

--- a/apps/worker/services/rpc.ts
+++ b/apps/worker/services/rpc.ts
@@ -1,0 +1,26 @@
+import { logger } from './logger.ts';
+
+export async function rpcCall<T>(fnName: string, call: () => Promise<T>, ctx: Record<string, any> = {}) {
+  const max = 3;
+  let attempt = 0;
+  while (true) {
+    attempt++;
+    const start = Date.now();
+    try {
+      const result = await call();
+      const took = Date.now() - start;
+      return { result, took };
+    } catch (e: any) {
+      const took = Date.now() - start;
+      const errMsg = e?.message || String(e);
+      logger.error('RPC', 'ERROR', `fn=${fnName} attempt=${attempt}/${max} took=${took}ms err=${errMsg}`, ctx);
+      if (attempt >= max) {
+        logger.error('RPC', 'GIVEUP', `fn=${fnName}`, ctx);
+        throw e;
+      }
+      const backoff = 200 * attempt;
+      logger.warn('RPC', 'RETRY', `fn=${fnName} attempt=${attempt}/${max} backoff=${backoff}ms`, ctx);
+      await new Promise((r) => setTimeout(r, backoff));
+    }
+  }
+}

--- a/apps/worker/services/scanBounds.ts
+++ b/apps/worker/services/scanBounds.ts
@@ -3,19 +3,16 @@ import { sql } from './db.ts';
 const DEFAULT_RECENT_BLOCKS = Number(process.env.USER_SCAN_RECENT_BLOCKS || 1000);
 const SAFETY_BUFFER = Number(process.env.USER_SCAN_SAFETY || 12);
 
-export async function getFromBlockForAddress(addr: string, latestBlock: number): Promise<number> {
-  const row = await sql.oneOrNone<{ max_block: number }>(
-    `SELECT MAX(block_number) AS max_block FROM wallet_deposits WHERE LOWER(to_address) = LOWER(?)`,
-    [addr]
-  );
-
+export async function getScanBounds(addr: string, latestBlock: number): Promise<{ fromBlock: number; toBlock: number }> {
   const baseline = latestBlock - DEFAULT_RECENT_BLOCKS + 1;
-  const maxBlock = row?.max_block ? Number(row.max_block) : null;
-
-  if (!maxBlock) {
-    return Math.max(0, baseline);
+  const row = await sql.oneOrNone<{ max: number }>(
+    'SELECT MAX(block_number) AS max FROM wallet_deposits WHERE to_address=?',
+    [addr.toLowerCase()]
+  );
+  let from = baseline;
+  if (row && row.max != null) {
+    from = Math.max(Number(row.max) - SAFETY_BUFFER, baseline);
   }
-
-  const from = Math.max(baseline, maxBlock - SAFETY_BUFFER);
-  return Math.max(0, from);
+  if (from < 0) from = 0;
+  return { fromBlock: from, toBlock: latestBlock };
 }

--- a/apps/worker/services/tokens.ts
+++ b/apps/worker/services/tokens.ts
@@ -2,15 +2,17 @@ import { ethers } from 'ethers';
 
 export const TRANSFER_TOPIC = ethers.id('Transfer(address,address,uint256)');
 
-export interface TokenInfo {
+export type TokenInfo = {
   symbol: string;
   address: string | null;
-}
+};
 
 export function getTokensInScope(): TokenInfo[] {
   const list: TokenInfo[] = [{ symbol: 'BNB', address: null }];
-  if (process.env.TOKEN_USDT) list.push({ symbol: 'USDT', address: process.env.TOKEN_USDT.toLowerCase() });
-  if (process.env.TOKEN_USDC) list.push({ symbol: 'USDC', address: process.env.TOKEN_USDC.toLowerCase() });
+  const usdt = (process.env.TOKEN_USDT || '0x55d398326f99059ff775485246999027b3197955').toLowerCase();
+  const usdc = (process.env.TOKEN_USDC || '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d').toLowerCase();
+  list.push({ symbol: 'USDT', address: usdt });
+  list.push({ symbol: 'USDC', address: usdc });
   return list;
 }
 
@@ -20,4 +22,11 @@ export function checksum(addr: string): string {
 
 export function hexToDec(hex: string | bigint): string {
   return BigInt(hex).toString();
+}
+
+export function decodeTransfer(log: { data: string; topics: string[] }) {
+  const from = '0x' + log.topics[1].slice(26);
+  const to = '0x' + log.topics[2].slice(26);
+  const amount = hexToDec(log.data);
+  return { from, to, amount };
 }


### PR DESCRIPTION
## Summary
- Add configurable logging levels with optional JSON output, sampling, and heartbeat metrics
- Print startup banners, per-cycle snapshots, and detailed ERC20/BNB scan logs with RPC timing
- Record database upserts for new, updated, duplicate, and confirmed deposits

## Testing
- `npm test`
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit` *(hangs, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bd947c8858832b9ef1c5f8ad7cd6aa