### PR TITLE
Ensure swept deposits are idempotent and credited safely

### DIFF
--- a/apps/sweeper/recordAndCredit.js
+++ b/apps/sweeper/recordAndCredit.js
@@ -10,7 +10,13 @@ async function recordAndCreditSweep(o) {
     await conn.beginTransaction();
 
     const tokenAddr = (o.tokenAddress && o.tokenAddress !== "") ? o.tokenAddress : NATIVE_ZERO;
+    const asset = (o.assetSymbol || "").toUpperCase();
     const amountWei = toWeiString(o.amount, 18);
+    if (amountWei.includes(".")) {
+      console.log(`[REC][SKIP] amount_format_error amount=${o.amount}`);
+      await conn.rollback();
+      return { ok: false };
+    }
 
     await conn.query(
       `INSERT INTO wallet_deposits
@@ -24,7 +30,7 @@ async function recordAndCreditSweep(o) {
          block_hash = COALESCE(VALUES(block_hash), block_hash),
          last_update_at = NOW()`,
       [
-        o.userId, o.chainId, o.address, o.assetSymbol,
+        o.userId, o.chainId, o.address, asset,
         o.sweepTxHash,
         o.blockNumber ?? null, o.blockHash ?? null,
         tokenAddr, amountWei,
@@ -42,15 +48,40 @@ async function recordAndCreditSweep(o) {
     if (!rows.length) throw new Error("deposit_row_missing");
     const d = rows[0];
 
-    if (!d.credited && (d.status === 'swept' || d.status === 'confirmed') && Number(d.confirmations) >= o.confirmations) {
+    const amt = BigInt(d.amount_wei);
+    if (
+      !d.credited &&
+      (d.status === "swept" || d.status === "confirmed") &&
+      Number(d.confirmations) >= o.confirmations &&
+      amt > 0n &&
+      asset
+    ) {
+      const [balRows] = await conn.query(
+        `SELECT balance_wei FROM user_balances WHERE user_id=? AND asset=? FOR UPDATE`,
+        [o.userId, asset]
+      );
+      const before = balRows.length ? BigInt(balRows[0].balance_wei) : 0n;
       await conn.query(
         `INSERT INTO user_balances (user_id, asset, balance_wei, created_at)
          VALUES (?, ?, ?, NOW())
          ON DUPLICATE KEY UPDATE balance_wei = balance_wei + VALUES(balance_wei)`,
-        [o.userId, o.assetSymbol, d.amount_wei]
+        [o.userId, asset, d.amount_wei]
       );
+      const after = before + amt;
 
       await conn.query(`UPDATE wallet_deposits SET credited=1, last_update_at=NOW() WHERE id=?`, [d.id]);
+      console.log(
+        `[CREDIT] depositId=${d.id} userId=${o.userId} asset=${asset} amountWei=${d.amount_wei} status=${d.status} confirmations=${d.confirmations} beforeBalance=${before} afterBalance=${after}`
+      );
+    } else {
+      let reason = "";
+      if (d.credited || !(d.status === "swept" || d.status === "confirmed")) reason = "credit_skip:status";
+      else if (Number(d.confirmations) < o.confirmations) reason = "credit_skip:conf";
+      else if (amt <= 0n) reason = "credit_skip:amount_zero";
+      else if (!asset) reason = "credit_skip:asset_missing";
+      console.log(
+        `[CREDIT][SKIP] reason=${reason} depositId=${d.id} status=${d.status} confirmations=${d.confirmations} credited=${d.credited} amountWei=${d.amount_wei} asset=${asset}`
+      );
     }
 
     await conn.commit();

--- a/apps/sweeper/recordAndCredit.ts
+++ b/apps/sweeper/recordAndCredit.ts
@@ -23,7 +23,13 @@ export async function recordAndCreditSweep(o: Opts) {
     await conn.beginTransaction();
 
     const tokenAddr = (o.tokenAddress && o.tokenAddress !== "") ? o.tokenAddress : NATIVE_ZERO;
+    const asset = (o.assetSymbol || "").toUpperCase();
     const amountWei = toWeiString(o.amount, 18);
+    if (amountWei.includes(".")) {
+      console.log(`[REC][SKIP] amount_format_error amount=${o.amount}`);
+      await conn.rollback();
+      return { ok: false };
+    }
 
     // 1) upsert الإيداع (Idempotent)
     await conn.query(
@@ -38,7 +44,7 @@ export async function recordAndCreditSweep(o: Opts) {
          block_hash = COALESCE(VALUES(block_hash), block_hash),
          last_update_at = NOW()`,
       [
-        o.userId, o.chainId, o.address, o.assetSymbol,
+        o.userId, o.chainId, o.address, asset,
         o.sweepTxHash,
         o.blockNumber ?? null, o.blockHash ?? null,
         tokenAddr, amountWei,
@@ -47,7 +53,7 @@ export async function recordAndCreditSweep(o: Opts) {
       ]
     );
 
-    // جبنا الصف للقفل والتأكد أنه لسه مش متائتمن
+    // جبنا الصف للقفل والتأكد من شروط الاعتماد
     const [rows] = await conn.query<any[]>(
       `SELECT id, credited, status, confirmations, amount_wei, token_symbol
        FROM wallet_deposits
@@ -57,16 +63,40 @@ export async function recordAndCreditSweep(o: Opts) {
     if (!rows.length) throw new Error("deposit_row_missing");
     const d = rows[0];
 
-    if (!d.credited && (d.status === 'swept' || d.status === 'confirmed') && Number(d.confirmations) >= o.confirmations) {
-      // 2) ائتمان الرصيد
+    const amt = BigInt(d.amount_wei);
+    if (
+      !d.credited &&
+      (d.status === "swept" || d.status === "confirmed") &&
+      Number(d.confirmations) >= o.confirmations &&
+      amt > 0n &&
+      asset
+    ) {
+      const [balRows] = await conn.query<any[]>(
+        `SELECT balance_wei FROM user_balances WHERE user_id=? AND asset=? FOR UPDATE`,
+        [o.userId, asset]
+      );
+      const before = balRows.length ? BigInt(balRows[0].balance_wei) : 0n;
       await conn.query(
         `INSERT INTO user_balances (user_id, asset, balance_wei, created_at)
          VALUES (?, ?, ?, NOW())
          ON DUPLICATE KEY UPDATE balance_wei = balance_wei + VALUES(balance_wei)`,
-        [o.userId, o.assetSymbol, d.amount_wei]
+        [o.userId, asset, d.amount_wei]
       );
+      const after = before + amt;
 
       await conn.query(`UPDATE wallet_deposits SET credited=1, last_update_at=NOW() WHERE id=?`, [d.id]);
+      console.log(
+        `[CREDIT] depositId=${d.id} userId=${o.userId} asset=${asset} amountWei=${d.amount_wei} status=${d.status} confirmations=${d.confirmations} beforeBalance=${before} afterBalance=${after}`
+      );
+    } else {
+      let reason = "";
+      if (d.credited || !(d.status === "swept" || d.status === "confirmed")) reason = "credit_skip:status";
+      else if (Number(d.confirmations) < o.confirmations) reason = "credit_skip:conf";
+      else if (amt <= 0n) reason = "credit_skip:amount_zero";
+      else if (!asset) reason = "credit_skip:asset_missing";
+      console.log(
+        `[CREDIT][SKIP] reason=${reason} depositId=${d.id} status=${d.status} confirmations=${d.confirmations} credited=${d.credited} amountWei=${d.amount_wei} asset=${asset}`
+      );
     }
 
     await conn.commit();

--- a/apps/sweeper/sweeper.js
+++ b/apps/sweeper/sweeper.js
@@ -17,6 +17,7 @@ if (!OMNIBUS_ADDRESS || !OMNIBUS_PK) throw new Error('OMNIBUS_ADDRESS/PK require
 
 const TOKENS = process.env.TOKENS_JSON ? JSON.parse(process.env.TOKENS_JSON) : [];
 const MIN_SWEEP_WEI_BNB = BigInt(process.env.MIN_SWEEP_WEI_BNB || '300000000000000');
+const KEEP_BNB_DUST_WEI = BigInt(process.env.KEEP_BNB_DUST_WEI || '1000000000000000');
 const MIN_TOKEN_SWEEP_USD = Number(process.env.MIN_TOKEN_SWEEP_USD || '0');
 const GAS_DRIP_WEI = BigInt(process.env.GAS_DRIP_WEI || '40000000000000');
 const TX_MAX_RETRY = Number(process.env.TX_MAX_RETRY || 3);
@@ -158,43 +159,43 @@ async function processAddress(row, provider, pool, omnibus) {
   let balBNB = await provider.getBalance(addr);
   const gasPrice = await resolveGasPriceWei(provider);
   const txCost = gasPrice * 21000n;
-  let eligibleBNB = balBNB > MIN_SWEEP_WEI_BNB && balBNB >= txCost * 10n;
+  const sendAmount = balBNB - txCost - KEEP_BNB_DUST_WEI;
+  let eligibleBNB = sendAmount > 0n && balBNB > MIN_SWEEP_WEI_BNB;
   let reasonBNB = 'ok';
   if (!eligibleBNB) {
     reasonBNB = balBNB <= MIN_SWEEP_WEI_BNB ? 'below_min' : 'needs_gas';
   }
   console.log(`[CHK] addr=${addr} bnb=${balBNB} eligible=${eligibleBNB} reason=${reasonBNB}`);
 
-    if (eligibleBNB) {
+  if (eligibleBNB) {
     const key = addr + '-BNB';
     if (acquireLock(key) && sweepCount < SWEEP_RATE_LIMIT_PER_MIN) {
-      const sendAmount = balBNB - txCost;
       try {
         console.log(`[PRE-SWEEP] addr=${addr} asset=BNB amount=${sendAmount}`);
         const tx = await withRetry(() =>
           wallet.sendTransaction({ to: OMNIBUS_ADDRESS, value: sendAmount, gasPrice, gasLimit: 21000 }),
         );
         console.log(`[SWEEP] addr=${addr} asset=BNB tx=${tx.hash}`);
-          const receipt = await tx.wait(CONFIRMATIONS);
-          console.log(`[CONFIRMED] tx=${tx.hash}`);
-          if (userId) {
-            await recordAndCreditSweep({
-              userId,
-              chainId: CHAIN_ID,
-              address: addr,
-              assetSymbol: 'BNB',
-              amount: sendAmount.toString(),
-              sweepTxHash: receipt.transactionHash,
-              blockNumber: receipt.blockNumber,
-              blockHash: receipt.blockHash,
-              confirmations: CONFIRMATIONS,
-            });
-          }
-          if (receipt.status !== 1) {
-            console.log(`[POST][SKIP] reason=receipt_status tx=${tx.hash} status=${receipt.status}`);
-          }
+        const receipt = await tx.wait(CONFIRMATIONS);
+        console.log(`[CONFIRMED] tx=${tx.hash}`);
+        if (userId) {
+          await recordAndCreditSweep({
+            userId,
+            chainId: CHAIN_ID,
+            address: addr,
+            assetSymbol: 'BNB',
+            amount: sendAmount.toString(),
+            sweepTxHash: receipt.transactionHash,
+            blockNumber: receipt.blockNumber,
+            blockHash: receipt.blockHash,
+            confirmations: CONFIRMATIONS,
+          });
+        }
+        if (receipt.status !== 1) {
+          console.log(`[POST][SKIP] reason=receipt_status tx=${tx.hash} status=${receipt.status}`);
+        }
       } catch (e) {
-        console.error(`[SWEEP ERROR] addr=${addr} asset=BNB`, e);
+        console.error(`[SWEEP][ERR] sweep_send_failed addr=${addr} asset=BNB`, e);
         errorCount++;
       } finally {
         console.log(`[POST-SWEEP] addr=${addr} asset=BNB`);
@@ -272,7 +273,7 @@ async function processAddress(row, provider, pool, omnibus) {
       }
       sweepCount++;
     } catch (e) {
-      console.error(`[SWEEP ERROR] addr=${addr} asset=${token.symbol}`, e);
+      console.error(`[SWEEP][ERR] sweep_send_failed addr=${addr} asset=${token.symbol}`, e);
       errorCount++;
     } finally {
       console.log(`[POST-SWEEP] addr=${addr} asset=${token.symbol}`);


### PR DESCRIPTION
## Summary
- Normalize asset data when recording sweeps and guard against malformed amounts
- Credit deposits atomically with detailed logging and idempotent balance updates
- Leave dust when sweeping BNB and log sweep_send_failed on transaction errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1925937e0832b8104cc9d8148a21f