### PR TITLE
feat: add idempotent deposit handling

### DIFF
--- a/apps/sweeper/recordAndCredit.js
+++ b/apps/sweeper/recordAndCredit.js
@@ -1,5 +1,5 @@
 const { getPool } = require('./db');
-const { randomUUID } = require('crypto');
+const { createHash } = require('crypto');
 
 const NATIVE_ZERO = '0x0000000000000000000000000000000000000000';
 
@@ -7,25 +7,32 @@ async function preRecordSweep(o) {
   const pool = await getPool();
   const tokenAddr = (o.tokenAddress && o.tokenAddress !== '') ? o.tokenAddress.toLowerCase() : NATIVE_ZERO;
   const asset = (o.assetSymbol || (tokenAddr === NATIVE_ZERO ? 'BNB' : '')).toUpperCase();
-  const txHash = `pre:${randomUUID()}`;
+  const key = createHash('sha256').update(`${o.address.toLowerCase()}|${tokenAddr}|${o.amountWei}`).digest('hex');
+  const txHash = `pre:${key}`;
   console.log(
-    JSON.stringify({ tag: 'SWP:DEPOSIT:PRE_RECORD:BEGIN', user_id: o.userId, asset, amount_wei: o.amountWei })
+    JSON.stringify({ tag: 'SWP:DEPOSIT:PRE_RECORD:BEGIN', user_id: o.userId, asset, amount_wei: o.amountWei, key })
   );
   try {
-    const sql = `INSERT INTO wallet_deposits
-         (user_id, chain_id, address, token_symbol, tx_hash, log_index, block_number, block_hash,
-          token_address, amount_wei, confirmations, status, credited, source, token_address_norm, created_at, last_update_at)
-         VALUES (?, ?, ?, ?, ?, 0, 0, '', ?, ?, 0, 'pre_sweep', 0, 'sweeper', LOWER(?), NOW(), NOW())
-         ON DUPLICATE KEY UPDATE status='pre_sweep', confirmations=0, last_update_at=VALUES(last_update_at), tx_hash=VALUES(tx_hash)`;
-    const [res] = await pool.query(sql, [o.userId, o.chainId, o.address, asset, txHash, tokenAddr, o.amountWei, tokenAddr]);
-    const dup = res.affectedRows === 2;
-    let id = res.insertId;
-    if (!id) {
-      const [rows] = await pool.query(
-        `SELECT id FROM wallet_deposits WHERE chain_id=? AND address=? AND token_address_norm=LOWER(?) AND tx_hash=? AND log_index=0`,
-        [o.chainId, o.address, tokenAddr, txHash]
+    let id;
+    let reused = false;
+    const [rows] = await pool.query(
+      `SELECT id FROM wallet_deposits WHERE chain_id=? AND address=? AND token_address_norm=LOWER(?) AND amount_wei=? AND status IN ('pre_sweep','send_error','wait_error') LIMIT 1`,
+      [o.chainId, o.address, tokenAddr, o.amountWei]
+    );
+    if (rows.length) {
+      id = rows[0].id;
+      reused = true;
+      await pool.query(
+        `UPDATE wallet_deposits SET token_symbol=?, tx_hash=?, status='pre_sweep', confirmations=0, last_update_at=NOW() WHERE id=?`,
+        [asset, txHash, id]
       );
-      if (rows.length) id = rows[0].id;
+    } else {
+      const sql = `INSERT INTO wallet_deposits
+           (user_id, chain_id, address, token_symbol, tx_hash, log_index, block_number, block_hash,
+            token_address, amount_wei, confirmations, status, credited, source, token_address_norm, created_at, last_update_at)
+           VALUES (?, ?, ?, ?, ?, 0, 0, '', ?, ?, 0, 'pre_sweep', 0, 'sweeper', LOWER(?), NOW(), NOW())`;
+      const [res] = await pool.query(sql, [o.userId, o.chainId, o.address, asset, txHash, tokenAddr, o.amountWei, tokenAddr]);
+      id = res.insertId;
     }
     console.log(
       JSON.stringify({
@@ -34,10 +41,11 @@ async function preRecordSweep(o) {
         asset,
         tx_hash: txHash,
         amount_wei: o.amountWei,
-        dup,
+        reused,
+        key,
       })
     );
-    return { id, txHash, asset, tokenAddr };
+    return { id, txHash, asset, tokenAddr, key };
   } catch (e) {
     console.log(JSON.stringify({ tag: 'SWP:DEPOSIT:PRE_RECORD:ERR', err: e.message }));
     throw e;
@@ -47,6 +55,10 @@ async function preRecordSweep(o) {
 async function finalizeSweep(o) {
   const pool = await getPool();
   const conn = await pool.getConnection();
+  const dayBucket = Math.floor(Date.now() / 86400000);
+  const intentId = createHash('sha256')
+    .update(`${o.address.toLowerCase()}|${o.tokenAddr}|${o.amountWei}|${dayBucket}`)
+    .digest('hex');
   console.log(
     JSON.stringify({ tag: 'SWP:DEPOSIT:UPSERT:BEGIN', id: o.id, status: o.status, tx_hash: o.finalTxHash })
   );
@@ -86,9 +98,18 @@ async function finalizeSweep(o) {
     }
     console.log(JSON.stringify({ tag: 'SWP:DEPOSIT:UPSERT:OK', id: o.id, status: o.status }));
     console.log(JSON.stringify({ tag: 'SWP:CREDIT:BEGIN', forced: o.forced || false }));
-    const [rows2] = await conn.query(`SELECT credited FROM wallet_deposits WHERE id=? FOR UPDATE`, [o.id]);
+    const [rows2] = await conn.query(`SELECT credited, amount_wei FROM wallet_deposits WHERE id=? FOR UPDATE`, [o.id]);
     if (!rows2.length) throw new Error('deposit_missing');
-    if (!rows2[0].credited && BigInt(o.amountWei) > 0n) {
+    const start = new Date(dayBucket * 86400000);
+    const end = new Date(start.getTime() + 86400000);
+    const [dupRows] = await conn.query(
+      `SELECT id FROM wallet_deposits WHERE chain_id=? AND address=? AND token_address_norm=? AND amount_wei=? AND credited=1 AND created_at BETWEEN ? AND ? LIMIT 1`,
+      [o.chainId, o.address, o.tokenAddr, rows2[0].amount_wei, start, end]
+    );
+    if (dupRows.length && dupRows[0].id !== o.id) {
+      await conn.query(`UPDATE wallet_deposits SET credited=1, last_update_at=NOW() WHERE id=?`, [o.id]);
+      console.log(JSON.stringify({ tag: 'SWP:IDEMPOTENT:SKIP', intent_id: intentId }));
+    } else if (!rows2[0].credited && BigInt(o.amountWei) > 0n) {
       const [balRows] = await conn.query(`SELECT balance_wei FROM user_balances WHERE user_id=? AND asset=? FOR UPDATE`, [o.userId, o.asset]);
       const before = balRows.length ? BigInt(balRows[0].balance_wei) : 0n;
       await conn.query(
@@ -99,7 +120,16 @@ async function finalizeSweep(o) {
       );
       const after = before + BigInt(o.amountWei);
       await conn.query(`UPDATE wallet_deposits SET credited=1, last_update_at=NOW() WHERE id=?`, [o.id]);
-      console.log(JSON.stringify({ tag: 'SWP:CREDIT:OK', before: before.toString(), after: after.toString(), forced: o.forced || false, reason: o.error }));
+      console.log(
+        JSON.stringify({
+          tag: 'SWP:CREDIT:OK',
+          before: before.toString(),
+          addInteger: o.amountWei,
+          after: after.toString(),
+          forced: o.forced || false,
+          reason: o.error,
+        })
+      );
     } else {
       console.log(JSON.stringify({ tag: 'SWP:CREDIT:SKIP', credited: rows2[0].credited }));
     }

--- a/apps/sweeper/recordAndCredit.ts
+++ b/apps/sweeper/recordAndCredit.ts
@@ -1,5 +1,5 @@
 import { getPool } from './db';
-import { randomUUID } from 'crypto';
+import { createHash } from 'crypto';
 
 const NATIVE_ZERO = '0x0000000000000000000000000000000000000000';
 
@@ -14,25 +14,32 @@ export async function preRecordSweep(o: {
   const pool = await getPool();
   const tokenAddr = o.tokenAddress && o.tokenAddress !== '' ? o.tokenAddress.toLowerCase() : NATIVE_ZERO;
   const asset = (o.assetSymbol || (tokenAddr === NATIVE_ZERO ? 'BNB' : '')).toUpperCase();
-  const txHash = `pre:${randomUUID()}`;
+  const key = createHash('sha256').update(`${o.address.toLowerCase()}|${tokenAddr}|${o.amountWei}`).digest('hex');
+  const txHash = `pre:${key}`;
   console.log(
-    JSON.stringify({ tag: 'SWP:DEPOSIT:PRE_RECORD:BEGIN', user_id: o.userId, asset, amount_wei: o.amountWei })
+    JSON.stringify({ tag: 'SWP:DEPOSIT:PRE_RECORD:BEGIN', user_id: o.userId, asset, amount_wei: o.amountWei, key })
   );
   try {
-    const sql = `INSERT INTO wallet_deposits
-         (user_id, chain_id, address, token_symbol, tx_hash, log_index, block_number, block_hash,
-          token_address, amount_wei, confirmations, status, credited, source, token_address_norm, created_at, last_update_at)
-         VALUES (?, ?, ?, ?, ?, 0, 0, '', ?, ?, 0, 'pre_sweep', 0, 'sweeper', LOWER(?), NOW(), NOW())
-         ON DUPLICATE KEY UPDATE status='pre_sweep', confirmations=0, last_update_at=VALUES(last_update_at), tx_hash=VALUES(tx_hash)`;
-    const [res] = await pool.query<any>(sql, [o.userId, o.chainId, o.address, asset, txHash, tokenAddr, o.amountWei, tokenAddr]);
-    const dup = res.affectedRows === 2;
-    let id = res.insertId as number;
-    if (!id) {
-      const [rows] = await pool.query<any[]>(
-        `SELECT id FROM wallet_deposits WHERE chain_id=? AND address=? AND token_address_norm=LOWER(?) AND tx_hash=? AND log_index=0`,
-        [o.chainId, o.address, tokenAddr, txHash]
+    let id: number | undefined;
+    let reused = false;
+    const [rows] = await pool.query<any[]>(
+      `SELECT id FROM wallet_deposits WHERE chain_id=? AND address=? AND token_address_norm=LOWER(?) AND amount_wei=? AND status IN ('pre_sweep','send_error','wait_error') LIMIT 1`,
+      [o.chainId, o.address, tokenAddr, o.amountWei]
+    );
+    if (rows.length) {
+      id = rows[0].id;
+      reused = true;
+      await pool.query(
+        `UPDATE wallet_deposits SET token_symbol=?, tx_hash=?, status='pre_sweep', confirmations=0, last_update_at=NOW() WHERE id=?`,
+        [asset, txHash, id]
       );
-      if (rows.length) id = rows[0].id;
+    } else {
+      const sql = `INSERT INTO wallet_deposits
+           (user_id, chain_id, address, token_symbol, tx_hash, log_index, block_number, block_hash,
+            token_address, amount_wei, confirmations, status, credited, source, token_address_norm, created_at, last_update_at)
+           VALUES (?, ?, ?, ?, ?, 0, 0, '', ?, ?, 0, 'pre_sweep', 0, 'sweeper', LOWER(?), NOW(), NOW())`;
+      const [res] = await pool.query<any>(sql, [o.userId, o.chainId, o.address, asset, txHash, tokenAddr, o.amountWei, tokenAddr]);
+      id = res.insertId as number;
     }
     console.log(
       JSON.stringify({
@@ -41,10 +48,11 @@ export async function preRecordSweep(o: {
         asset,
         tx_hash: txHash,
         amount_wei: o.amountWei,
-        dup,
+        reused,
+        key,
       })
     );
-    return { id, txHash, asset, tokenAddr };
+    return { id: id!, txHash, asset, tokenAddr, key };
   } catch (e: any) {
     console.log(JSON.stringify({ tag: 'SWP:DEPOSIT:PRE_RECORD:ERR', err: e.message }));
     throw e;
@@ -67,6 +75,10 @@ export async function finalizeSweep(o: {
 }) {
   const pool = await getPool();
   const conn = await pool.getConnection();
+  const dayBucket = Math.floor(Date.now() / 86400000);
+  const intentId = createHash('sha256')
+    .update(`${o.address.toLowerCase()}|${o.tokenAddr}|${o.amountWei}|${dayBucket}`)
+    .digest('hex');
   console.log(
     JSON.stringify({ tag: 'SWP:DEPOSIT:UPSERT:BEGIN', id: o.id, status: o.status, tx_hash: o.finalTxHash })
   );
@@ -106,9 +118,18 @@ export async function finalizeSweep(o: {
     }
     console.log(JSON.stringify({ tag: 'SWP:DEPOSIT:UPSERT:OK', id: o.id, status: o.status }));
     console.log(JSON.stringify({ tag: 'SWP:CREDIT:BEGIN', forced: o.forced || false }));
-    const [rows2] = await conn.query<any[]>(`SELECT credited FROM wallet_deposits WHERE id=? FOR UPDATE`, [o.id]);
+    const [rows2] = await conn.query<any[]>(`SELECT credited, amount_wei FROM wallet_deposits WHERE id=? FOR UPDATE`, [o.id]);
     if (!rows2.length) throw new Error('deposit_missing');
-    if (!rows2[0].credited && BigInt(o.amountWei) > 0n) {
+    const start = new Date(dayBucket * 86400000);
+    const end = new Date(start.getTime() + 86400000);
+    const [dupRows] = await conn.query<any[]>(
+      `SELECT id FROM wallet_deposits WHERE chain_id=? AND address=? AND token_address_norm=? AND amount_wei=? AND credited=1 AND created_at BETWEEN ? AND ? LIMIT 1`,
+      [o.chainId, o.address, o.tokenAddr, rows2[0].amount_wei, start, end]
+    );
+    if (dupRows.length && dupRows[0].id !== o.id) {
+      await conn.query(`UPDATE wallet_deposits SET credited=1, last_update_at=NOW() WHERE id=?`, [o.id]);
+      console.log(JSON.stringify({ tag: 'SWP:IDEMPOTENT:SKIP', intent_id: intentId }));
+    } else if (!rows2[0].credited && BigInt(o.amountWei) > 0n) {
       const [balRows] = await conn.query<any[]>(`SELECT balance_wei FROM user_balances WHERE user_id=? AND asset=? FOR UPDATE`, [o.userId, o.asset]);
       const before = balRows.length ? BigInt(balRows[0].balance_wei) : 0n;
       await conn.query(
@@ -119,12 +140,23 @@ export async function finalizeSweep(o: {
       );
       const after = before + BigInt(o.amountWei);
       await conn.query(`UPDATE wallet_deposits SET credited=1, last_update_at=NOW() WHERE id=?`, [o.id]);
-      console.log(JSON.stringify({ tag: 'SWP:CREDIT:OK', before: before.toString(), after: after.toString(), forced: o.forced || false, reason: o.error }));
+      console.log(
+        JSON.stringify({
+          tag: 'SWP:CREDIT:OK',
+          before: before.toString(),
+          addInteger: o.amountWei,
+          after: after.toString(),
+          forced: o.forced || false,
+          reason: o.error,
+        })
+      );
     } else {
       console.log(JSON.stringify({ tag: 'SWP:CREDIT:SKIP', credited: rows2[0].credited }));
     }
     await conn.commit();
-    console.log(JSON.stringify({ tag: 'SWP:DONE', user_id: o.userId, asset: o.asset, tx_hash: o.finalTxHash, status: o.status, credited: 1 }));
+    console.log(
+      JSON.stringify({ tag: 'SWP:DONE', user_id: o.userId, asset: o.asset, tx_hash: o.finalTxHash, status: o.status, credited: 1 })
+    );
   } catch (e: any) {
     try { await conn.rollback(); } catch {}
     console.log(JSON.stringify({ tag: 'SWP:CREDIT:ERR', err: e.message }));

--- a/apps/sweeper/sweeper.js
+++ b/apps/sweeper/sweeper.js
@@ -231,7 +231,7 @@ async function processAddress(row, provider, pool, omnibus) {
               asset: 'BNB',
               tokenAddr: pre.tokenAddr,
               amountWei: amountWei.toString(),
-              finalTxHash: `err:${Date.now()}`,
+              finalTxHash: `err:${pre.key}`,
               status: 'wait_error',
               confirmations: 0,
               forced: true,
@@ -242,20 +242,20 @@ async function processAddress(row, provider, pool, omnibus) {
       } catch (e) {
         console.log(JSON.stringify({ tag: 'SWP:SEND:ERR', err: e.message }));
         if (userId) {
-          await finalizeSweep({
-            id: pre.id,
-            userId,
-            chainId: CHAIN_ID,
-            address: addr,
-            asset: 'BNB',
-            tokenAddr: pre.tokenAddr,
-            amountWei: amountWei.toString(),
-            finalTxHash: `err:${Date.now()}`,
-            status: 'send_error',
-            confirmations: 0,
-            forced: true,
-            error: e.message,
-          });
+            await finalizeSweep({
+              id: pre.id,
+              userId,
+              chainId: CHAIN_ID,
+              address: addr,
+              asset: 'BNB',
+              tokenAddr: pre.tokenAddr,
+              amountWei: amountWei.toString(),
+              finalTxHash: `err:${pre.key}`,
+              status: 'send_error',
+              confirmations: 0,
+              forced: true,
+              error: e.message,
+            });
         }
         errorCount++;
       } finally {
@@ -389,7 +389,7 @@ async function processAddress(row, provider, pool, omnibus) {
               asset: symbol,
               tokenAddr: pre.tokenAddr,
               amountWei: amountCredit,
-              finalTxHash: `err:${Date.now()}`,
+              finalTxHash: `err:${pre.key}`,
               status: 'send_error',
               confirmations: 0,
               forced: true,
@@ -440,7 +440,7 @@ async function processAddress(row, provider, pool, omnibus) {
               asset: symbol,
               tokenAddr: pre.tokenAddr,
               amountWei: amountCredit,
-              finalTxHash: `err:${Date.now()}`,
+              finalTxHash: `err:${pre.key}`,
               status: 'wait_error',
               confirmations: 0,
               forced: true,
@@ -459,7 +459,7 @@ async function processAddress(row, provider, pool, omnibus) {
             asset: symbol,
             tokenAddr: pre.tokenAddr,
             amountWei: amountCredit,
-            finalTxHash: `err:${Date.now()}`,
+            finalTxHash: `err:${pre.key}`,
             status: 'send_error',
             confirmations: 0,
             forced: true,


### PR DESCRIPTION
## Summary
- reuse deposit pre-records using stable keys and log reuse information
- add intent-based idempotency guard before crediting balances
- tag failed sweeps with stable-key error hashes for consistent tracking

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1a9ff1a44832b94588bdb4ca6fead