### PR TITLE
Avoid caching for wallet API requests

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -36,6 +36,11 @@ app.use((req, res, next) => {
 });
 app.use(express.json());
 app.use(cookieParser());
+// ensure wallet routes are not cached
+app.use(['/wallet', '/api/wallet'], (req, res, next) => {
+  res.set('Cache-Control', 'no-store');
+  next();
+});
 
 const pool = mysql.createPool(
   process.env.DATABASE_URL || {

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -13,6 +13,7 @@ export async function apiFetch<T = any>(path: string, options: RequestInit = {})
   try {
     const res = await fetch(url, {
       credentials: 'include',
+      cache: 'no-store',
       ...options,
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- add `cache: 'no-store'` to client API fetch helper
- set `Cache-Control: no-store` for wallet-related Express routes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68beefe26064832ba171e1e6b814145c