### PR TITLE
Add account deletion request page

### DIFF
--- a/app/account-deletion/page.tsx
+++ b/app/account-deletion/page.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState } from 'react';
+import { dict, useLang } from '../lib/i18n';
+
+export default function AccountDeletionPage() {
+  const { lang } = useLang();
+  const t = dict[lang];
+  const [email, setEmail] = useState('');
+  const [userId, setUserId] = useState('');
+  const [reason, setReason] = useState('');
+  const [message, setMessage] = useState('');
+  const [confirm, setConfirm] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!confirm) return;
+    setStatus(null);
+    try {
+      const res = await fetch('/api/account-deletion', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, userId, reason, message }),
+      });
+      if (res.ok) {
+        setStatus(t.accountDeletion.success);
+        setEmail('');
+        setUserId('');
+        setReason('');
+        setMessage('');
+        setConfirm(false);
+      } else {
+        setStatus(t.common.genericError);
+      }
+    } catch {
+      setStatus(t.common.genericError);
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">{t.accountDeletion.title}</h1>
+      <form onSubmit={submit} className="space-y-2 max-w-md">
+        <input
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder={t.accountDeletion.email}
+          className="w-full p-2 rounded bg-white/5"
+        />
+        <input
+          type="text"
+          required
+          value={userId}
+          onChange={(e) => setUserId(e.target.value)}
+          placeholder={t.accountDeletion.userId}
+          className="w-full p-2 rounded bg-white/5"
+        />
+        <input
+          type="text"
+          required
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder={t.accountDeletion.reason}
+          className="w-full p-2 rounded bg-white/5"
+        />
+        <textarea
+          required
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder={t.accountDeletion.message}
+          className="w-full p-2 rounded bg-white/5"
+        />
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={confirm}
+            onChange={(e) => setConfirm(e.target.checked)}
+            required
+          />
+          <span>{t.accountDeletion.confirm}</span>
+        </label>
+        <button type="submit" className="bg-yellow-600 hover:bg-yellow-500 px-4 py-2 rounded">
+          {t.accountDeletion.send}
+        </button>
+        {status && <div className="text-sm opacity-80">{status}</div>}
+      </form>
+    </div>
+  );
+}
+

--- a/app/api/account-deletion/route.ts
+++ b/app/api/account-deletion/route.ts
@@ -1,0 +1,34 @@
+import nodemailer from 'nodemailer';
+
+export async function POST(request: Request) {
+  const { email, userId, reason, message } = await request.json();
+
+  try {
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: Number(process.env.SMTP_PORT) || 587,
+      secure: false,
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+
+    const text = `Email: ${email}\nUser ID: ${userId}\nReason: ${reason}\nMessage: ${message}`;
+
+    await transporter.sendMail({
+      from: process.env.SMTP_FROM || process.env.SMTP_USER,
+      replyTo: email,
+      to: 'info.eltx@gmail.com',
+      subject: 'Account Deletion Request',
+      text,
+    });
+
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  } catch (error) {
+    console.error('account deletion form error', error);
+    return new Response(JSON.stringify({ error: 'Email failed to send' }), {
+      status: 500,
+    });
+  }
+}

--- a/app/lib/i18n.tsx
+++ b/app/lib/i18n.tsx
@@ -117,6 +117,16 @@ export const dict = {
       send: 'Send',
       success: 'Message sent!',
     },
+    accountDeletion: {
+      title: 'Account Deletion Request',
+      email: 'Email',
+      userId: 'User ID',
+      reason: 'Reason for deletion',
+      message: 'Message',
+      confirm: 'I confirm that I want to delete my account from the ELTX platform',
+      send: 'Submit request',
+      success: 'Request sent!',
+    },
     audience: {
       title: 'Who we serve',
       governments: {
@@ -256,6 +266,16 @@ export const dict = {
       message: 'الرسالة',
       send: 'إرسال',
       success: 'تم إرسال الرسالة!',
+    },
+    accountDeletion: {
+      title: 'طلب حذف الحساب',
+      email: 'البريد الإلكتروني',
+      userId: 'معرف المستخدم',
+      reason: 'سبب طلب الحذف',
+      message: 'الرسالة',
+      confirm: 'أؤكد أنني أريد حذف حسابي من منصة ELTX',
+      send: 'إرسال الطلب',
+      success: 'تم إرسال الطلب!',
     },
     audience: {
       title: 'الفئات المستهدفة',


### PR DESCRIPTION
## Summary
- add public account deletion request page with confirmation checkbox
- send account deletion requests via email
- localize account deletion strings in English and Arabic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c41ccb90a0832b81a1d70e674b44fb