### PR TITLE
feat(sweeper): ensure balance covers gas before sweeping

### DIFF
--- a/apps/sweeper/sweeper.js
+++ b/apps/sweeper/sweeper.js
@@ -174,26 +174,34 @@ async function processAddress(row, provider, pool, omnibus) {
       }
       try {
         console.log(`[ELIGIBLE] addr=${addr} asset=BNB amount=${sendAmount}`);
-        const tx = await withRetry(() =>
-          wallet.sendTransaction({ to: OMNIBUS_ADDRESS, value: sendAmount, gasPrice, gasLimit: 21000 }),
-        );
-        console.log(`[SWEEP] addr=${addr} asset=BNB tx=${tx.hash}`);
-        const receipt = await tx.wait(1);
-        console.log(`[CONFIRMED] tx=${tx.hash}`);
-        if (userId) {
-          await recordUserDepositNoTx(pool, {
-            userId,
-            chainId: CHAIN_ID,
-            depositAddressLc: addr,
-            tokenSymbol: 'BNB',
-            tokenAddressLc: null,
-            amountTokenDecimalStr: amountDec,
-          });
+        const balCheck = await provider.getBalance(addr);
+        const needed = sendAmount + gasPrice * 21000n;
+        if (balCheck < needed) {
+          console.log(
+            `[SKIP] addr=${addr} reason=insufficient_balance have=${balCheck} needed=${needed}`,
+          );
+        } else {
+          const tx = await withRetry(() =>
+            wallet.sendTransaction({ to: OMNIBUS_ADDRESS, value: sendAmount, gasPrice, gasLimit: 21000 }),
+          );
+          console.log(`[SWEEP] addr=${addr} asset=BNB tx=${tx.hash}`);
+          const receipt = await tx.wait(1);
+          console.log(`[CONFIRMED] tx=${tx.hash}`);
+          if (userId) {
+            await recordUserDepositNoTx(pool, {
+              userId,
+              chainId: CHAIN_ID,
+              depositAddressLc: addr,
+              tokenSymbol: 'BNB',
+              tokenAddressLc: null,
+              amountTokenDecimalStr: amountDec,
+            });
+          }
+          if (receipt.status !== 1) {
+            console.log(`[POST][SKIP] reason=receipt_status tx=${tx.hash} status=${receipt.status}`);
+          }
+          sweepCount++;
         }
-        if (receipt.status !== 1) {
-          console.log(`[POST][SKIP] reason=receipt_status tx=${tx.hash} status=${receipt.status}`);
-        }
-        sweepCount++;
       } catch (e) {
         console.error('[ERR][SWEEP]', e);
         errorCount++;
@@ -251,9 +259,15 @@ async function processAddress(row, provider, pool, omnibus) {
       }
       console.log(`[ELIGIBLE] addr=${addr} asset=${token.symbol} amount=${bal}`);
       balBNB = await provider.getBalance(addr);
-      if (balBNB < txCost) {
+      const tokenWallet = wallet.connect(provider);
+      const contract = new ethers.Contract(token.address, erc20Abi, tokenWallet);
+      const gasLimit = await contract.estimateGas.transfer(OMNIBUS_ADDRESS, bal, { gasPrice });
+      let needed = gasPrice * gasLimit;
+      if (balBNB < needed) {
         try {
-          const dripTx = await withRetry(() => omnibus.sendTransaction({ to: addr, value: GAS_DRIP_WEI, gasPrice, gasLimit: 21000 }));
+          const dripTx = await withRetry(() =>
+            omnibus.sendTransaction({ to: addr, value: GAS_DRIP_WEI, gasPrice, gasLimit: 21000 }),
+          );
           console.log(`[DRIP] addr=${addr} tx=${dripTx.hash}`);
           await dripTx.wait(1);
           dripCount++;
@@ -261,13 +275,17 @@ async function processAddress(row, provider, pool, omnibus) {
         } catch (e) {
           console.error('[ERR][DRIP]', e);
           errorCount++;
-          releaseLock(key);
+          continue;
+        }
+        needed = gasPrice * gasLimit;
+        if (balBNB < needed) {
+          console.log(
+            `[SKIP] addr=${addr} asset=${token.symbol} reason=insufficient_gas have=${balBNB} needed=${needed}`,
+          );
           continue;
         }
       }
-      const tokenWallet = wallet.connect(provider);
-      const contract = new ethers.Contract(token.address, erc20Abi, tokenWallet);
-      const tx = await withRetry(() => contract.transfer(OMNIBUS_ADDRESS, bal, { gasPrice }));
+      const tx = await withRetry(() => contract.transfer(OMNIBUS_ADDRESS, bal, { gasPrice, gasLimit }));
       console.log(`[SWEEP] addr=${addr} asset=${token.symbol} tx=${tx.hash}`);
       const receipt = await tx.wait(1);
       console.log(`[CONFIRMED] tx=${tx.hash}`);


### PR DESCRIPTION
## Summary
- skip BNB sweep when balance cannot cover transfer plus gas cost
- estimate ERC20 sweep gas, dripping funds if needed and skipping when still short

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68beefda75e8832b8f2a38217ea16849