### PR TITLE
Handle duplicate wallet addresses during provisioning

### DIFF
--- a/api/src/services/wallet.js
+++ b/api/src/services/wallet.js
@@ -4,52 +4,61 @@ async function provisionUserAddress(db, userId, chainId = Number(process.env.CHA
   if (!process.env.MASTER_MNEMONIC) {
     throw new Error('MASTER_MNEMONIC not set');
   }
-  const isConn = !db.getConnection; // if passed connection
-  const conn = isConn ? db : await db.getConnection();
+  const isConnection = !db.getConnection; // if passed connection
+  const conn = isConnection ? db : await db.getConnection();
   try {
     const [existing] = await conn.query(
       'SELECT chain_id, address, derivation_index FROM wallet_addresses WHERE user_id=? AND chain_id=?',
       [userId, chainId]
     );
     if (existing.length) {
-      if (!isConn) conn.release();
+      if (!isConnection) conn.release();
       return { chain_id: existing[0].chain_id, address: existing[0].address };
     }
-    if (!isConn) await conn.beginTransaction();
-    const [rows] = await conn.query(
-      'SELECT next_index FROM wallet_index WHERE chain_id=? FOR UPDATE',
-      [chainId]
-    );
-    const nextIndex = rows[0].next_index;
-    await conn.query('UPDATE wallet_index SET next_index=? WHERE chain_id=?', [nextIndex + 1, chainId]);
-    const wallet = ethers.Wallet.fromPhrase(
-      process.env.MASTER_MNEMONIC,
-      `m/44'/60'/0'/0/${nextIndex}`
-    );
-    const address = wallet.address.toLowerCase();
-    try {
-      await conn.query(
-        'INSERT INTO wallet_addresses (user_id, chain_id, derivation_index, address) VALUES (?,?,?,?)',
-        [userId, chainId, nextIndex, address]
+    if (!isConnection) await conn.beginTransaction();
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const [rows] = await conn.query(
+        'SELECT next_index FROM wallet_index WHERE chain_id=? FOR UPDATE',
+        [chainId]
       );
-      if (!isConn) await conn.commit();
-      return { chain_id: chainId, address };
-    } catch (err) {
-      if (!isConn) await conn.rollback();
-      if (err.code === 'ER_DUP_ENTRY') {
-        const [existing2] = await conn.query(
-          'SELECT chain_id, address FROM wallet_addresses WHERE user_id=? AND chain_id=?',
-          [userId, chainId]
+      const nextIndex = rows[0].next_index;
+      await conn.query('UPDATE wallet_index SET next_index=? WHERE chain_id=?', [nextIndex + 1, chainId]);
+      const wallet = ethers.Wallet.fromPhrase(
+        process.env.MASTER_MNEMONIC,
+        `m/44'/60'/0'/0/${nextIndex}`
+      );
+      const address = wallet.address.toLowerCase();
+      try {
+        await conn.query(
+          'INSERT INTO wallet_addresses (user_id, chain_id, derivation_index, address) VALUES (?,?,?,?)',
+          [userId, chainId, nextIndex, address]
         );
-        if (existing2.length) return { chain_id: existing2[0].chain_id, address: existing2[0].address };
+        if (!isConnection) await conn.commit();
+        return { chain_id: chainId, address };
+      } catch (err) {
+        if (err.code === 'ER_DUP_ENTRY') {
+          const [existing2] = await conn.query(
+            'SELECT chain_id, address FROM wallet_addresses WHERE user_id=? AND chain_id=?',
+            [userId, chainId]
+          );
+          if (existing2.length) {
+            if (!isConnection) await conn.commit();
+            return { chain_id: existing2[0].chain_id, address: existing2[0].address };
+          }
+          // address belongs to another user, try again with next index
+          continue;
+        }
+        if (!isConnection) await conn.rollback();
+        throw err;
       }
-      throw err;
     }
+    if (!isConnection) await conn.rollback();
+    throw new Error('Unable to provision unique wallet address');
   } catch (err) {
-    if (!isConn) await conn.rollback();
+    if (!isConnection) await conn.rollback();
     throw err;
   } finally {
-    if (!isConn) conn.release();
+    if (!isConnection) conn.release();
   }
 }
 

--- a/db/wallet.sql
+++ b/db/wallet.sql
@@ -54,7 +54,7 @@ CREATE TABLE IF NOT EXISTS wallet_addresses (
   derivation_index INT UNSIGNED NOT NULL,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   UNIQUE KEY uniq_user_chain (user_id, chain_id),
-  UNIQUE KEY uniq_addr (address),
+  UNIQUE KEY uniq_addr (chain_id, address),
   INDEX idx_user (user_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -68,7 +68,7 @@ ALTER TABLE wallet_addresses
   ADD COLUMN IF NOT EXISTS chain_id INT UNSIGNED NOT NULL AFTER user_id,
   ADD COLUMN IF NOT EXISTS derivation_index INT UNSIGNED NOT NULL AFTER chain_id,
   ADD UNIQUE KEY uniq_user_chain (user_id, chain_id),
-  ADD UNIQUE KEY uniq_addr (address),
+  ADD UNIQUE KEY uniq_addr (chain_id, address),
   ADD INDEX idx_user (user_id);
 
 -- deposits


### PR DESCRIPTION
## Summary
- allow wallet address reuse across chains by making `wallet_addresses` unique on `(chain_id, address)`
- retry address generation on duplicate entries and cap retries with clearer connection handling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c310a53994832baf4be2f5a9daf663