### PR TITLE
Fix build by deferring OpenAI client and adjusting React types

### DIFF
--- a/app/(app)/ai/page.tsx
+++ b/app/(app)/ai/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { FormEvent, useEffect, useState } from 'react';
+import { FormEvent, Suspense, useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '../../lib/auth';
 
 type Message = { role: 'user' | 'assistant'; content: string };
 
-export default function AIPage() {
+function AIPageInner() {
   const { user } = useAuth();
   const router = useRouter();
 
@@ -81,6 +81,14 @@ export default function AIPage() {
         </button>
       </form>
     </div>
+  );
+}
+
+export default function AIPage() {
+  return (
+    <Suspense fallback={null}>
+      <AIPageInner />
+    </Suspense>
   );
 }
 

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { dict, useLang } from '../lib/i18n';
+import type { ReactNode } from 'react';
 
 export default function AboutPage() {
   const { lang } = useLang();
   const t = dict[lang];
-  const content: Record<'en' | 'ar', JSX.Element> = {
+  const content: Record<'en' | 'ar', ReactNode> = {
     en: (
       <>
         <p className="opacity-80 text-sm">ELTX — the utility token platform</p>

--- a/app/api/ai/route.ts
+++ b/app/api/ai/route.ts
@@ -1,8 +1,7 @@
 import OpenAI from 'openai';
 
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
-
 export async function POST(request: Request) {
+  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
   const { messages } = await request.json();
   if (!Array.isArray(messages)) {
     return new Response(JSON.stringify({ error: 'Invalid messages' }), { status: 400 });

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -3,11 +3,12 @@
 /* eslint-disable react/no-unescaped-entities */
 
 import { dict, useLang } from '../lib/i18n';
+import type { ReactNode } from 'react';
 
 export default function PrivacyPage() {
   const { lang } = useLang();
   const t = dict[lang];
-  const content: Record<'en' | 'ar', JSX.Element> = {
+  const content: Record<'en' | 'ar', ReactNode> = {
     en: (
       <>
         <p className="opacity-80 text-sm">Last updated: 10/9/2025</p>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -3,11 +3,12 @@
 /* eslint-disable react/no-unescaped-entities */
 
 import { dict, useLang } from '../lib/i18n';
+import type { ReactNode } from 'react';
 
 export default function TermsPage() {
   const { lang } = useLang();
   const t = dict[lang];
-  const content: Record<'en' | 'ar', JSX.Element> = {
+  const content: Record<'en' | 'ar', ReactNode> = {
     en: (
       <>
         <p className="opacity-80 text-sm">Last updated: 10/9/2025</p>


### PR DESCRIPTION
## Summary
- import `ReactNode` and use it for content maps in about/privacy/terms pages
- move OpenAI client creation inside API handler
- wrap AI page with `<Suspense>` to satisfy `useSearchParams`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1d6fe6568832bb1292eb716edf33f