### PR TITLE
feat: improve sweeper crediting and gas handling

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -363,13 +363,16 @@ app.get('/wallet/transactions', walletLimiter, async (req, res, next) => {
     for (const row of rows) {
       row.token_address = (row.token_address || ZERO).toLowerCase();
       row.amount_wei = row.amount_wei?.toString() ?? '0';
+      row.amount_int = row.amount_wei;
       if (row.token_address === ZERO) {
         row.display_symbol = row.token_symbol || 'BNB';
         row.decimals = 18;
+        row.amount = ethers.formatEther(row.amount_wei);
       } else {
         const meta = tokenMeta[row.token_address];
         row.display_symbol = row.token_symbol || (meta ? meta.symbol : 'UNKNOWN');
         row.decimals = meta ? meta.decimals : 18;
+        row.amount = row.amount_wei;
       }
       row.amount_formatted = formatUnitsStr(row.amount_wei, row.decimals);
     }

--- a/app/(app)/account/wallet/page.tsx
+++ b/app/(app)/account/wallet/page.tsx
@@ -5,7 +5,14 @@ import Link from 'next/link';
 import { apiFetch } from '../../../lib/api';
 import { ethers } from 'ethers';
 
-type Deposit = { tx_hash: string; amount_wei: string; confirmations: number; status: string; created_at: string };
+type Deposit = {
+  tx_hash: string;
+  amount_wei: string;
+  confirmations: number;
+  status: string;
+  created_at: string;
+  amount_int: string;
+};
 type WalletInfo = { chain_id: number; address: string };
 
 export default function WalletPage() {

--- a/app/(app)/transactions/page.tsx
+++ b/app/(app)/transactions/page.tsx
@@ -12,6 +12,7 @@ type Deposit = {
   symbol: string;
   decimals: number;
   amount_formatted: string;
+  amount_int: string;
   confirmations: number;
   status: string;
   created_at: string;

--- a/app/(app)/wallet/page.tsx
+++ b/app/(app)/wallet/page.tsx
@@ -28,6 +28,7 @@ type Deposit = {
   display_symbol: string;
   decimals: number;
   amount_formatted: string;
+  amount_int: string;
   confirmations: number;
   status: string;
   created_at: string;

--- a/apps/sweeper/recordAndCredit.ts
+++ b/apps/sweeper/recordAndCredit.ts
@@ -20,27 +20,28 @@ export async function preRecordSweep(o: {
     JSON.stringify({ tag: 'DEPOSIT:PRE_RECORD:BEGIN', user_id: o.userId, asset, amount_wei: o.amountWei, key })
   );
   try {
-    let id: number | undefined;
-    let reused = false;
-    const [rows] = await pool.query<any[]>(
-      `SELECT id FROM wallet_deposits WHERE chain_id=? AND address=? AND token_address_norm=LOWER(?) AND amount_wei=? AND status IN ('pre_sweep','send_error','wait_error') LIMIT 1`,
-      [o.chainId, o.address, tokenAddr, o.amountWei]
-    );
-    if (rows.length) {
-      id = rows[0].id;
-      reused = true;
-      await pool.query(
-        `UPDATE wallet_deposits SET token_symbol=?, tx_hash=?, status='pre_sweep', confirmations=0, last_update_at=NOW() WHERE id=?`,
-        [asset, txHash, id]
-      );
-    } else {
-      const sql = `INSERT INTO wallet_deposits
-           (user_id, chain_id, address, token_symbol, tx_hash, log_index, block_number, block_hash,
-            token_address, amount_wei, confirmations, status, credited, source, token_address_norm, created_at, last_update_at)
-           VALUES (?, ?, ?, ?, ?, 0, 0, '', ?, ?, 0, 'pre_sweep', 0, 'sweeper', LOWER(?), NOW(), NOW())`;
-      const [res] = await pool.query<any>(sql, [o.userId, o.chainId, o.address, asset, txHash, tokenAddr, o.amountWei, tokenAddr]);
-      id = res.insertId as number;
-    }
+    const sql = `INSERT INTO wallet_deposits
+         (user_id, chain_id, address, token_symbol, tx_hash, log_index, block_number, block_hash,
+          token_address, amount_wei, confirmations, status, credited, source, token_address_norm, created_at, last_update_at)
+         VALUES (?, ?, ?, ?, ?, 0, 0, '', ?, ?, 0, 'pre_sweep', 0, 'sweeper', LOWER(?), NOW(), NOW())
+         ON DUPLICATE KEY UPDATE
+           id=LAST_INSERT_ID(id),
+           token_symbol=VALUES(token_symbol),
+           status='pre_sweep',
+           confirmations=0,
+           last_update_at=NOW()`;
+    const [res] = await pool.query<any>(sql, [
+      o.userId,
+      o.chainId,
+      o.address,
+      asset,
+      txHash,
+      tokenAddr,
+      o.amountWei,
+      tokenAddr,
+    ]);
+    const id = res.insertId as number;
+    const reused = res.affectedRows > 1;
     console.log(
       JSON.stringify({
         tag: 'DEPOSIT:PRE_RECORD:OK',
@@ -49,10 +50,11 @@ export async function preRecordSweep(o: {
         tx_hash: txHash,
         amount_wei: o.amountWei,
         reused,
+        id,
         key,
       })
     );
-    return { id: id!, txHash, asset, tokenAddr, key };
+    return { id, txHash, asset, tokenAddr, key };
   } catch (e: any) {
     console.log(JSON.stringify({ tag: 'DEPOSIT:PRE_RECORD:ERR', err: e.message }));
     throw e;

--- a/apps/sweeper/sweeper.js
+++ b/apps/sweeper/sweeper.js
@@ -1,6 +1,5 @@
 const mysql = require('mysql2/promise');
 const { ethers } = require('ethers');
-const Decimal = require('decimal.js');
 const path = require('path');
 require('dotenv').config({ path: path.join(__dirname, '../../.env') });
 const { resolveUserId } = require('./depositRecorder');
@@ -58,39 +57,35 @@ async function withRetry(fn, attempts = TX_MAX_RETRY) {
 }
 
 // helper: احصل على gasPrice (wei) مع fallback وcap
-async function resolveGasPriceWei(provider, capGwei = Number(process.env.GAS_PRICE_CAP_GWEI || 3)) {
-  // cap بالـ wei
-  const capWei = BigInt(Math.max(1, capGwei)) * 1_000_000_000n;
+async function resolveGasPriceWei(provider, minGwei = Number(process.env.GAS_PRICE_MIN_GWEI || 3)) {
+  const minWei = BigInt(Math.max(1, minGwei)) * 1_000_000_000n;
 
-  // 1) v6: getFeeData().gasPrice
   try {
-    const fd = await provider.getFeeData(); // ethers v6
+    const fd = await provider.getFeeData();
     if (fd && fd.gasPrice != null) {
-      const gp = BigInt(fd.gasPrice.toString());
-      const chosen = gp > capWei ? capWei : gp;
-      console.log(`[GAS] feeData gasPrice=${gp} wei (~${Number(gp) / 1e9} gwei) cap=${capGwei} → using=${chosen} wei`);
-      return chosen;
+      let gp = BigInt(fd.gasPrice.toString());
+      if (gp < minWei) gp = minWei;
+      console.log(`[GAS] feeData gasPrice=${gp} wei (~${Number(gp) / 1e9} gwei) min=${minGwei}`);
+      return gp;
     }
   } catch (e) {
     console.warn('[GAS] getFeeData failed, fallback to eth_gasPrice', e?.code || e?.message || e);
   }
 
-  // 2) JSON-RPC مباشر
   try {
     const hex = await provider.send('eth_gasPrice', []);
     if (typeof hex === 'string') {
-      const gp = BigInt(hex);
-      const chosen = gp > capWei ? capWei : gp;
-      console.log(`[GAS] rpc eth_gasPrice=${gp} wei (~${Number(gp) / 1e9} gwei) cap=${capGwei} → using=${chosen} wei`);
-      return chosen;
+      let gp = BigInt(hex);
+      if (gp < minWei) gp = minWei;
+      console.log(`[GAS] rpc eth_gasPrice=${gp} wei (~${Number(gp) / 1e9} gwei) min=${minGwei}`);
+      return gp;
     }
   } catch (e) {
     console.warn('[GAS] eth_gasPrice failed', e?.code || e?.message || e);
   }
 
-  // 3) fallback نهائي: استخدم الـ cap نفسه (gwei → wei)
-  console.log(`[GAS] fallback: using cap only ${capGwei} gwei`);
-  return capWei;
+  console.log(`[GAS] fallback: using min only ${minGwei} gwei`);
+  return minWei;
 }
 
 // ---- init ----
@@ -181,107 +176,7 @@ async function processAddress(row, provider, pool, omnibus) {
     console.log(`[POST][SKIP] no user for address=${addr}`);
   }
   let balBNB = await provider.getBalance(addr);
-  const gasPrice = await resolveGasPriceWei(provider);
-  const txCost = gasPrice * 21000n;
-  const originalSendAmount = balBNB - txCost - KEEP_BNB_DUST_WEI;
-  const gasBuffer = txCost * 2n; // extra buffer for fluctuating gas prices
-  const sendAmount = originalSendAmount - gasBuffer;
-  let eligibleBNB = sendAmount > 0n && balBNB > MIN_SWEEP_WEI_BNB;
-  let reasonBNB = 'ok';
-  if (!eligibleBNB) {
-    reasonBNB = balBNB <= MIN_SWEEP_WEI_BNB ? 'below_min' : 'needs_gas';
-  }
-  if (!eligibleBNB && reasonBNB === 'below_min') {
-    console.log('BNB:SKIP below_min');
-  }
-
-  if (eligibleBNB) {
-    const key = addr + '-BNB';
-    if (acquireLock(key) && sweepCount < SWEEP_RATE_LIMIT_PER_MIN) {
-      const amountWei = sendAmount;
-      let pre;
-      try {
-        pre = await preRecordSweep({
-          userId,
-          chainId: CHAIN_ID,
-          address: addr,
-          assetSymbol: 'BNB',
-          amountWei: amountWei.toString(),
-        });
-      } catch (e) {
-        releaseLock(key);
-        return;
-      }
-      try {
-        console.log(JSON.stringify({ tag: 'SEND:BEGIN', symbol: 'BNB', amount: amountWei.toString(), tx_hash: pre.txHash }));
-        const tx = await withRetry(() =>
-          wallet.sendTransaction({ to: OMNIBUS_ADDRESS, value: amountWei, gasPrice, gasLimit: 21000 }),
-        );
-        console.log(JSON.stringify({ tag: 'SEND:OK', tx_hash: tx.hash }));
-        try {
-          const receipt = await tx.wait(CONFIRMATIONS);
-          console.log(JSON.stringify({ tag: 'WAIT:OK', confirmations: CONFIRMATIONS }));
-          if (userId) {
-            await finalizeSweep({
-              id: pre.id,
-              userId,
-              chainId: CHAIN_ID,
-              address: addr,
-              asset: 'BNB',
-              tokenAddr: pre.tokenAddr,
-              amountWei: amountWei.toString(),
-              finalTxHash: receipt.transactionHash,
-              status: 'swept',
-              confirmations: CONFIRMATIONS,
-            });
-          }
-          if (receipt.status !== 1) {
-            console.log(`[POST][SKIP] reason=receipt_status tx=${tx.hash} status=${receipt.status}`);
-          }
-        } catch (e) {
-          console.log(JSON.stringify({ tag: 'WAIT:ERR', message: e.message }));
-          if (userId) {
-            await finalizeSweep({
-              id: pre.id,
-              userId,
-              chainId: CHAIN_ID,
-              address: addr,
-              asset: 'BNB',
-              tokenAddr: pre.tokenAddr,
-              amountWei: amountWei.toString(),
-              finalTxHash: `err:${pre.key}`,
-              status: 'wait_error',
-              confirmations: 0,
-              forced: true,
-              error: e.message,
-            });
-          }
-        }
-      } catch (e) {
-        console.log(JSON.stringify({ tag: 'SEND:ERR', message: e.message }));
-        if (userId) {
-            await finalizeSweep({
-              id: pre.id,
-              userId,
-              chainId: CHAIN_ID,
-              address: addr,
-              asset: 'BNB',
-              tokenAddr: pre.tokenAddr,
-              amountWei: amountWei.toString(),
-              finalTxHash: `err:${pre.key}`,
-              status: 'send_error',
-              confirmations: 0,
-              forced: true,
-              error: e.message,
-            });
-        }
-        errorCount++;
-      } finally {
-        console.log(`[POST-SWEEP] addr=${addr} asset=BNB`);
-        releaseLock(key);
-      }
-    }
-  }
+  let gasPrice = await resolveGasPriceWei(provider);
 
   for (const token of TOKENS) {
     const symbol = token.symbol.toUpperCase();
@@ -360,16 +255,14 @@ async function processAddress(row, provider, pool, omnibus) {
       if (!userId) {
         console.log(`[POST][SKIP] no user for address=${addr}`);
       }
-      const amountDb = new Decimal(bal.toString())
-        .div(new Decimal(10).pow(decimals))
-        .toFixed(18);
+      const amountDb = bal.toString();
       const amountCredit = bal.toString();
       console.log(
         JSON.stringify({
           tag: 'ERC20:UNITS',
           symbol,
           decimals,
-          amount_db_format: amountDb,
+          amount_db_integer: amountDb,
           amount_credit_integer: amountCredit,
         })
       );
@@ -388,7 +281,7 @@ async function processAddress(row, provider, pool, omnibus) {
         continue;
       }
       balBNB = await provider.getBalance(addr);
-      const gasLimit = await contract.estimateGas.transfer(OMNIBUS_ADDRESS, bal, { gasPrice });
+      let gasLimit = await contract.estimateGas.transfer(OMNIBUS_ADDRESS, bal, { gasPrice });
       let needed = gasPrice * gasLimit;
       if (balBNB < needed) {
         console.log(
@@ -407,6 +300,8 @@ async function processAddress(row, provider, pool, omnibus) {
           await dripTx.wait(1);
           dripCount++;
           balBNB += GAS_DRIP_WEI;
+          gasPrice = await resolveGasPriceWei(provider);
+          gasLimit = await contract.estimateGas.transfer(OMNIBUS_ADDRESS, bal, { gasPrice });
         } catch (e) {
           console.log(
             JSON.stringify({ tag: 'DRIP:ERR', providerCode: e.code, message: e.message })
@@ -513,6 +408,104 @@ async function processAddress(row, provider, pool, omnibus) {
       console.error(`[SWEEP][ERR] sweep_send_failed addr=${addr} asset=${symbol}`, e);
       errorCount++;
       releaseLock(key);
+    }
+  }
+
+  // sweep remaining BNB after ERC20 transfers
+  balBNB = await provider.getBalance(addr);
+  gasPrice = await resolveGasPriceWei(provider);
+  const txCost = gasPrice * 21000n;
+  const originalSendAmount = balBNB - txCost - KEEP_BNB_DUST_WEI;
+  const gasBuffer = txCost * 2n;
+  const sendAmount = originalSendAmount - gasBuffer;
+  let eligibleBNB = sendAmount > 0n && balBNB > MIN_SWEEP_WEI_BNB;
+  if (!eligibleBNB) {
+    console.log('BNB:SKIP below_min');
+  } else {
+    const keyBNB = addr + '-BNB';
+    if (acquireLock(keyBNB) && sweepCount < SWEEP_RATE_LIMIT_PER_MIN) {
+      const amountWei = sendAmount;
+      let pre;
+      try {
+        pre = await preRecordSweep({
+          userId,
+          chainId: CHAIN_ID,
+          address: addr,
+          assetSymbol: 'BNB',
+          amountWei: amountWei.toString(),
+        });
+      } catch (e) {
+        releaseLock(keyBNB);
+        return;
+      }
+      try {
+        console.log(JSON.stringify({ tag: 'SEND:BEGIN', symbol: 'BNB', amount: amountWei.toString(), tx_hash: pre.txHash }));
+        const tx = await withRetry(() =>
+          wallet.sendTransaction({ to: OMNIBUS_ADDRESS, value: amountWei, gasPrice, gasLimit: 21000 })
+        );
+        console.log(JSON.stringify({ tag: 'SEND:OK', tx_hash: tx.hash }));
+        try {
+          const receipt = await tx.wait(CONFIRMATIONS);
+          console.log(JSON.stringify({ tag: 'WAIT:OK', confirmations: CONFIRMATIONS }));
+          if (userId) {
+            await finalizeSweep({
+              id: pre.id,
+              userId,
+              chainId: CHAIN_ID,
+              address: addr,
+              asset: 'BNB',
+              tokenAddr: pre.tokenAddr,
+              amountWei: amountWei.toString(),
+              finalTxHash: receipt.transactionHash,
+              status: 'swept',
+              confirmations: CONFIRMATIONS,
+            });
+          }
+          if (receipt.status !== 1) {
+            console.log(`[POST][SKIP] reason=receipt_status tx=${tx.hash} status=${receipt.status}`);
+          }
+        } catch (e) {
+          console.log(JSON.stringify({ tag: 'WAIT:ERR', message: e.message }));
+          if (userId) {
+            await finalizeSweep({
+              id: pre.id,
+              userId,
+              chainId: CHAIN_ID,
+              address: addr,
+              asset: 'BNB',
+              tokenAddr: pre.tokenAddr,
+              amountWei: amountWei.toString(),
+              finalTxHash: `err:${pre.key}`,
+              status: 'wait_error',
+              confirmations: 0,
+              forced: true,
+              error: e.message,
+            });
+          }
+        }
+      } catch (e) {
+        console.log(JSON.stringify({ tag: 'SEND:ERR', message: e.message }));
+        if (userId) {
+          await finalizeSweep({
+            id: pre.id,
+            userId,
+            chainId: CHAIN_ID,
+            address: addr,
+            asset: 'BNB',
+            tokenAddr: pre.tokenAddr,
+            amountWei: amountWei.toString(),
+            finalTxHash: `err:${pre.key}`,
+            status: 'send_error',
+            confirmations: 0,
+            forced: true,
+            error: e.message,
+          });
+        }
+        errorCount++;
+      } finally {
+        console.log(`[POST-SWEEP] addr=${addr} asset=BNB`);
+        releaseLock(keyBNB);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- handle duplicate pre-records with upsert and log reuse
- drip BNB for ERC20 gas and sweep BNB after tokens
- expose raw amount_int through API and UI

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1b4ebfb98832b9f3645015ec5c18c