### PR TITLE
chore: improve sweeper logging

### DIFF
--- a/apps/sweeper/depositRecorder.js
+++ b/apps/sweeper/depositRecorder.js
@@ -13,7 +13,7 @@ async function upsertDeposit(pool, row) {
     ]);
     prev = kRows[0];
   } catch (e) {
-    console.error('[POST][ERR][DB]', e?.message || e);
+    console.error('[POST][ERR][DB] select', e, { row });
     return { error: e };
   }
   const sql = `INSERT INTO wallet_deposits (
@@ -34,9 +34,11 @@ async function upsertDeposit(pool, row) {
     row.source,
   ];
   try {
+    console.log('[POST][DB] insert row=', row);
+    console.log('[POST][DB] insert params=', params);
     await pool.query(sql, params);
   } catch (e) {
-    console.error('[POST][ERR][DB]', e?.message || e);
+    console.error('[POST][ERR][DB] insert', e, { row, params });
     return { error: e };
   }
   if (prev) return { kind: 'updated', prev };
@@ -80,7 +82,7 @@ async function recordDepositAfterSweepSuccess(ctx, pool) {
       source: 'sweeper',
     });
     if (res.error) {
-      console.error(`[POST][ERR] mode=ok reason=${res.error?.message || res.error}`);
+      console.error('[POST][ERR] mode=ok', res.error);
     } else if (res.kind === 'new') {
       console.log(
         `[POST][NEW] user=${userId} token=${tokenSymbol} to=${addr} amount=${amount} src=sweeper`,
@@ -91,7 +93,7 @@ async function recordDepositAfterSweepSuccess(ctx, pool) {
       );
     }
   } catch (e) {
-    console.error(`[POST][ERR] mode=ok reason=${e?.message || e}`);
+    console.error('[POST][ERR] mode=ok', e);
   } finally {
     console.log(`[POST][DONE] mode=ok took=${Date.now() - start}ms`);
   }
@@ -132,7 +134,7 @@ async function recordDepositOnSweepFail(ctx, pool) {
       source: 'sweeper_fail',
     });
     if (res.error) {
-      console.error(`[POST][ERR] mode=fail reason=${res.error?.message || res.error}`);
+      console.error('[POST][ERR] mode=fail', res.error);
     } else if (res.kind === 'new') {
       console.log(
         `[POST][NEW] user=${userId} token=${tokenSymbol} to=${addr} amount=${amount} src=sweeper_fail`,
@@ -143,7 +145,7 @@ async function recordDepositOnSweepFail(ctx, pool) {
       );
     }
   } catch (e) {
-    console.error(`[POST][ERR] mode=fail reason=${e?.message || e}`);
+    console.error('[POST][ERR] mode=fail', e);
   } finally {
     console.log(`[POST][DONE] mode=fail took=${Date.now() - start}ms`);
   }

--- a/apps/sweeper/sweeper.js
+++ b/apps/sweeper/sweeper.js
@@ -145,7 +145,7 @@ async function processAddress(row, provider, pool, omnibus) {
   try {
     wallet = deriveWallet(index, provider);
   } catch (e) {
-    console.error(`[ERR][WALLET] addr=${addr} code=${e.code || e.message}`);
+    console.error(`[ERR][WALLET] addr=${addr}`, e);
     errorCount++;
     return;
   }
@@ -189,14 +189,14 @@ async function processAddress(row, provider, pool, omnibus) {
               pool,
             );
           } catch (e) {
-            console.error('[POST-OK][ERR]', e.code || e.message);
+            console.error('[POST-OK][ERR]', e);
           }
         } else {
           console.log(`[POST][SKIP] reason=receipt_status tx=${tx.hash} status=${receipt.status}`);
         }
         sweepCount++;
       } catch (e) {
-        console.error('[ERR][SWEEP]', e.code || e.message);
+        console.error('[ERR][SWEEP]', e);
         errorCount++;
         try {
           await recordDepositOnSweepFail(
@@ -211,7 +211,7 @@ async function processAddress(row, provider, pool, omnibus) {
             pool,
           );
         } catch (err) {
-          console.error('[POST-FAIL][ERR]', err.code || err.message);
+          console.error('[POST-FAIL][ERR]', err);
         }
       } finally {
         releaseLock(key);
@@ -243,7 +243,7 @@ async function processAddress(row, provider, pool, omnibus) {
           dripCount++;
           balBNB += GAS_DRIP_WEI;
         } catch (e) {
-          console.error('[ERR][DRIP]', e.code || e.message);
+          console.error('[ERR][DRIP]', e);
           errorCount++;
           releaseLock(key);
           continue;
@@ -271,14 +271,14 @@ async function processAddress(row, provider, pool, omnibus) {
             pool,
           );
         } catch (e) {
-          console.error('[POST-OK][ERR]', e.code || e.message);
+          console.error('[POST-OK][ERR]', e);
         }
       } else {
         console.log(`[POST][SKIP] reason=receipt_status tx=${tx.hash} status=${receipt.status}`);
       }
       sweepCount++;
     } catch (e) {
-      console.error('[ERR][SWEEP]', e.code || e.message);
+      console.error('[ERR][SWEEP]', e);
       errorCount++;
       try {
         await recordDepositOnSweepFail(
@@ -293,7 +293,7 @@ async function processAddress(row, provider, pool, omnibus) {
           pool,
         );
       } catch (err) {
-        console.error('[POST-FAIL][ERR]', err.code || err.message);
+        console.error('[POST-FAIL][ERR]', err);
       }
     } finally {
       releaseLock(key);


### PR DESCRIPTION
## Summary
- expand sweeper logging to show full error objects for wallet, sweep, and deposit handling
- log SQL parameters and row data when inserting deposits to aid debugging

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdc5d5e914832b8d09b83681def822