### PR TITLE
Normalize wallet deposit data and ensure idempotent upserts

### DIFF
--- a/api/migrations/2025-10-01_wallet_deposits_idempotent.sql
+++ b/api/migrations/2025-10-01_wallet_deposits_idempotent.sql
@@ -1,0 +1,12 @@
+-- Migration: wallet_deposits idempotent key and normalization
+
+UPDATE wallet_deposits SET token_address='0x0000000000000000000000000000000000000000' WHERE token_address IS NULL;
+UPDATE wallet_deposits SET tx_hash=CONCAT('legacy:', id) WHERE tx_hash IS NULL OR tx_hash='';
+
+ALTER TABLE wallet_deposits ADD COLUMN IF NOT EXISTS log_index INT UNSIGNED NOT NULL DEFAULT 0 AFTER tx_hash;
+ALTER TABLE wallet_deposits MODIFY token_address VARCHAR(64) NOT NULL DEFAULT '0x0000000000000000000000000000000000000000';
+ALTER TABLE wallet_deposits MODIFY tx_hash VARCHAR(80) NOT NULL;
+
+ALTER TABLE wallet_deposits DROP INDEX IF EXISTS uniq_wallet_deposits_tx_token_addr;
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_wallet_deposits_chain_token_addr_tx_log ON wallet_deposits (chain_id, token_address, address, tx_hash, log_index);
+CREATE INDEX IF NOT EXISTS idx_wallet_deposits_addr_block ON wallet_deposits (address, block_number);

--- a/db/migrations/202503150000_wallet_deposits_idempotent.sql
+++ b/db/migrations/202503150000_wallet_deposits_idempotent.sql
@@ -1,0 +1,25 @@
+-- ensure wallet_deposits has idempotent key and normalized data
+
+-- normalize existing data
+UPDATE wallet_deposits SET token_address='0x0000000000000000000000000000000000000000' WHERE token_address IS NULL;
+UPDATE wallet_deposits SET tx_hash=CONCAT('legacy:', id) WHERE tx_hash IS NULL OR tx_hash='';
+
+-- make columns non-null with defaults
+ALTER TABLE wallet_deposits
+  MODIFY token_address VARCHAR(64) NOT NULL DEFAULT '0x0000000000000000000000000000000000000000',
+  MODIFY tx_hash VARCHAR(80) NOT NULL;
+
+-- add log_index column if missing
+SET @col := (SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wallet_deposits' AND COLUMN_NAME = 'log_index');
+SET @sql := IF(@col = 0, 'ALTER TABLE wallet_deposits ADD COLUMN log_index INT UNSIGNED NOT NULL DEFAULT 0 AFTER tx_hash', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- replace unique index
+SET @idx := (SELECT COUNT(*) FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wallet_deposits' AND INDEX_NAME = 'uniq_wallet_deposits_chain_token_addr_tx_log');
+SET @sql := IF(@idx = 0, 'ALTER TABLE wallet_deposits DROP INDEX IF EXISTS uniq_wallet_deposits_tx_token_addr, ADD UNIQUE KEY uniq_wallet_deposits_chain_token_addr_tx_log (chain_id, token_address, address, tx_hash, log_index)', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- helper index for address lookups
+SET @idx := (SELECT COUNT(*) FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wallet_deposits' AND INDEX_NAME = 'idx_addr_block');
+SET @sql := IF(@idx = 0, 'ALTER TABLE wallet_deposits ADD INDEX idx_addr_block (address, block_number)', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/db/wallet.sql
+++ b/db/wallet.sql
@@ -75,17 +75,18 @@ CREATE TABLE IF NOT EXISTS wallet_deposits (
   chain_id INT UNSIGNED NOT NULL,
   address VARCHAR(64) NOT NULL,
   tx_hash VARCHAR(80) NOT NULL,
+  log_index INT UNSIGNED NOT NULL DEFAULT 0,
   block_number BIGINT UNSIGNED NOT NULL,
   block_hash VARCHAR(80) NOT NULL,
-  token_address VARCHAR(64) NULL,
+  token_address VARCHAR(64) NOT NULL DEFAULT '0x0000000000000000000000000000000000000000',
   amount_wei DECIMAL(65,0) NOT NULL,
   confirmations INT UNSIGNED NOT NULL DEFAULT 0,
   status ENUM('seen','confirmed','swept','orphaned') NOT NULL DEFAULT 'seen',
   credited TINYINT(1) NOT NULL DEFAULT 0,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  UNIQUE KEY uniq_tx (tx_hash),
+  UNIQUE KEY uniq_wallet_deposit (chain_id, token_address, address, tx_hash, log_index),
   INDEX idx_user_chain (user_id, chain_id),
-  INDEX idx_addr (address)
+  INDEX idx_addr_block (address, block_number)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 ALTER TABLE wallet_deposits


### PR DESCRIPTION
## Summary
- make wallet_deposits schema idempotent with log_index and zero-address normalization
- upsert deposits with normalized addresses, synthetic tx hashes, and helper migration
- allow sweeper and worker to reprocess events without duplicate errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf3394a410832b9675cdd9b251290d