### PR TITLE
feat(sweeper): credit deposits without tx

### DIFF
--- a/apps/sweeper/depositRecorder.js
+++ b/apps/sweeper/depositRecorder.js
@@ -1,5 +1,59 @@
 const crypto = require('crypto');
 
+async function resolveUserId(pool, { chainId, addressLc }) {
+  try {
+    const [rows] = await pool.query(
+      'SELECT user_id FROM wallet_addresses WHERE chain_id=? AND LOWER(address)=? LIMIT 1',
+      [chainId, addressLc],
+    );
+    return rows[0] ? rows[0].user_id : null;
+  } catch (e) {
+    console.error('[POST][ERR][resolveUserId]', e);
+    return null;
+  }
+}
+
+async function recordUserDepositNoTx(
+  pool,
+  { userId, chainId, depositAddressLc, tokenSymbol, tokenAddressLc, amountTokenDecimalStr },
+) {
+  const amt = amountTokenDecimalStr;
+  if (!userId) {
+    console.log(`[POST][SKIP] no user for address=${depositAddressLc}`);
+    return;
+  }
+  if (!amt || isNaN(Number(amt)) || Number(amt) <= 0) {
+    console.log(`[POST][SKIP] user=${userId} addr=${depositAddressLc} invalid_amount=${amt}`);
+    return;
+  }
+  const addrLc = (depositAddressLc || '').toLowerCase();
+  const tokenAddrLc = tokenAddressLc ? tokenAddressLc.toLowerCase() : null;
+  const statusVal = 'confirmed';
+  const confirmations = Number(process.env.CONFIRMATIONS || 12);
+  try {
+    const [rows] = await pool.query(
+      `SELECT id FROM wallet_deposits WHERE user_id=? AND chain_id=? AND LOWER(address)=? AND ((token_address IS NULL AND ? IS NULL) OR (LOWER(token_address)=?)) AND amount_wei=? AND source='sweeper' AND tx_hash='' AND created_at >= NOW() - INTERVAL 1 DAY LIMIT 1`,
+      [userId, chainId, addrLc, tokenAddrLc, tokenAddrLc, amt],
+    );
+    if (rows[0]) {
+      await pool.query(
+        'UPDATE wallet_deposits SET status=?, credited=1, confirmations=?, last_update_at=NOW() WHERE id=?',
+        [statusVal, confirmations, rows[0].id],
+      );
+    } else {
+      await pool.query(
+        'INSERT INTO wallet_deposits (user_id, chain_id, address, token_symbol, token_address, amount_wei, tx_hash, block_number, block_hash, confirmations, status, credited, source, created_at) VALUES (?,?,?,?,?,?,?, ?, ?, ?, ?, 1, \'sweeper\', NOW())',
+        [userId, chainId, addrLc, tokenSymbol, tokenAddrLc, amt, '', null, '', confirmations, statusVal],
+      );
+    }
+    console.log(
+      `[POST][CREDIT] user=${userId} addr=${addrLc} sym=${tokenSymbol} amount=${amt} status=${statusVal} tx=''`,
+    );
+  } catch (e) {
+    console.error('[POST][ERR][recordUserDepositNoTx]', e);
+  }
+}
+
 async function detectAndUpsertDeposit(ctx, pool) {
   const start = Date.now();
   const {
@@ -202,5 +256,7 @@ async function recordSweepFailure(ctx, pool) {
 module.exports = {
   detectAndUpsertDeposit,
   recordSweepFailure,
+  resolveUserId,
+  recordUserDepositNoTx,
 };
 

--- a/apps/sweeper/sweeper.js
+++ b/apps/sweeper/sweeper.js
@@ -3,8 +3,9 @@ const { ethers } = require('ethers');
 const path = require('path');
 require('dotenv').config({ path: path.join(__dirname, '../../.env') });
 const {
-  detectAndUpsertDeposit,
   recordSweepFailure,
+  resolveUserId,
+  recordUserDepositNoTx,
 } = require('./depositRecorder');
 
 // ---- env ----
@@ -23,8 +24,6 @@ const MIN_TOKEN_SWEEP_USD = Number(process.env.MIN_TOKEN_SWEEP_USD || '0');
 const GAS_DRIP_WEI = BigInt(process.env.GAS_DRIP_WEI || '40000000000000');
 const TX_MAX_RETRY = Number(process.env.TX_MAX_RETRY || 3);
 const SWEEP_RATE_LIMIT_PER_MIN = Number(process.env.SWEEP_RATE_LIMIT_PER_MIN || 12);
-const RECORD_DEPOSITS_ON_DETECT =
-  (process.env.RECORD_DEPOSITS_ON_DETECT || 'true').toLowerCase() !== 'false';
 
 // ---- utils ----
 function maskUrl(url) {
@@ -138,7 +137,6 @@ async function getCandidates(pool) {
 async function processAddress(row, provider, pool, omnibus) {
   const addr = row.address.toLowerCase();
   const index = Number(row.derivation_index);
-  const userId = row.user_id;
   if (!Number.isInteger(index)) {
     console.warn(`[WARN] addr=${addr} invalid_index=${row.derivation_index}`);
     return;
@@ -168,53 +166,31 @@ async function processAddress(row, provider, pool, omnibus) {
   if (eligibleBNB) {
     const key = addr + '-BNB';
     if (acquireLock(key) && sweepCount < SWEEP_RATE_LIMIT_PER_MIN) {
+      const amountDec = ethers.formatUnits(balBNB, 18);
       const sendAmount = balBNB - txCost;
+      const userId = await resolveUserId(pool, { chainId: CHAIN_ID, addressLc: addr });
+      if (!userId) {
+        console.log(`[POST][SKIP] no user for address=${addr}`);
+      }
       try {
         console.log(`[ELIGIBLE] addr=${addr} asset=BNB amount=${sendAmount}`);
-        if (RECORD_DEPOSITS_ON_DETECT) {
-          try {
-            await detectAndUpsertDeposit(
-              {
-                chainId: CHAIN_ID,
-                address: addr,
-                tokenAddress: null,
-                amountWei: sendAmount,
-                txHash: null,
-                blockNumber: null,
-                nowTs: Date.now(),
-              },
-              pool,
-            );
-          } catch (err) {
-            console.error('[DEPOSIT][ERR][detect]', err);
-          }
-        }
         const tx = await withRetry(() =>
           wallet.sendTransaction({ to: OMNIBUS_ADDRESS, value: sendAmount, gasPrice, gasLimit: 21000 }),
         );
         console.log(`[SWEEP] addr=${addr} asset=BNB tx=${tx.hash}`);
         const receipt = await tx.wait(1);
         console.log(`[CONFIRMED] tx=${tx.hash}`);
-        if (receipt.status === 1) {
-          try {
-            await detectAndUpsertDeposit(
-              {
-                chainId: CHAIN_ID,
-                address: addr,
-                tokenAddress: null,
-                amountWei: sendAmount,
-                txHash: tx.hash,
-                blockNumber: receipt.blockNumber,
-                status: 'swept',
-                credited: 1,
-                nowTs: Date.now(),
-              },
-              pool,
-            );
-          } catch (e) {
-            console.error('[DEPOSIT][ERR][update]', e);
-          }
-        } else {
+        if (userId) {
+          await recordUserDepositNoTx(pool, {
+            userId,
+            chainId: CHAIN_ID,
+            depositAddressLc: addr,
+            tokenSymbol: 'BNB',
+            tokenAddressLc: null,
+            amountTokenDecimalStr: amountDec,
+          });
+        }
+        if (receipt.status !== 1) {
           console.log(`[POST][SKIP] reason=receipt_status tx=${tx.hash} status=${receipt.status}`);
         }
         sweepCount++;
@@ -236,6 +212,16 @@ async function processAddress(row, provider, pool, omnibus) {
         } catch (err) {
           console.error('[POST-FAIL][ERR]', err);
         }
+        if (userId) {
+          await recordUserDepositNoTx(pool, {
+            userId,
+            chainId: CHAIN_ID,
+            depositAddressLc: addr,
+            tokenSymbol: 'BNB',
+            tokenAddressLc: null,
+            amountTokenDecimalStr: amountDec,
+          });
+        }
       } finally {
         releaseLock(key);
       }
@@ -247,6 +233,8 @@ async function processAddress(row, provider, pool, omnibus) {
     if (sweepCount >= SWEEP_RATE_LIMIT_PER_MIN) break;
     if (!acquireLock(key)) continue;
     let bal = 0n;
+    let userId;
+    let amountDec;
     try {
       const erc = new ethers.Contract(token.address, erc20Abi, provider);
       bal = await erc.balanceOf(addr);
@@ -256,25 +244,12 @@ async function processAddress(row, provider, pool, omnibus) {
         releaseLock(key);
         continue;
       }
-      console.log(`[ELIGIBLE] addr=${addr} asset=${token.symbol} amount=${bal}`);
-      if (RECORD_DEPOSITS_ON_DETECT) {
-        try {
-          await detectAndUpsertDeposit(
-            {
-              chainId: CHAIN_ID,
-              address: addr,
-              tokenAddress: token.address,
-              amountWei: bal,
-              txHash: null,
-              blockNumber: null,
-              nowTs: Date.now(),
-            },
-            pool,
-          );
-        } catch (err) {
-          console.error('[DEPOSIT][ERR][detect]', err);
-        }
+      userId = await resolveUserId(pool, { chainId: CHAIN_ID, addressLc: addr });
+      amountDec = ethers.formatUnits(bal, token.decimals || 18);
+      if (!userId) {
+        console.log(`[POST][SKIP] no user for address=${addr}`);
       }
+      console.log(`[ELIGIBLE] addr=${addr} asset=${token.symbol} amount=${bal}`);
       balBNB = await provider.getBalance(addr);
       if (balBNB < txCost) {
         try {
@@ -296,26 +271,17 @@ async function processAddress(row, provider, pool, omnibus) {
       console.log(`[SWEEP] addr=${addr} asset=${token.symbol} tx=${tx.hash}`);
       const receipt = await tx.wait(1);
       console.log(`[CONFIRMED] tx=${tx.hash}`);
-      if (receipt.status === 1) {
-        try {
-          await detectAndUpsertDeposit(
-            {
-              chainId: CHAIN_ID,
-              address: addr,
-              tokenAddress: token.address,
-              amountWei: bal,
-              txHash: tx.hash,
-              blockNumber: receipt.blockNumber,
-              status: 'swept',
-              credited: 1,
-              nowTs: Date.now(),
-            },
-            pool,
-          );
-        } catch (e) {
-          console.error('[DEPOSIT][ERR][update]', e);
-        }
-      } else {
+      if (userId) {
+        await recordUserDepositNoTx(pool, {
+          userId,
+          chainId: CHAIN_ID,
+          depositAddressLc: addr,
+          tokenSymbol: token.symbol,
+          tokenAddressLc: token.address.toLowerCase(),
+          amountTokenDecimalStr: amountDec,
+        });
+      }
+      if (receipt.status !== 1) {
         console.log(`[POST][SKIP] reason=receipt_status tx=${tx.hash} status=${receipt.status}`);
       }
       sweepCount++;
@@ -336,6 +302,16 @@ async function processAddress(row, provider, pool, omnibus) {
         );
       } catch (err) {
         console.error('[POST-FAIL][ERR]', err);
+      }
+      if (userId) {
+        await recordUserDepositNoTx(pool, {
+          userId,
+          chainId: CHAIN_ID,
+          depositAddressLc: addr,
+          tokenSymbol: token.symbol,
+          tokenAddressLc: token.address.toLowerCase(),
+          amountTokenDecimalStr: amountDec,
+        });
       }
     } finally {
       releaseLock(key);


### PR DESCRIPTION
## Summary
- add resolveUserId and recordUserDepositNoTx helpers for sweeper deposits
- sweeper credits BNB and ERC-20 deposits immediately without tx hash
- ensure deposits are stored with status confirmed and amounts recorded

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bee2da6e64832b99892d8261105ecd