### PR TITLE
feat: modern staking plan cards

### DIFF
--- a/app/(app)/staking/page.tsx
+++ b/app/(app)/staking/page.tsx
@@ -33,11 +33,17 @@ export default function StakingPlansPage() {
           <Link
             key={p.id}
             href={`/staking/new?plan=${p.id}`}
-            className="p-4 rounded-2xl bg-white/5 hover:bg-white/10 transition flex flex-col shadow"
+            className="group relative p-6 rounded-2xl bg-white/5 border border-white/10 hover:bg-white/10 hover:border-white/20 transition flex flex-col shadow overflow-hidden"
           >
-            <div className="font-semibold mb-1">{p.name}</div>
-            <div className="text-sm mb-1">{p.duration_days} days</div>
-            <div className="text-sm">{(p.apr_bps / 100).toFixed(2)}% APR</div>
+            <div className="absolute inset-0 bg-gradient-to-br from-purple-500/20 via-transparent to-cyan-500/20 opacity-0 group-hover:opacity-100 transition pointer-events-none" />
+            <div className="relative z-10 flex flex-col gap-2">
+              <div className="text-sm font-medium">{p.name}</div>
+              <div className="text-xs uppercase tracking-wide text-white/60">Duration</div>
+              <div className="text-2xl font-bold mb-2">{p.duration_days} days</div>
+              <div className="text-xs uppercase tracking-wide text-white/60">Profit</div>
+              <div className="text-xl font-semibold">{(p.apr_bps / 100).toFixed(2)}%</div>
+              <div className="text-xs uppercase tracking-wide text-white/60">APR</div>
+            </div>
           </Link>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- redesign staking plans listing with modern gradient cards
- highlight plan duration and APR for clarity

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1dc254830832ba7522fa25c951587