### PR TITLE
Improve staking flow and spot feedback

### DIFF
--- a/app/(app)/staking/new/page.tsx
+++ b/app/(app)/staking/new/page.tsx
@@ -1,55 +1,187 @@
 'use client';
 
+import Decimal from 'decimal.js';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { apiFetch } from '../../../lib/api';
 import { useAuth } from '../../../lib/auth';
+
+type Plan = {
+  id: number;
+  name: string;
+  duration_days: number;
+  apr_bps: number;
+  asset: string;
+  asset_decimals: number;
+  min_deposit?: string | null;
+};
+
+type WalletAsset = {
+  symbol: string;
+  balance: string;
+  balance_wei: string;
+  decimals: number;
+};
+
+function formatDecimal(value: Decimal | string | number | null | undefined, places = 6) {
+  if (value === null || value === undefined) return '0';
+  try {
+    const decimal = value instanceof Decimal ? value : new Decimal(value);
+    const fixed = decimal.toFixed(places, Decimal.ROUND_DOWN);
+    const trimmed = fixed.replace(/\.0+$/, '').replace(/(\.\d*?)0+$/, '$1');
+    return trimmed.endsWith('.') ? trimmed.slice(0, -1) || '0' : trimmed || '0';
+  } catch {
+    return '0';
+  }
+}
+
+function safeDecimal(value: string | number | null | undefined) {
+  try {
+    if (value === null || value === undefined) return new Decimal(0);
+    const normalized = typeof value === 'string' && value.trim() === '' ? '0' : value;
+    return new Decimal(normalized as Decimal.Value);
+  } catch {
+    return new Decimal(0);
+  }
+}
 
 export default function NewStakePage() {
   const { user } = useAuth();
   const router = useRouter();
-  const [plans, setPlans] = useState<any[]>([]);
+
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [assets, setAssets] = useState<WalletAsset[]>([]);
   const [planId, setPlanId] = useState<number | undefined>(undefined);
   const [amount, setAmount] = useState('');
-  const [daily, setDaily] = useState(0);
+  const [amountError, setAmountError] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
 
   useEffect(() => {
     if (user === null) router.replace('/login');
-    if (user) {
-      apiFetch<{ plans: any[] }>('/staking/plans').then((res) => {
-        if (!res.ok) {
-          if (res.status === 401) router.replace('/login');
-          else setError(res.error || 'Failed to load plans');
-        } else {
-          setPlans(res.data.plans);
-          const qs = new URLSearchParams(window.location.search);
-          const p = qs.get('plan');
-          if (p) setPlanId(Number(p));
-        }
-      });
-    }
   }, [user, router]);
 
   useEffect(() => {
-    const plan = plans.find((p) => p.id === planId);
-    const amt = parseFloat(amount);
-    if (plan && amt > 0) {
-      setDaily(amt * (plan.apr_bps / 10000 / 365));
-    } else {
-      setDaily(0);
+    if (!user) return;
+    let cancelled = false;
+    const qsPlan = () => {
+      const qs = new URLSearchParams(window.location.search);
+      const p = qs.get('plan');
+      return p ? Number(p) : undefined;
+    };
+    (async () => {
+      setLoading(true);
+      const res = await apiFetch<{ plans: Plan[] }>('/staking/plans');
+      if (!cancelled) {
+        setLoading(false);
+        if (res.ok) {
+          setPlans(res.data.plans);
+          const preferred = qsPlan();
+          if (preferred) setPlanId(preferred);
+        } else if (res.status === 401) {
+          router.replace('/login');
+        } else {
+          setError(res.error || 'حصل خطأ أثناء تحميل خطط الاستاكينج.');
+        }
+      }
+    })();
+    (async () => {
+      const res = await apiFetch<{ assets: WalletAsset[] }>('/wallet/assets');
+      if (!cancelled && res.ok) setAssets(res.data.assets);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, router]);
+
+  useEffect(() => {
+    if (planId !== undefined) return;
+    if (plans.length === 0) return;
+    setPlanId(plans[0].id);
+  }, [plans, planId]);
+
+  useEffect(() => {
+    if (!plans.length) return;
+    if (planId === undefined) return;
+    if (!plans.some((p) => p.id === planId)) setPlanId(plans[0].id);
+  }, [plans, planId]);
+
+  const selectedPlan = useMemo(() => plans.find((p) => p.id === planId) || null, [plans, planId]);
+
+  const assetSymbol = selectedPlan?.asset?.toUpperCase() || 'ELTX';
+  const walletAsset = useMemo(
+    () => assets.find((a) => (a.symbol || '').toUpperCase() === assetSymbol) || null,
+    [assets, assetSymbol]
+  );
+
+  const balanceDecimal = useMemo(() => safeDecimal(walletAsset?.balance), [walletAsset?.balance]);
+  const minDepositDecimal = useMemo(
+    () => (selectedPlan?.min_deposit ? safeDecimal(selectedPlan.min_deposit) : null),
+    [selectedPlan?.min_deposit]
+  );
+
+  useEffect(() => {
+    if (!selectedPlan) {
+      setAmountError('');
+      return;
     }
-  }, [planId, amount, plans]);
+    const trimmed = amount.trim();
+    if (!trimmed) {
+      setAmountError('');
+      return;
+    }
+    try {
+      const value = new Decimal(trimmed);
+      if (!value.isFinite() || value.lte(0)) {
+        setAmountError('القيمة المدخلة غير صالحة.');
+        return;
+      }
+      if (minDepositDecimal && value.lt(minDepositDecimal)) {
+        setAmountError(
+          `الحد الأدنى للاستاكينج هو ${formatDecimal(minDepositDecimal, 6)} ${assetSymbol}.`
+        );
+        return;
+      }
+      if (value.gt(balanceDecimal)) {
+        setAmountError('رصيدك مش كافي للكمية دي.');
+        return;
+      }
+      setAmountError('');
+    } catch {
+      setAmountError('القيمة المدخلة غير صالحة.');
+    }
+  }, [amount, selectedPlan, minDepositDecimal, balanceDecimal, assetSymbol]);
+
+  const aprPercent = selectedPlan ? selectedPlan.apr_bps / 100 : 0;
+
+  const estimatedDaily = useMemo(() => {
+    if (!selectedPlan) return null;
+    const trimmed = amount.trim();
+    if (!trimmed) return null;
+    try {
+      const value = new Decimal(trimmed);
+      if (!value.isFinite() || value.lte(0)) return null;
+      const aprDecimal = new Decimal(selectedPlan.apr_bps || 0).div(10000).div(365);
+      return value.mul(aprDecimal);
+    } catch {
+      return null;
+    }
+  }, [amount, selectedPlan]);
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!selectedPlan || !amount.trim() || amountError) return;
+    setSubmitting(true);
     setError('');
-    const res = await apiFetch<any>('/staking/positions', {
+    const res = await apiFetch<{ id: number }>('/staking/positions', {
       method: 'POST',
-      body: JSON.stringify({ planId, amount }),
+      body: JSON.stringify({ planId: selectedPlan.id, amount }),
     });
+    setSubmitting(false);
     if (!res.ok) {
-      setError(res.error || 'Failed to stake');
+      const code = (res.data as any)?.error?.code;
+      setError(`${res.error || 'تعذر تنفيذ العملية.'}${code ? ` (${code})` : ''}`.trim());
     } else {
       router.push('/earn/staking/positions');
     }
@@ -59,36 +191,79 @@ export default function NewStakePage() {
     <div className="p-4 flex justify-center">
       <form
         onSubmit={submit}
-        className="space-y-4 w-full max-w-md bg-white/5 border border-white/10 rounded-lg p-6"
+        className="space-y-5 w-full max-w-md bg-white/5 border border-white/10 rounded-2xl p-6 shadow-lg"
       >
-        <h1 className="text-xl font-semibold">New Stake</h1>
-        {error && <div className="text-sm text-red-500">{error}</div>}
-        <select
-          value={planId ?? ''}
-          onChange={(e) => setPlanId(Number(e.target.value))}
-          className="w-full p-2 rounded bg-black/20 border border-white/20 hover:bg-black/30 transition"
-        >
-          <option value="" disabled>
-            Select plan
-          </option>
-          {plans.map((p) => (
-            <option key={p.id} value={p.id}>
-              {p.name}
-            </option>
-          ))}
-        </select>
-        <input
-          value={amount}
-          onChange={(e) => setAmount(e.target.value)}
-          placeholder="Amount"
-          className="w-full p-2 rounded bg-black/20 border border-white/20 hover:bg-black/30 transition"
-        />
-        {daily > 0 && (
-          <div className="text-sm">Est. daily reward: {daily.toFixed(8)}</div>
+        <div className="space-y-1">
+          <h1 className="text-xl font-semibold">استاكينج ELTX</h1>
+          <p className="text-sm opacity-70">
+            اقفل رصيدك لفترة محددة علشان تكسب عائد ثابت على عملة {assetSymbol}.
+          </p>
+        </div>
+
+        {error && <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/40 rounded p-2">{error}</div>}
+
+        {loading && plans.length === 0 ? (
+          <div className="text-sm opacity-70">جاري تحميل خطط الاستاكينج…</div>
+        ) : plans.length === 0 ? (
+          <div className="text-sm opacity-70">مافيش خطط متاحة دلوقتي.</div>
+        ) : (
+          <>
+            <div>
+              <label className="block text-xs mb-1 opacity-70">اختر الخطة</label>
+              <select
+                value={planId ?? ''}
+                onChange={(e) => setPlanId(Number(e.target.value))}
+                className="w-full p-2 rounded bg-black/20 border border-white/20 hover:bg-black/30 transition"
+              >
+                {plans.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name} · {p.duration_days} يوم · APR {formatDecimal(p.apr_bps / 100, 2)}%
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="rounded-lg bg-black/20 border border-white/10 p-3 text-sm space-y-1">
+              <div>
+                <span className="opacity-70">الرصيد المتاح:</span>{' '}
+                <span className="font-semibold">{formatDecimal(balanceDecimal, 6)}</span>{' '}
+                {assetSymbol}
+              </div>
+              {minDepositDecimal && (
+                <div className="opacity-70">
+                  الحد الأدنى للدخول: {formatDecimal(minDepositDecimal, 6)} {assetSymbol}
+                </div>
+              )}
+              <div className="opacity-70">العائد السنوي (APR): {formatDecimal(aprPercent, 2)}%</div>
+            </div>
+
+            <div>
+              <label className="block text-xs mb-1 opacity-70">الكمية اللي هتستاكها</label>
+              <input
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                placeholder={`مثال: 100 ${assetSymbol}`}
+                className="w-full p-2 rounded bg-black/20 border border-white/20 hover:bg-black/30 transition"
+                inputMode="decimal"
+              />
+              {amountError && <div className="text-xs text-red-400 mt-1">{amountError}</div>}
+            </div>
+
+            {estimatedDaily && (
+              <div className="text-sm bg-amber-500/10 border border-amber-500/40 rounded p-2">
+                العائد اليومي المتوقع: {formatDecimal(estimatedDaily, 6)} {assetSymbol}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              className="btn btn-primary w-full justify-center disabled:opacity-60"
+              disabled={submitting || !selectedPlan || !amount.trim() || !!amountError}
+            >
+              {submitting ? 'جاري التنفيذ…' : 'ابدأ الاستاكينج'}
+            </button>
+          </>
         )}
-        <button type="submit" className="btn btn-primary w-full justify-center">
-          Stake
-        </button>
       </form>
     </div>
   );

--- a/app/(app)/staking/page.tsx
+++ b/app/(app)/staking/page.tsx
@@ -38,11 +38,16 @@ export default function StakingPlansPage() {
             <div className="absolute inset-0 bg-gradient-to-br from-purple-500/20 via-transparent to-cyan-500/20 opacity-0 group-hover:opacity-100 transition pointer-events-none" />
             <div className="relative z-10 flex flex-col gap-2">
               <div className="text-sm font-medium">{p.name}</div>
+              <div className="text-xs uppercase tracking-wide text-white/60">Asset</div>
+              <div className="text-lg font-semibold">{(p.asset || 'ELTX').toUpperCase()}</div>
               <div className="text-xs uppercase tracking-wide text-white/60">Duration</div>
               <div className="text-2xl font-bold mb-2">{p.duration_days} days</div>
               <div className="text-xs uppercase tracking-wide text-white/60">Profit</div>
               <div className="text-xl font-semibold">{(p.apr_bps / 100).toFixed(2)}%</div>
               <div className="text-xs uppercase tracking-wide text-white/60">APR</div>
+              {p.min_deposit && (
+                <div className="text-xs opacity-70">Min stake: {p.min_deposit} {(p.asset || 'ELTX').toUpperCase()}</div>
+              )}
             </div>
           </Link>
         ))}

--- a/app/(app)/staking/positions/page.tsx
+++ b/app/(app)/staking/positions/page.tsx
@@ -28,6 +28,7 @@ export default function PositionsPage() {
           <thead className="sticky top-0 bg-white/10">
             <tr>
               <th className="p-2 text-left">Plan</th>
+              <th className="p-2 text-left">Asset</th>
               <th className="p-2 text-right">Amount</th>
               <th className="p-2 text-right">Accrued</th>
               <th className="p-2 text-left">End</th>
@@ -38,8 +39,13 @@ export default function PositionsPage() {
             {positions.map((p) => (
               <tr key={p.id} className="border-b border-white/5 hover:bg-white/5">
                 <td className="p-2">{p.name}</td>
-                <td className="p-2 text-right">{p.amount}</td>
-                <td className="p-2 text-right">{p.accrued_total}</td>
+                <td className="p-2">{(p.stake_asset || 'ELTX').toUpperCase()}</td>
+                <td className="p-2 text-right">
+                  {p.amount} {(p.stake_asset || 'ELTX').toUpperCase()}
+                </td>
+                <td className="p-2 text-right">
+                  {p.accrued_total} {(p.stake_asset || 'ELTX').toUpperCase()}
+                </td>
                 <td className="p-2">{p.end_date?.slice(0, 10)}</td>
                 <td className="p-2">{p.status}</td>
               </tr>

--- a/app/(app)/trade/spot/page.tsx
+++ b/app/(app)/trade/spot/page.tsx
@@ -605,6 +605,8 @@ export default function SpotTradePage() {
     }
     toast({ message: t.spotTrade.notifications.placed, variant: 'success' });
     if (res.data.order.status === 'filled') toast({ message: t.spotTrade.notifications.filled, variant: 'success' });
+    else if (res.data.order.status === 'cancelled')
+      toast({ message: t.spotTrade.notifications.cancelledNoLiquidity, variant: 'error' });
     setAmount('');
     if (formType === 'limit') setPrice('');
     loadOrderbook(selectedMarket);

--- a/app/lib/i18n.tsx
+++ b/app/lib/i18n.tsx
@@ -219,6 +219,7 @@ export const dict = {
         placed: 'Order placed.',
         cancelled: 'Order cancelled.',
         filled: 'Order filled.',
+        cancelledNoLiquidity: 'Order cancelled because no liquidity was available.',
       },
       errors: {
         marketRequired: 'Select a market first.',
@@ -536,6 +537,7 @@ export const dict = {
         placed: 'تم إنشاء الأمر.',
         cancelled: 'تم إلغاء الأمر.',
         filled: 'تم تنفيذ الأمر بالكامل.',
+        cancelledNoLiquidity: 'الأمر اتلغى تلقائيًا علشان مافيش سيولة كفاية دلوقتي.',
       },
       errors: {
         marketRequired: 'يرجى اختيار السوق.',

--- a/db/migrations/202407011200_staking.sql
+++ b/db/migrations/202407011200_staking.sql
@@ -1,23 +1,34 @@
 CREATE TABLE IF NOT EXISTS staking_plans (
   id INT AUTO_INCREMENT PRIMARY KEY,
-  name VARCHAR(20) NOT NULL,
+  name VARCHAR(32) NOT NULL,
   duration_days INT NOT NULL,
   apr_bps INT NOT NULL,
-  is_active BOOLEAN NOT NULL DEFAULT 1,
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+  stake_asset VARCHAR(32) NOT NULL DEFAULT 'ELTX',
+  stake_decimals INT NOT NULL DEFAULT 18,
+  min_deposit_wei DECIMAL(65,0) DEFAULT NULL,
+  is_active TINYINT(1) NOT NULL DEFAULT 1,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
+
+ALTER TABLE staking_plans
+  ADD COLUMN IF NOT EXISTS stake_asset VARCHAR(32) NOT NULL DEFAULT 'ELTX' AFTER apr_bps,
+  ADD COLUMN IF NOT EXISTS stake_decimals INT NOT NULL DEFAULT 18 AFTER stake_asset,
+  ADD COLUMN IF NOT EXISTS min_deposit_wei DECIMAL(65,0) NULL DEFAULT NULL AFTER stake_decimals;
 
 CREATE TABLE IF NOT EXISTS staking_positions (
   id BIGINT AUTO_INCREMENT PRIMARY KEY,
   user_id BIGINT NOT NULL,
   plan_id INT NOT NULL,
-  amount DECIMAL(24,8) NOT NULL,
+  stake_asset VARCHAR(32) NOT NULL DEFAULT 'ELTX',
+  stake_decimals INT NOT NULL DEFAULT 18,
+  amount DECIMAL(36,18) NOT NULL,
+  amount_wei DECIMAL(65,0) NOT NULL,
   apr_bps_snapshot INT NOT NULL,
   start_date DATE NOT NULL,
   end_date DATE NOT NULL,
-  daily_reward DECIMAL(24,8) NOT NULL,
-  accrued_total DECIMAL(24,8) NOT NULL DEFAULT 0,
+  daily_reward DECIMAL(36,18) NOT NULL,
+  accrued_total DECIMAL(36,18) NOT NULL DEFAULT 0,
   status ENUM('active','matured','cancelled') NOT NULL DEFAULT 'active',
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -25,18 +36,35 @@ CREATE TABLE IF NOT EXISTS staking_positions (
   FOREIGN KEY (user_id) REFERENCES users(id)
 );
 
+ALTER TABLE staking_positions
+  ADD COLUMN IF NOT EXISTS stake_asset VARCHAR(32) NOT NULL DEFAULT 'ELTX' AFTER plan_id,
+  ADD COLUMN IF NOT EXISTS stake_decimals INT NOT NULL DEFAULT 18 AFTER stake_asset,
+  ADD COLUMN IF NOT EXISTS amount_wei DECIMAL(65,0) NOT NULL AFTER amount,
+  ADD COLUMN IF NOT EXISTS daily_reward DECIMAL(36,18) NOT NULL AFTER end_date,
+  ADD COLUMN IF NOT EXISTS accrued_total DECIMAL(36,18) NOT NULL DEFAULT 0 AFTER daily_reward,
+  MODIFY COLUMN amount DECIMAL(36,18) NOT NULL,
+  MODIFY COLUMN daily_reward DECIMAL(36,18) NOT NULL,
+  MODIFY COLUMN accrued_total DECIMAL(36,18) NOT NULL DEFAULT 0;
+
 CREATE TABLE IF NOT EXISTS staking_accruals (
   id BIGINT AUTO_INCREMENT PRIMARY KEY,
   position_id BIGINT NOT NULL,
   accrual_date DATE NOT NULL,
-  amount DECIMAL(24,8) NOT NULL,
+  amount DECIMAL(36,18) NOT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   UNIQUE KEY uniq_accrual (position_id, accrual_date),
   FOREIGN KEY (position_id) REFERENCES staking_positions(id)
 );
 
-INSERT INTO staking_plans (id, name, duration_days, apr_bps) VALUES
-  (1, '30d', 30, 600),
-  (2, '6m', 180, 1000),
-  (3, '1y', 365, 1600)
-ON DUPLICATE KEY UPDATE name=VALUES(name), duration_days=VALUES(duration_days), apr_bps=VALUES(apr_bps), is_active=1;
+INSERT INTO staking_plans (id, name, duration_days, apr_bps, stake_asset, stake_decimals, is_active)
+VALUES
+  (1, '30d', 30, 600, 'ELTX', 18, 1),
+  (2, '6m', 180, 1000, 'ELTX', 18, 1),
+  (3, '1y', 365, 1600, 'ELTX', 18, 1)
+ON DUPLICATE KEY UPDATE
+  name=VALUES(name),
+  duration_days=VALUES(duration_days),
+  apr_bps=VALUES(apr_bps),
+  stake_asset=VALUES(stake_asset),
+  stake_decimals=VALUES(stake_decimals),
+  is_active=VALUES(is_active);

--- a/db/wallet.sql
+++ b/db/wallet.sql
@@ -146,6 +146,92 @@ INSERT IGNORE INTO asset_prices (asset, price_eltx, min_amount, spread_bps) VALU
 INSERT IGNORE INTO asset_prices (asset, price_eltx, min_amount, spread_bps) VALUES ('BNB', 0, 0.01, 25);
 INSERT IGNORE INTO asset_prices (asset, price_eltx, min_amount, spread_bps) VALUES ('ETH', 0, 0.005, 25);
 
+-- staking configuration
+CREATE TABLE IF NOT EXISTS staking_plans (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(32) NOT NULL,
+  duration_days INT NOT NULL,
+  apr_bps INT NOT NULL,
+  stake_asset VARCHAR(32) NOT NULL DEFAULT 'ELTX',
+  stake_decimals INT NOT NULL DEFAULT 18,
+  min_deposit_wei DECIMAL(65,0) DEFAULT NULL,
+  is_active TINYINT(1) NOT NULL DEFAULT 1,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+ALTER TABLE staking_plans
+  ADD COLUMN IF NOT EXISTS name VARCHAR(32) NOT NULL AFTER id,
+  ADD COLUMN IF NOT EXISTS duration_days INT NOT NULL AFTER name,
+  ADD COLUMN IF NOT EXISTS apr_bps INT NOT NULL AFTER duration_days,
+  ADD COLUMN IF NOT EXISTS stake_asset VARCHAR(32) NOT NULL DEFAULT 'ELTX' AFTER apr_bps,
+  ADD COLUMN IF NOT EXISTS stake_decimals INT NOT NULL DEFAULT 18 AFTER stake_asset,
+  ADD COLUMN IF NOT EXISTS min_deposit_wei DECIMAL(65,0) NULL DEFAULT NULL AFTER stake_decimals,
+  ADD COLUMN IF NOT EXISTS is_active TINYINT(1) NOT NULL DEFAULT 1 AFTER min_deposit_wei,
+  ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER is_active,
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER created_at;
+
+CREATE TABLE IF NOT EXISTS staking_positions (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  user_id BIGINT NOT NULL,
+  plan_id INT NOT NULL,
+  stake_asset VARCHAR(32) NOT NULL DEFAULT 'ELTX',
+  stake_decimals INT NOT NULL DEFAULT 18,
+  amount DECIMAL(36,18) NOT NULL,
+  amount_wei DECIMAL(65,0) NOT NULL,
+  apr_bps_snapshot INT NOT NULL,
+  start_date DATE NOT NULL,
+  end_date DATE NOT NULL,
+  daily_reward DECIMAL(36,18) NOT NULL,
+  accrued_total DECIMAL(36,18) NOT NULL DEFAULT 0,
+  status ENUM('active','matured','cancelled') NOT NULL DEFAULT 'active',
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (plan_id) REFERENCES staking_plans(id),
+  FOREIGN KEY (user_id) REFERENCES users(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+ALTER TABLE staking_positions
+  ADD COLUMN IF NOT EXISTS stake_asset VARCHAR(32) NOT NULL DEFAULT 'ELTX' AFTER plan_id,
+  ADD COLUMN IF NOT EXISTS stake_decimals INT NOT NULL DEFAULT 18 AFTER stake_asset,
+  ADD COLUMN IF NOT EXISTS amount DECIMAL(36,18) NOT NULL AFTER stake_decimals,
+  ADD COLUMN IF NOT EXISTS amount_wei DECIMAL(65,0) NOT NULL AFTER amount,
+  ADD COLUMN IF NOT EXISTS apr_bps_snapshot INT NOT NULL AFTER amount_wei,
+  ADD COLUMN IF NOT EXISTS daily_reward DECIMAL(36,18) NOT NULL AFTER end_date,
+  ADD COLUMN IF NOT EXISTS accrued_total DECIMAL(36,18) NOT NULL DEFAULT 0 AFTER daily_reward,
+  ADD COLUMN IF NOT EXISTS status ENUM('active','matured','cancelled') NOT NULL DEFAULT 'active' AFTER accrued_total,
+  ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER status,
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER created_at,
+  MODIFY COLUMN amount DECIMAL(36,18) NOT NULL,
+  MODIFY COLUMN daily_reward DECIMAL(36,18) NOT NULL,
+  MODIFY COLUMN accrued_total DECIMAL(36,18) NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS staking_accruals (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  position_id BIGINT NOT NULL,
+  accrual_date DATE NOT NULL,
+  amount DECIMAL(36,18) NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY uniq_accrual (position_id, accrual_date),
+  FOREIGN KEY (position_id) REFERENCES staking_positions(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+ALTER TABLE staking_accruals
+  ADD COLUMN IF NOT EXISTS accrual_date DATE NOT NULL AFTER position_id,
+  ADD COLUMN IF NOT EXISTS amount DECIMAL(36,18) NOT NULL AFTER accrual_date,
+  ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER amount,
+  ADD UNIQUE KEY IF NOT EXISTS uniq_accrual (position_id, accrual_date);
+
+INSERT INTO staking_plans (id, name, duration_days, apr_bps, stake_asset, stake_decimals, is_active)
+VALUES
+  (1, '30d', 30, 600, 'ELTX', 18, 1),
+  (2, '6m', 180, 1000, 'ELTX', 18, 1),
+  (3, '1y', 365, 1600, 'ELTX', 18, 1)
+ON DUPLICATE KEY UPDATE
+  name=VALUES(name),
+  duration_days=VALUES(duration_days),
+  apr_bps=VALUES(apr_bps),
+  stake_asset=VALUES(stake_asset),
+  stake_decimals=VALUES(stake_decimals),
+  is_active=VALUES(is_active);
+
 -- stored swap quotes
 CREATE TABLE IF NOT EXISTS trade_quotes (
   id CHAR(36) NOT NULL,


### PR DESCRIPTION
## Summary
- enrich staking plan metadata, add schema migrations, and enforce balance checks during stake creation
- surface staking asset info, user balances, and validation on the staking UI
- surface a toast when spot market orders auto-cancel because of missing liquidity

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d309cfc148832b84e1cdc4371879b2