### PR TITLE
fix: set default block fields in sweeper deposit recorder

### DIFF
--- a/apps/sweeper/depositRecorder.js
+++ b/apps/sweeper/depositRecorder.js
@@ -59,7 +59,7 @@ async function recordUserDepositNoTx(
       `INSERT INTO wallet_deposits (user_id, chain_id, address, token_symbol, token_address, amount_wei, tx_hash, log_index, block_number, block_hash, confirmations, status, credited, source, created_at)
        VALUES (?,?,?,?,?,?,?,?,?,?,?, ?, 1, 'sweeper', NOW())
        ON DUPLICATE KEY UPDATE status=VALUES(status), credited=1, confirmations=VALUES(confirmations), last_update_at=NOW()`,
-      [userId, chainId, addrLc, tokenSym, tokenAddrLc, amtWei, txHash, 0, null, '', confirmations, statusVal],
+      [userId, chainId, addrLc, tokenSym, tokenAddrLc, amtWei, txHash, 0, 0, '0x', confirmations, statusVal],
     );
     if (res.affectedRows === 1) {
       const asset = tokenSym || (tokenAddrLc === ZERO ? 'BNB' : '');


### PR DESCRIPTION
## Summary
- ensure `recordUserDepositNoTx` inserts block number 0 and placeholder block hash

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c185d7c518832b8b0a6779930ca102