### PR TITLE
Document manual liquidity alignment for swap pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ The API uses a MySQL database. Create one and run `api/schema.sql` plus `db/wall
 
 Re-run `db/wallet.sql` after updates to remove any legacy columns.
 
+### Seed swap testing data
+استخدم سكريبت الـ SQL اليدوي لو عايز تضبط اسعار السواب وتزود رصيد مستخدم بنفسك:
+
+```bash
+mysql -u <user> -p <database> < docs/sql/manual_swap_seed.sql
+```
+
+السكريبت بيسجّل اسعار تقريبية لـ ELTX مقابل USDT/USDC/BNB/ETH، وبيدي مثال ازاي تجيب `user_id` بالبريد وتزوّد الرصيد بعملات مختلفة. عدّل القيم جوه الملف قبل ما ترنه عشان تناسب تجربتك، ولو محتاج السعر يتغيّر مع السيولة الداخلية اربط نفس القيمة في بلوك تحديث `swap_liquidity_pools` جوه السكريبت علشان السواب والسبوت يعكسوا نفس المعروض (وفي آخر السكربت فيه استعلام بيوضح أرصدة المجمع بعد التنفيذ).
+
+> لو محتاج تصفّي الرصيد القديم، فك التعليق عن أمر الـ `DELETE` الموجود **قبل** أوامر الإدراج مباشرة علشان مايمسحش القيم الجديدة.
+
 ### ENV required (names only)
 ```
 CHAIN

--- a/docs/sql/manual_swap_seed.sql
+++ b/docs/sql/manual_swap_seed.sql
@@ -1,0 +1,86 @@
+-- سكربت تهيئة يدوي لتحديد اسعار السواب وتجهيز رصيد مستخدم للتجارب
+-- عدّل القيم بالاسفل قبل التنفيذ حسب احتياجك ثم نفّذ الاوامر في MySQL.
+
+START TRANSACTION;
+
+-- 1) حدّد اسعار ELTX مقابل باقي الاصول المستخدمة في اختبار السواب.
+--    price_eltx يعني كام ELTX يكافئ وحدة واحدة من الاصل التاني.
+REPLACE INTO asset_prices (asset, price_eltx, min_amount, max_amount, spread_bps)
+VALUES
+  ('ELTX', 1.000000000000000000, 0.000000000000000000, NULL, 0),
+  ('USDT', 12.500000000000000000, 1.000000000000000000, NULL, 10),
+  ('USDC', 12.450000000000000000, 1.000000000000000000, NULL, 10),
+  ('BNB', 420.000000000000000000, 0.010000000000000000, NULL, 25),
+  ('ETH', 7500.000000000000000000, 0.005000000000000000, NULL, 25);
+
+-- 2) هات الـ id الخاص بالمستخدم اللي هتجرب بيه.
+--    بدّل البريد في المتغير ده ببريد المستخدم الفعلي عندك.
+SET @user_email := 'tester@eltx.io';
+SELECT id INTO @user_id FROM users WHERE email = @user_email LIMIT 1;
+
+-- اتأكد ان المستخدم موجود قبل ما تكمل.
+SELECT @user_id AS user_id; -- لو النتيجة NULL يبقى لازم تضيف المستخدم الاول.
+
+-- 3) (اختياري) لو عايز تفضي الارصدة القديمة قبل التعبئة، نفّذ الامر ده.
+--    سيبه متعلّق لو عايز تحتفظ بالرصد السابق.
+-- DELETE FROM user_balances WHERE user_id = @user_id AND asset IN ('ELTX','USDT','USDC','BNB','ETH');
+
+-- 4) عبّي الرصيد الجديد للمستخدم بنفس الوحدات (wei = 10^18).
+INSERT INTO user_balances (user_id, asset, balance_wei)
+VALUES
+  (@user_id, 'ELTX', 50000000000000000000000),    -- 50,000 ELTX
+  (@user_id, 'USDT', 2500000000000000000000),     -- 2,500 USDT
+  (@user_id, 'USDC', 1500000000000000000000),     -- 1,500 USDC
+  (@user_id, 'BNB', 100000000000000000000),       -- 100 BNB
+  (@user_id, 'ETH', 50000000000000000000)         -- 50 ETH
+ON DUPLICATE KEY UPDATE
+  balance_wei = VALUES(balance_wei);
+
+-- 5) (اختياري) علشان تربط سعر السواب مع المعروض والسيولة الداخلية، عدّل احتياطيات
+--    swap_liquidity_pools بناءً على نفس السعر اللي سجلته في asset_prices. كرّر
+--    البلوك ده لكل اصل انت محتاجه، مع ضبط الديسيمل الخاص بكل عملة وتغيير
+--    المتغيرات قبل ما تعيد التنفيذ.
+--    - @pool_eltx_reserve: كمية ELTX اللي عايزها جوه المجمع (بوحدة wei = ‎10^18‎).
+--    السعر بيتسحب تلقائياً من asset_prices، ولو صفر سيب البلوك ده متعلّق.
+--    مثال: لو عدّلت السعر لـ 0.0001 ELTX لكل 1 USDT، حدّد اي رصيد ELTX مناسب
+--    في المتغير @pool_eltx_reserve (مثلاً 1,000 ELTX) والاسكربت هيحسب تلقائيًا
+--    كمية USDT المطلوبة علشان نفس السعر يظهر في السواب والسبوت.
+SET @pool_asset := 'USDT';
+SET @pool_asset_decimals := 18;
+SET @pool_eltx_reserve := CAST(50000000000000000000000 AS DECIMAL(65,0)); -- 50,000 ELTX
+SET @pool_price_eltx := IFNULL(
+  (SELECT price_eltx FROM asset_prices WHERE asset = @pool_asset LIMIT 1),
+  CAST(0 AS DECIMAL(36,18))
+);
+SET @pool_asset_reserve := IF(
+  @pool_price_eltx > 0,
+  CAST(@pool_eltx_reserve / @pool_price_eltx AS DECIMAL(65,0)),
+  NULL
+);
+
+INSERT INTO swap_liquidity_pools (asset, asset_decimals, asset_reserve_wei, eltx_reserve_wei)
+SELECT
+  @pool_asset,
+  @pool_asset_decimals,
+  @pool_asset_reserve,
+  @pool_eltx_reserve
+WHERE @pool_asset_reserve IS NOT NULL
+ON DUPLICATE KEY UPDATE
+  asset_decimals = VALUES(asset_decimals),
+  asset_reserve_wei = VALUES(asset_reserve_wei),
+  eltx_reserve_wei = VALUES(eltx_reserve_wei);
+
+COMMIT;
+
+-- بعد التنفيذ، تأكد ان البيانات اتحدّثت بالقيم اللي انت محددها.
+SELECT asset, price_eltx, min_amount, max_amount, spread_bps
+FROM asset_prices
+WHERE asset IN ('ELTX','USDT','USDC','BNB','ETH');
+
+SELECT asset, balance_wei
+FROM user_balances
+WHERE user_id = @user_id;
+
+SELECT asset, asset_reserve_wei, eltx_reserve_wei
+FROM swap_liquidity_pools
+WHERE asset IN ('USDT','USDC','BNB','ETH');


### PR DESCRIPTION
## Summary
- extend the manual swap seed SQL script with an optional block that syncs swap_liquidity_pools reserves to the configured ELTX price so swap quotes track manual price updates
- add a verification query for pool reserves and document the liquidity alignment step in the README

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68dd89d3b158832b823e5bbf881849db