### PR TITLE
Disable caching for transaction data

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,12 @@
+# Disable caching for API routes
+<IfModule mod_headers.c>
+  SetEnvIfNoCase Request_URI ^/api/ no_cache
+  Header set Cache-Control "no-store, no-cache, must-revalidate, max-age=0" env=no_cache
+  Header set Pragma "no-cache" env=no_cache
+</IfModule>
+
+<IfModule mod_expires.c>
+  ExpiresActive On
+  ExpiresDefault "access plus 1 year"
+  ExpiresActive Off env=no_cache
+</IfModule>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## Unreleased
+- Added server-side headers to disable caching for wallet and transaction APIs.
+- Marked transaction-related pages as dynamic with polling and focus refresh for fresh data.
+- Introduced Service Worker that bypasses `/api/*` requests and auto-updates clients.
+- Documented Cloudflare cache bypass rule and Apache `.htaccess` for API paths.
+- Added runbook for verifying cache headers and targeted purges.

--- a/api/server.js
+++ b/api/server.js
@@ -37,10 +37,14 @@ app.use((req, res, next) => {
 app.use(express.json());
 app.use(cookieParser());
 // ensure wallet routes are not cached
-app.use(['/wallet', '/api/wallet'], (req, res, next) => {
-  res.set('Cache-Control', 'no-store');
+const noCache = (req, res, next) => {
+  res.set('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0');
+  res.set('Pragma', 'no-cache');
+  res.set('Vary', 'Authorization, Cookie');
   next();
-});
+};
+
+app.use(['/wallet', '/api/wallet', '/api/transactions'], noCache);
 
 const pool = mysql.createPool(
   process.env.DATABASE_URL || {

--- a/app/(app)/account/wallet/page.tsx
+++ b/app/(app)/account/wallet/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+export const dynamic = 'force-dynamic';
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { apiFetch } from '../../../lib/api';
@@ -26,7 +27,16 @@ export default function WalletPage() {
     if (txRes.ok) setDeposits(txRes.data.transactions);
   }, []);
 
-  useEffect(() => { load(); }, [load]);
+  useEffect(() => {
+    load();
+    const id = setInterval(load, 10000);
+    const onFocus = () => load();
+    window.addEventListener('focus', onFocus);
+    return () => {
+      clearInterval(id);
+      window.removeEventListener('focus', onFocus);
+    };
+  }, [load]);
 
   const handleRefresh = async () => {
     await apiFetch('/wallet/refresh', { method: 'POST' });

--- a/app/(app)/transactions/page.tsx
+++ b/app/(app)/transactions/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+export const dynamic = 'force-dynamic';
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
@@ -29,13 +30,23 @@ export default function TransactionsPage() {
   }, [user, router]);
 
   useEffect(() => {
-    apiFetch<{ transactions: Deposit[] }>('/wallet/transactions').then(res => {
-      if (!res.ok) {
-        if (res.status === 401) router.replace('/login');
-      } else {
-        setDeposits(res.data.transactions || []);
-      }
-    });
+    const load = () => {
+      apiFetch<{ transactions: Deposit[] }>('/wallet/transactions').then(res => {
+        if (!res.ok) {
+          if (res.status === 401) router.replace('/login');
+        } else {
+          setDeposits(res.data.transactions || []);
+        }
+      });
+    };
+    load();
+    const id = setInterval(load, 10000);
+    const onFocus = () => load();
+    window.addEventListener('focus', onFocus);
+    return () => {
+      clearInterval(id);
+      window.removeEventListener('focus', onFocus);
+    };
   }, [router]);
 
   const statusLabel = (s: string) => {

--- a/app/(app)/wallet/page.tsx
+++ b/app/(app)/wallet/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+export const dynamic = 'force-dynamic';
 
 import { useCallback, useEffect, useState } from 'react';
 import { apiFetch } from '../../lib/api';
@@ -50,7 +51,16 @@ export default function WalletPage() {
     if (txRes.ok) setDeposits(txRes.data.transactions);
   }, [t]);
 
-  useEffect(() => { load(); }, [load]);
+  useEffect(() => {
+    load();
+    const id = setInterval(load, 10000);
+    const onFocus = () => load();
+    window.addEventListener('focus', onFocus);
+    return () => {
+      clearInterval(id);
+      window.removeEventListener('focus', onFocus);
+    };
+  }, [load]);
 
   const handleRefresh = async () => {
     await apiFetch('/wallet/refresh', { method: 'POST' });

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { ToastProvider } from './lib/toast';
 import { AuthProvider } from './lib/auth';
 import NavBar from '../components/layout/NavBar';
 import Footer from '../components/layout/Footer';
+import ServiceWorkerManager from '../components/ServiceWorkerManager';
 
 export const metadata = {
   title: 'ELTX — Next',
@@ -17,6 +18,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <LangProvider>
           <AuthProvider>
             <ToastProvider>
+              <ServiceWorkerManager />
               <NavBar />
               <main className="flex-1">{children}</main>
               <Footer />

--- a/components/ServiceWorkerManager.tsx
+++ b/components/ServiceWorkerManager.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useToast } from '../app/lib/toast';
+
+export default function ServiceWorkerManager() {
+  const toast = useToast();
+
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/sw.js').then((reg) => {
+        const notify = () => {
+          toast('New version available, reloading...');
+          reg.waiting?.postMessage('skipWaiting');
+        };
+        if (reg.waiting) notify();
+        reg.addEventListener('updatefound', () => {
+          const nw = reg.installing;
+          if (nw) {
+            nw.addEventListener('statechange', () => {
+              if (nw.state === 'installed' && navigator.serviceWorker.controller) {
+                notify();
+              }
+            });
+          }
+        });
+      });
+      let refreshing = false;
+      navigator.serviceWorker.addEventListener('controllerchange', () => {
+        if (!refreshing) {
+          refreshing = true;
+          window.location.reload();
+        }
+      });
+    }
+  }, [toast]);
+
+  return null;
+}

--- a/docs/CACHE-RUNBOOK.md
+++ b/docs/CACHE-RUNBOOK.md
@@ -1,0 +1,17 @@
+# Cache Verification Runbook
+
+## Check API headers
+```bash
+curl -I https://api.eltx.online/wallet/transactions -H "Cookie: sid=..."
+```
+Expect:
+- `Cache-Control: no-store, no-cache, must-revalidate, max-age=0`
+- `Pragma: no-cache`
+- `Vary: Authorization, Cookie`
+
+## Verify Cloudflare
+- In Cloudflare dashboard, ensure Cache Rule for `/api/` shows **Bypass**.
+- In DevTools network tab, `CF-Cache-Status` should be `DYNAMIC` or `BYPASS` for API requests.
+
+## Purge targeted assets
+- Use Cloudflare Purge by URL for modified files (`/sw.js`, affected pages) after deployment.

--- a/docs/CLOUDFLARE.md
+++ b/docs/CLOUDFLARE.md
@@ -1,0 +1,12 @@
+# Cloudflare Cache Rules
+
+Create a Cache Rule to bypass caching for API routes:
+
+- **If**: `http.request.uri.path` contains `/api/`
+- **Then**:
+  - Cache level: Bypass
+  - Origin Cache Control: On
+
+Ensure no "Cache Everything" rule applies to `/api/*`.
+
+Static assets may still be cached normally (e.g. `/_next/static/*`, `/assets/*`).

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,22 @@
+const VERSION = '1.0.0';
+
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('message', (event) => {
+  if (event.data === 'skipWaiting') {
+    self.skipWaiting();
+  }
+});
+
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+  if (url.pathname.startsWith('/api/')) {
+    event.respondWith(fetch(event.request, { cache: 'no-store', credentials: 'include' }));
+  }
+});


### PR DESCRIPTION
## Summary
- send no-store headers for wallet and transaction APIs
- mark transaction pages as dynamic with polling and focus refresh
- add service worker that bypasses `/api/*` and document cache rules for Cloudflare and Apache

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bef73a7200832b8b5969252f9e6073