### PR TITLE
Handle deposit entries without transaction hash

### DIFF
--- a/app/(app)/wallet/page.tsx
+++ b/app/(app)/wallet/page.tsx
@@ -130,7 +130,7 @@ export default function WalletPage() {
         <h2 className="font-semibold mb-2">{t.wallet.transactions}</h2>
         <div className="space-y-2">
           {deposits.map((d) => (
-            <div key={d.tx_hash} className="p-3 bg-white/5 rounded text-sm space-y-1">
+            <div key={d.tx_hash || d.created_at} className="p-3 bg-white/5 rounded text-sm space-y-1">
               <div className="flex justify-between text-xs opacity-70">
                 <span>{new Date(d.created_at).toLocaleString()}</span>
                 <span>{d.confirmations}</span>


### PR DESCRIPTION
## Summary
- ensure each wallet deposit uses transaction hash or timestamp as key so records without a hash render independently

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68beefd620f0832bbc7b532b382418f9