### PR TITLE
Refine ERC20 sweeper and amount API

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -366,15 +366,14 @@ app.get('/wallet/transactions', walletLimiter, async (req, res, next) => {
       row.amount_int = row.amount_wei;
       if (row.token_address === ZERO) {
         row.display_symbol = row.token_symbol || 'BNB';
+        row.symbol = row.display_symbol;
         row.decimals = 18;
-        row.amount = ethers.formatEther(row.amount_wei);
       } else {
         const meta = tokenMeta[row.token_address];
         row.display_symbol = row.token_symbol || (meta ? meta.symbol : 'UNKNOWN');
+        row.symbol = row.display_symbol;
         row.decimals = meta ? meta.decimals : 18;
-        row.amount = row.amount_wei;
       }
-      row.amount_formatted = formatUnitsStr(row.amount_wei, row.decimals);
     }
     res.json({ ok: true, transactions: rows });
   } catch (err) {

--- a/app/(app)/account/wallet/page.tsx
+++ b/app/(app)/account/wallet/page.tsx
@@ -7,11 +7,12 @@ import { ethers } from 'ethers';
 
 type Deposit = {
   tx_hash: string;
-  amount_wei: string;
+  amount_int: string;
+  decimals: number;
+  display_symbol: string;
   confirmations: number;
   status: string;
   created_at: string;
-  amount_int: string;
 };
 type WalletInfo = { chain_id: number; address: string };
 
@@ -73,7 +74,7 @@ export default function WalletPage() {
           {deposits.map((d) => (
             <div key={d.tx_hash} className="p-3 bg-gray-100 rounded">
               <a href={`https://bscscan.com/tx/${d.tx_hash}`} target="_blank" rel="noopener noreferrer" className="break-all text-sm underline">{d.tx_hash}</a>
-              <div className="text-xs">{d.amount_wei} wei</div>
+              <div className="text-xs">{ethers.formatUnits(d.amount_int, d.decimals)} {d.display_symbol}</div>
               <div className="text-xs">{d.confirmations} conf — {d.status}</div>
               <div className="text-xs">{new Date(d.created_at).toLocaleString()}</div>
             </div>

--- a/app/(app)/transactions/page.tsx
+++ b/app/(app)/transactions/page.tsx
@@ -6,13 +6,12 @@ import { useRouter } from 'next/navigation';
 import { apiFetch } from '../../lib/api';
 import { dict, useLang } from '../../lib/i18n';
 import { useAuth } from '../../lib/auth';
+import { ethers } from 'ethers';
 type Deposit = {
   tx_hash: string;
-  amount_wei: string;
+  amount_int: string;
   symbol: string;
   decimals: number;
-  amount_formatted: string;
-  amount_int: string;
   confirmations: number;
   status: string;
   created_at: string;
@@ -91,7 +90,7 @@ export default function TransactionsPage() {
               {d.tx_hash}
             </a>
             <div>
-              {Number(d.amount_formatted).toFixed(6)} {d.symbol}
+              {Number(ethers.formatUnits(d.amount_int, d.decimals)).toFixed(6)} {d.symbol}
             </div>
             <div className="text-xs">{statusLabel(d.status)}</div>
           </div>

--- a/app/(app)/wallet/page.tsx
+++ b/app/(app)/wallet/page.tsx
@@ -24,11 +24,9 @@ function formatWei(wei: string, decimals: number, precision = 6): string {
 type Deposit = {
   tx_hash: string;
   token_address?: string;
-  amount_wei: string;
+  amount_int: string;
   display_symbol: string;
   decimals: number;
-  amount_formatted: string;
-  amount_int: string;
   confirmations: number;
   status: string;
   created_at: string;
@@ -161,24 +159,24 @@ export default function WalletPage() {
                 <span>{new Date(d.created_at).toLocaleString()}</span>
                 <span>{d.confirmations}</span>
               </div>
-            {d.tx_hash ? (
-              <a
-                href={`https://bscscan.com/tx/${d.tx_hash}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="break-all underline"
-              >
-                {d.tx_hash}
-              </a>
-            ) : (
-              <div>-</div>
-            )}
-            <div>
-              {Number(d.amount_formatted).toFixed(6)} {d.display_symbol}
+              {d.tx_hash ? (
+                <a
+                  href={`https://bscscan.com/tx/${d.tx_hash}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="break-all underline"
+                >
+                  {d.tx_hash}
+                </a>
+              ) : (
+                <div>-</div>
+              )}
+              <div>
+                {formatWei(d.amount_int, d.decimals)} {d.display_symbol}
+              </div>
+              <div className="text-xs">{statusLabel(d.status)}</div>
             </div>
-            <div className="text-xs">{statusLabel(d.status)}</div>
-          </div>
-        ))}
+          ))}
           {deposits.length === 0 && <div className="text-sm">-</div>}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- fix ERC20 sweeper to use direct v6 calls with manual encoding fallback
- top up gas before transfers and log ERC20 send checks
- return token amounts as integers + decimals in API and format on client

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1bcfaa33c832baf87b727b3c18347