### PR TITLE
Record deposits on detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,4 @@ SCAN_INTERVAL_MS=15000
 BACKFILL_BLOCKS=5000
 # optional: force worker to start scanning from a specific block
 START_BLOCK=
+RECORD_DEPOSITS_ON_DETECT=true


### PR DESCRIPTION
## Summary
- log deposits as soon as balances appear using new `detectAndUpsertDeposit`
- allow optional pre-sweep recording via `RECORD_DEPOSITS_ON_DETECT`
- use streamlined `recordSweepFailure` for sweep errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be0bc801b0832b9c4ca4f24cf48bd5