### PR TITLE
feat(sweeper): record and credit sweeps directly

### DIFF
--- a/apps/sweeper/db.js
+++ b/apps/sweeper/db.js
@@ -1,0 +1,14 @@
+const { createPool } = require("mysql2/promise");
+const path = require("path");
+require("dotenv").config({ path: path.join(__dirname, "../../.env") });
+
+let pool;
+
+async function getPool() {
+  if (pool) return pool;
+  if (!process.env.DATABASE_URL) throw new Error("DATABASE_URL missing");
+  pool = createPool(process.env.DATABASE_URL);
+  return pool;
+}
+
+module.exports = { getPool };

--- a/apps/sweeper/db.ts
+++ b/apps/sweeper/db.ts
@@ -1,0 +1,14 @@
+import { createPool, Pool } from "mysql2/promise";
+import { config as dotenv } from "dotenv";
+import path from "path";
+
+dotenv({ path: path.join(__dirname, "../../.env") });
+
+let pool: Pool | null = null;
+
+export async function getPool(): Promise<Pool> {
+  if (pool) return pool;
+  if (!process.env.DATABASE_URL) throw new Error("DATABASE_URL missing");
+  pool = createPool(process.env.DATABASE_URL);
+  return pool;
+}

--- a/apps/sweeper/lib/units.js
+++ b/apps/sweeper/lib/units.js
@@ -1,0 +1,11 @@
+const Decimal = require("decimal.js");
+
+function toWeiString(amount, decimals = 18) {
+  const s = String(amount).trim();
+  if (s.includes(".")) return new Decimal(s).mul(new Decimal(10).pow(decimals)).toFixed(0);
+  // لو رقم صغير جدًا (مش wei غالبًا) حوّله:
+  if (new Decimal(s).lessThan("1000000000000")) return new Decimal(s).mul(new Decimal(10).pow(decimals)).toFixed(0);
+  return s; // اعتبره wei بالفعل
+}
+
+module.exports = { toWeiString };

--- a/apps/sweeper/lib/units.ts
+++ b/apps/sweeper/lib/units.ts
@@ -1,0 +1,9 @@
+import Decimal from "decimal.js";
+
+export function toWeiString(amount: string | number, decimals = 18): string {
+  const s = String(amount).trim();
+  if (s.includes(".")) return new Decimal(s).mul(new Decimal(10).pow(decimals)).toFixed(0);
+  // لو رقم صغير جدًا (مش wei غالبًا) حوّله:
+  if (new Decimal(s).lessThan("1000000000000")) return new Decimal(s).mul(new Decimal(10).pow(decimals)).toFixed(0);
+  return s; // اعتبره wei بالفعل
+}

--- a/apps/sweeper/recordAndCredit.js
+++ b/apps/sweeper/recordAndCredit.js
@@ -1,0 +1,66 @@
+const { getPool } = require("./db");
+const { toWeiString } = require("./lib/units");
+
+const NATIVE_ZERO = "0x0000000000000000000000000000000000000000";
+
+async function recordAndCreditSweep(o) {
+  const pool = await getPool();
+  const conn = await pool.getConnection();
+  try {
+    await conn.beginTransaction();
+
+    const tokenAddr = (o.tokenAddress && o.tokenAddress !== "") ? o.tokenAddress : NATIVE_ZERO;
+    const amountWei = toWeiString(o.amount, 18);
+
+    await conn.query(
+      `INSERT INTO wallet_deposits
+       (user_id, chain_id, address, token_symbol, tx_hash, log_index, block_number, block_hash,
+        token_address, amount_wei, confirmations, status, created_at, credited, token_address_norm, source, last_update_at)
+       VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, 'swept', NOW(), 0, LOWER(?), 'sweeper', NOW())
+       ON DUPLICATE KEY UPDATE
+         confirmations = GREATEST(confirmations, VALUES(confirmations)),
+         status = VALUES(status),
+         block_number = COALESCE(VALUES(block_number), block_number),
+         block_hash = COALESCE(VALUES(block_hash), block_hash),
+         last_update_at = NOW()`,
+      [
+        o.userId, o.chainId, o.address, o.assetSymbol,
+        o.sweepTxHash,
+        o.blockNumber ?? null, o.blockHash ?? null,
+        tokenAddr, amountWei,
+        o.confirmations,
+        tokenAddr
+      ]
+    );
+
+    const [rows] = await conn.query(
+      `SELECT id, credited, status, confirmations, amount_wei, token_symbol
+       FROM wallet_deposits
+       WHERE tx_hash=? AND address=? AND token_address_norm=LOWER(?) FOR UPDATE`,
+      [o.sweepTxHash, o.address, tokenAddr]
+    );
+    if (!rows.length) throw new Error("deposit_row_missing");
+    const d = rows[0];
+
+    if (!d.credited && (d.status === 'swept' || d.status === 'confirmed') && Number(d.confirmations) >= o.confirmations) {
+      await conn.query(
+        `INSERT INTO user_balances (user_id, asset, balance_wei, created_at)
+         VALUES (?, ?, ?, NOW())
+         ON DUPLICATE KEY UPDATE balance_wei = balance_wei + VALUES(balance_wei)`,
+        [o.userId, o.assetSymbol, d.amount_wei]
+      );
+
+      await conn.query(`UPDATE wallet_deposits SET credited=1, last_update_at=NOW() WHERE id=?`, [d.id]);
+    }
+
+    await conn.commit();
+    return { ok: true };
+  } catch (e) {
+    try { await conn.rollback(); } catch {}
+    throw e;
+  } finally {
+    conn.release();
+  }
+}
+
+module.exports = { recordAndCreditSweep };

--- a/apps/sweeper/recordAndCredit.ts
+++ b/apps/sweeper/recordAndCredit.ts
@@ -1,0 +1,80 @@
+import { getPool } from "./db";
+import { toWeiString } from "./lib/units";
+
+const NATIVE_ZERO = "0x0000000000000000000000000000000000000000";
+
+type Opts = {
+  userId: number;
+  chainId: number;         // 56 على BSC
+  address: string;         // عنوان الإيداع الذي تم سويپته
+  assetSymbol: string;     // "BNB" أو "USDT"/"USDC"
+  tokenAddress?: string;   // NATIVE_ZERO للناتيف
+  amount: string;          // ممكن decimal أو wei string
+  sweepTxHash: string;
+  blockNumber?: number|null;
+  blockHash?: string|null;
+  confirmations: number;   // CONFIRMATIONS
+};
+
+export async function recordAndCreditSweep(o: Opts) {
+  const pool = await getPool();
+  const conn = await pool.getConnection();
+  try {
+    await conn.beginTransaction();
+
+    const tokenAddr = (o.tokenAddress && o.tokenAddress !== "") ? o.tokenAddress : NATIVE_ZERO;
+    const amountWei = toWeiString(o.amount, 18);
+
+    // 1) upsert الإيداع (Idempotent)
+    await conn.query(
+      `INSERT INTO wallet_deposits
+       (user_id, chain_id, address, token_symbol, tx_hash, log_index, block_number, block_hash,
+        token_address, amount_wei, confirmations, status, created_at, credited, token_address_norm, source, last_update_at)
+       VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, 'swept', NOW(), 0, LOWER(?), 'sweeper', NOW())
+       ON DUPLICATE KEY UPDATE
+         confirmations = GREATEST(confirmations, VALUES(confirmations)),
+         status = VALUES(status),
+         block_number = COALESCE(VALUES(block_number), block_number),
+         block_hash = COALESCE(VALUES(block_hash), block_hash),
+         last_update_at = NOW()`,
+      [
+        o.userId, o.chainId, o.address, o.assetSymbol,
+        o.sweepTxHash,
+        o.blockNumber ?? null, o.blockHash ?? null,
+        tokenAddr, amountWei,
+        o.confirmations,
+        tokenAddr
+      ]
+    );
+
+    // جبنا الصف للقفل والتأكد أنه لسه مش متائتمن
+    const [rows] = await conn.query<any[]>(
+      `SELECT id, credited, status, confirmations, amount_wei, token_symbol
+       FROM wallet_deposits
+       WHERE tx_hash=? AND address=? AND token_address_norm=LOWER(?) FOR UPDATE`,
+      [o.sweepTxHash, o.address, tokenAddr]
+    );
+    if (!rows.length) throw new Error("deposit_row_missing");
+    const d = rows[0];
+
+    if (!d.credited && (d.status === 'swept' || d.status === 'confirmed') && Number(d.confirmations) >= o.confirmations) {
+      // 2) ائتمان الرصيد
+      await conn.query(
+        `INSERT INTO user_balances (user_id, asset, balance_wei, created_at)
+         VALUES (?, ?, ?, NOW())
+         ON DUPLICATE KEY UPDATE balance_wei = balance_wei + VALUES(balance_wei)`,
+        [o.userId, o.assetSymbol, d.amount_wei]
+      );
+
+      await conn.query(`UPDATE wallet_deposits SET credited=1, last_update_at=NOW() WHERE id=?`, [d.id]);
+    }
+
+    await conn.commit();
+    return { ok: true };
+  } catch (e) {
+    try { await conn.rollback(); } catch {}
+    throw e;
+  } finally {
+    conn.release();
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "argon2": "^0.44.0",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
+        "decimal.js": "^10.4.3",
         "dotenv": "^16.4.5",
         "ethers": "^6.11.1",
         "express": "^4.19.2",
@@ -2254,6 +2255,12 @@
       "dependencies": {
         "ms": "2.0.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "framer-motion": "^11.18.2",
     "helmet": "^7.1.0",
     "lucide-react": "^0.379.0",
+    "decimal.js": "^10.4.3",
     "mysql2": "^3.9.7",
     "next": "14.2.5",
     "nodemailer": "^6.10.1",


### PR DESCRIPTION
## Summary
- normalize human inputs to wei with Decimal.js
- add MySQL pool and atomic `recordAndCreditSweep`
- sweeper credits balances immediately after a sweep

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c18c6c0640832b8e5c968816f8b160