### PR TITLE
Align wallet transfer user IDs with users table

### DIFF
--- a/db/wallet.sql
+++ b/db/wallet.sql
@@ -128,8 +128,8 @@ INSERT IGNORE INTO platform_settings (name, value) VALUES ('transfer_fee_bps', '
 -- internal transfers between users
 CREATE TABLE IF NOT EXISTS wallet_transfers (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  from_user_id BIGINT UNSIGNED NOT NULL,
-  to_user_id BIGINT UNSIGNED NOT NULL,
+  from_user_id INT NOT NULL,
+  to_user_id INT NOT NULL,
   asset VARCHAR(32) NOT NULL,
   amount_wei DECIMAL(65,0) NOT NULL,
   fee_wei DECIMAL(65,0) NOT NULL DEFAULT 0,


### PR DESCRIPTION
## Summary
- Ensure wallet_transfers uses INT user IDs compatible with users.id
- Retain InnoDB engine and utf8mb4 charset for wallet_transfers table

## Testing
- `mysql --socket=/tmp/mysql.sock eltx -e "DESCRIBE wallet_transfers;"`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1f011065c832ba7494bb4bfa1c061