### PR TITLE
Add extra gas buffer for BNB sweeper

### DIFF
--- a/apps/sweeper/sweeper.js
+++ b/apps/sweeper/sweeper.js
@@ -159,13 +159,17 @@ async function processAddress(row, provider, pool, omnibus) {
   let balBNB = await provider.getBalance(addr);
   const gasPrice = await resolveGasPriceWei(provider);
   const txCost = gasPrice * 21000n;
-  const sendAmount = balBNB - txCost - KEEP_BNB_DUST_WEI;
+  const originalSendAmount = balBNB - txCost - KEEP_BNB_DUST_WEI;
+  const gasBuffer = txCost * 2n; // extra buffer for fluctuating gas prices
+  const sendAmount = originalSendAmount - gasBuffer;
   let eligibleBNB = sendAmount > 0n && balBNB > MIN_SWEEP_WEI_BNB;
   let reasonBNB = 'ok';
   if (!eligibleBNB) {
     reasonBNB = balBNB <= MIN_SWEEP_WEI_BNB ? 'below_min' : 'needs_gas';
   }
-  console.log(`[CHK] addr=${addr} bnb=${balBNB} eligible=${eligibleBNB} reason=${reasonBNB}`);
+  console.log(
+    `[CHK] addr=${addr} bnb=${balBNB} orig_send=${originalSendAmount} adj_send=${sendAmount} buffer=${gasBuffer} eligible=${eligibleBNB} reason=${reasonBNB}`,
+  );
 
   if (eligibleBNB) {
     const key = addr + '-BNB';


### PR DESCRIPTION
## Summary
- keep extra 2x gas cost when sweeping BNB to avoid gas price spikes
- log original vs adjusted send amounts for monitoring

## Testing
- `npm test`
- `npm run lint`
- `CHAIN_ID=56 RPC_HTTP=https://bsc-dataseed.binance.org OMNIBUS_ADDRESS=0x0000000000000000000000000000000000000000 OMNIBUS_PK=0x59c6995e998f97a5a0044966f094538de6b800f2d30005559ef55af5c0ddd1b8 DATABASE_URL=mysql://root@localhost/test MASTER_MNEMONIC="test test test test test test test test test test test junk" node apps/sweeper/sweeper.js` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68c19dcc6394832b825dc71145fbdef6