### PR TITLE
Add content for public footer pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -5,10 +5,26 @@ import { dict, useLang } from '../lib/i18n';
 export default function AboutPage() {
   const { lang } = useLang();
   const t = dict[lang];
+  const content = {
+    en: [
+      'ELTX is a utility token platform enabling secure and low-cost transfers on the BNB Smart Chain. Designed for governments, enterprises, and everyday users, ELTX simplifies blockchain integration for real-world services.',
+      'Our mission is to provide reliable infrastructure and user-friendly tools so that institutions and individuals can interact with digital assets confidently.',
+      'The platform leverages audited smart contracts and decentralized architecture to deliver transparency, speed, and scalability.',
+    ],
+    ar: [
+      'ELTX هي منصة توكن خدمي تمكّنك من إجراء تحويلات آمنة ومنخفضة التكلفة على شبكة بينانس الذكية. تم تصميمها لخدمة الحكومات والشركات والمستخدمين الأفراد، مما يجعل دمج البلوك تشين في الخدمات اليومية أمرًا بسيطًا.',
+      'هدفنا هو توفير بنية موثوقة وأدوات سهلة الاستخدام حتى يتمكن المؤسسات والأفراد من التعامل مع الأصول الرقمية بثقة.',
+      'تعتمد المنصة على عقود ذكية خضعت للتدقيق وهيكلية لامركزية لتقديم الشفافية والسرعة وقابلية التوسع.',
+    ],
+  } as const;
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-xl font-semibold">{t.footer.about}</h1>
-      <p className="opacity-80 text-sm">{t.pages.about}</p>
+      {content[lang].map((p, i) => (
+        <p key={i} className="opacity-80 text-sm">
+          {p}
+        </p>
+      ))}
     </div>
   );
 }

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -5,10 +5,22 @@ import { dict, useLang } from '../lib/i18n';
 export default function DocsPage() {
   const { lang } = useLang();
   const t = dict[lang];
+  const linkText = { en: 'Read the white paper', ar: 'اقرأ الورقة البيضاء' }[lang];
+  const url =
+    'https://docs.google.com/document/d/1GvKvPaaUwEH7oVHFG7AnQsAlfQCr7yeM/edit?tab=t.0';
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-xl font-semibold">{t.footer.docs}</h1>
-      <p className="opacity-80 text-sm">{t.pages.docs}</p>
+      <p className="opacity-80 text-sm">
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-yellow-500 hover:underline"
+        >
+          {linkText}
+        </a>
+      </p>
     </div>
   );
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -5,10 +5,26 @@ import { dict, useLang } from '../lib/i18n';
 export default function PrivacyPage() {
   const { lang } = useLang();
   const t = dict[lang];
+  const content = {
+    en: [
+      'ELTX collects minimal personal information such as email addresses to operate the service.',
+      'Data is used only to provide and secure the platform and is never sold to third parties.',
+      'We apply industry-standard security measures to protect your information. Contact us with any privacy concerns.',
+    ],
+    ar: [
+      'تجمع ELTX أقل قدر ممكن من المعلومات الشخصية مثل عناوين البريد الإلكتروني لتشغيل الخدمة.',
+      'يتم استخدام البيانات فقط لتقديم المنصة وتأمينها ولن تُباع لأي طرف ثالث.',
+      'نطبق تدابير أمان وفق المعايير الصناعية لحماية معلوماتك. تواصل معنا لأي استفسار يتعلق بالخصوصية.',
+    ],
+  } as const;
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-xl font-semibold">{t.footer.privacy}</h1>
-      <p className="opacity-80 text-sm">{t.pages.privacy}</p>
+      {content[lang].map((p, i) => (
+        <p key={i} className="opacity-80 text-sm">
+          {p}
+        </p>
+      ))}
     </div>
   );
 }

--- a/app/status/page.tsx
+++ b/app/status/page.tsx
@@ -1,14 +1,54 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { dict, useLang } from '../lib/i18n';
+
+type S = 'loading' | 'ok' | 'down';
 
 export default function StatusPage() {
   const { lang } = useLang();
   const t = dict[lang];
+  const [rpcStatus, setRpcStatus] = useState<S>('loading');
+
+  useEffect(() => {
+    const check = async () => {
+      try {
+        const res = await fetch('https://bsc-dataseed.binance.org/', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ jsonrpc: '2.0', method: 'eth_chainId', params: [], id: 1 }),
+        });
+        const data = await res.json();
+        setRpcStatus(res.ok && data.result ? 'ok' : 'down');
+      } catch {
+        setRpcStatus('down');
+      }
+    };
+    check();
+  }, []);
+
+  const statusLabel = (s: S) =>
+    s === 'loading'
+      ? { en: 'Checking...', ar: 'جار الفحص...' }[lang]
+      : s === 'ok'
+      ? { en: 'Operational', ar: 'يعمل' }[lang]
+      : { en: 'Down', ar: 'متوقف' }[lang];
+
+  const services = [
+    { name: { en: 'Website', ar: 'الموقع' }, status: 'ok' as S },
+    { name: { en: 'BSC RPC', ar: 'واجهة BSC' }, status: rpcStatus },
+  ];
+
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-xl font-semibold">{t.footer.status}</h1>
-      <p className="opacity-80 text-sm">{t.pages.status}</p>
+      <ul className="opacity-80 text-sm space-y-2">
+        {services.map((s, i) => (
+          <li key={i}>
+            {s.name[lang]}: {statusLabel(s.status)}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -5,10 +5,28 @@ import { dict, useLang } from '../lib/i18n';
 export default function TermsPage() {
   const { lang } = useLang();
   const t = dict[lang];
+  const content = {
+    en: [
+      'By accessing or using the ELTX platform, you agree to these terms and any future updates.',
+      "The service is provided 'as is' without warranties; users are responsible for complying with applicable laws.",
+      'ELTX may modify or discontinue services at any time. Continued use after changes constitutes acceptance.',
+      'Tokens and deposits remain the responsibility of the user. Keep your credentials secure and never share them.',
+    ],
+    ar: [
+      'باستخدامك لمنصة ELTX فإنك توافق على هذه الشروط وأي تحديثات مستقبلية.',
+      'يتم تقديم الخدمة كما هي دون أي ضمانات، ويتحمل المستخدمون مسؤولية الالتزام بجميع القوانين المعمول بها.',
+      'يجوز لـ ELTX تعديل الخدمات أو إيقافها في أي وقت، ويعد استمرارك في الاستخدام بعد التغييرات قبولًا لها.',
+      'تظل الأصول والودائع تحت مسؤولية المستخدم. احرص على حماية بيانات الدخول الخاصة بك وعدم مشاركتها.',
+    ],
+  } as const;
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-xl font-semibold">{t.footer.terms}</h1>
-      <p className="opacity-80 text-sm">{t.pages.terms}</p>
+      {content[lang].map((p, i) => (
+        <p key={i} className="opacity-80 text-sm">
+          {p}
+        </p>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- populate About, Terms, and Privacy pages with English and Arabic content
- add simple service checks to Status page
- link Docs page to external white paper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1c104118c832bb7725998fc06a53f