### PR TITLE
Record sweeper deposits in balances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/node_modules
-/.next
+node_modules
+.next
 .env
 

--- a/api/src/services/wallet.js
+++ b/api/src/services/wallet.js
@@ -53,7 +53,7 @@ async function provisionUserAddress(db, userId, chainId = Number(process.env.CHA
   }
 }
 
-async function getUserBalance(db, userId, asset = 'native') {
+async function getUserBalance(db, userId, asset = 'BNB') {
   const [rows] = await db.query(
     'SELECT balance_wei FROM user_balances WHERE user_id=? AND asset=?',
     [userId, asset]

--- a/apps/sweeper/depositRecorder.js
+++ b/apps/sweeper/depositRecorder.js
@@ -54,7 +54,7 @@ async function recordUserDepositNoTx(
   const statusVal = status === 'swept' ? 'swept' : 'confirmed';
   const txHash = `manual:sweeper:${chainId}:${addrLc}:${tokenAddrLc}:${amtWei}`;
   try {
-    const tokenSym = (tokenSymbol || '').toUpperCase();
+    const tokenSym = (tokenSymbol || (tokenAddrLc === ZERO ? 'BNB' : '')).toUpperCase();
     const [res] = await pool.query(
       `INSERT INTO wallet_deposits (user_id, chain_id, address, token_symbol, token_address, amount_wei, tx_hash, log_index, block_number, block_hash, confirmations, status, credited, source, created_at)
        VALUES (?,?,?,?,?,?,?,?,?,?,?, ?, 1, 'sweeper', NOW())
@@ -62,7 +62,7 @@ async function recordUserDepositNoTx(
       [userId, chainId, addrLc, tokenSym, tokenAddrLc, amtWei, txHash, 0, null, '', confirmations, statusVal],
     );
     if (res.affectedRows === 1) {
-      const asset = tokenAddrLc === ZERO ? 'native' : tokenSym;
+      const asset = tokenSym || (tokenAddrLc === ZERO ? 'BNB' : '');
       await pool.query(
         `INSERT INTO user_balances (user_id, asset, balance_wei)
          VALUES (?,?,?)

--- a/db/wallet.sql
+++ b/db/wallet.sql
@@ -103,7 +103,7 @@ ALTER TABLE wallet_deposits
 -- user balances per asset
 CREATE TABLE IF NOT EXISTS user_balances (
   user_id BIGINT UNSIGNED NOT NULL,
-  asset VARCHAR(32) NOT NULL DEFAULT 'native',
+  asset VARCHAR(32) NOT NULL,
   balance_wei DECIMAL(65,0) NOT NULL DEFAULT 0,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (user_id, asset),


### PR DESCRIPTION
## Summary
- credit sweeper deposits whether or not sweeps succeed and update user balances
- expose per-asset balances from user_balances in wallet endpoints

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `node api/server.js` (fails: MASTER_MNEMONIC is not set)
- `node apps/sweeper/sweeper.js` (fails: RPC_HTTP is required)


------
https://chatgpt.com/codex/tasks/task_e_68c17e802314832b80dcdf8865936d3a