### PR TITLE
Add 'Explore' menu with Privacy / Terms / Child Safety / Contact links

### DIFF
--- a/app/lib/i18n.tsx
+++ b/app/lib/i18n.tsx
@@ -820,6 +820,7 @@ export const dict = {
       logout: 'Logout',
       language: 'Language',
       balance: 'Balance',
+      explore: 'Explore',
     },
     appNav: {
       home: 'Home',
@@ -1983,6 +1984,7 @@ export const dict = {
       logout: 'تسجيل الخروج',
       language: 'اللغة',
       balance: 'الرصيد',
+      explore: 'استكشاف',
     },
     appNav: {
       home: 'الرئيسية',

--- a/components/layout/MobileMenu.tsx
+++ b/components/layout/MobileMenu.tsx
@@ -11,12 +11,14 @@ export default function MobileMenu({
   open,
   setOpen,
   links,
+  publicLinks,
   user,
   logout,
 }: {
   open: boolean;
   setOpen: Dispatch<SetStateAction<boolean>>;
   links: NavLink[];
+  publicLinks: NavLink[];
   user: any;
   logout: () => Promise<void>;
 }) {
@@ -46,7 +48,7 @@ export default function MobileMenu({
       <nav
         ref={panelRef}
         data-open={open}
-        className="fixed top-0 right-0 h-full w-80 max-w-[85%] border-l border-[#2f3336] bg-black text-white translate-x-full data-[open=true]:translate-x-0 transition-transform duration-200 z-[70] p-6 flex flex-col gap-4"
+        className="fixed top-0 right-0 h-full w-80 max-w-[85%] overflow-y-auto border-l border-[#2f3336] bg-black text-white translate-x-full data-[open=true]:translate-x-0 transition-transform duration-200 z-[70] p-6 flex flex-col gap-3"
         role="dialog"
         aria-modal="true"
       >
@@ -58,6 +60,16 @@ export default function MobileMenu({
             {l.label}
           </Link>
         ))}
+        <div className="mt-2 rounded-2xl border border-[#2f3336] bg-[#111216]/80 p-3">
+          <p className="px-2 pb-2 text-[10px] uppercase tracking-[0.2em] text-white/50">{t.nav.explore}</p>
+          <div className="flex flex-col gap-1">
+            {publicLinks.map((l) => (
+              <Link key={l.href} href={l.href} onClick={() => setOpen(false)} className="rounded-full px-3 py-2 text-sm text-white/80 hover:bg-white/10 hover:text-white">
+                {l.label}
+              </Link>
+            ))}
+          </div>
+        </div>
         {!user && (
           <>
             <Link href="/login" onClick={() => setOpen(false)} className="rounded-full px-3 py-2 hover:bg-white/10">
@@ -88,4 +100,3 @@ export default function MobileMenu({
     </>
   );
 }
-

--- a/components/layout/NavBar.tsx
+++ b/components/layout/NavBar.tsx
@@ -12,6 +12,7 @@ import { apiFetch } from '../../app/lib/api';
 import { formatWei } from '../../app/lib/format';
 
 interface NavLink { href: string; label: string; }
+interface PublicLink { href: string; label: string; }
 
 export default function NavBar() {
   const { user, logout } = useAuth();
@@ -80,6 +81,12 @@ export default function NavBar() {
     : [
       { href: '/', label: t.nav.home },
     ];
+  const publicLinks: PublicLink[] = [
+    { href: '/privacy', label: t.footer.privacy },
+    { href: '/terms', label: t.footer.terms },
+    { href: '/child-safety', label: t.footer.childSafety },
+    { href: '/contact', label: t.footer.contact },
+  ];
 
   const isActive = (href: string) => (pathname === href ? 'text-white font-semibold' : 'text-white/70');
 
@@ -115,6 +122,15 @@ export default function NavBar() {
               {l.label}
             </Link>
           ))}
+          <div className="mx-1 h-6 w-px bg-[#2f3336]" aria-hidden="true" />
+          <div className="flex items-center gap-1 rounded-full border border-[#2f3336] bg-[#111216]/80 px-2 py-1">
+            <span className="px-2 text-[10px] uppercase tracking-[0.2em] text-white/50">{t.nav.explore}</span>
+            {publicLinks.map((l) => (
+              <Link key={l.href} href={l.href} className="rounded-full px-2.5 py-1.5 text-xs text-white/70 transition-colors hover:bg-white/10 hover:text-white">
+                {l.label}
+              </Link>
+            ))}
+          </div>
           {!user && (
             <>
               <Link href="/login" className="rounded-full px-3 py-2 hover:bg-white/10">{t.nav.login}</Link>
@@ -154,7 +170,7 @@ export default function NavBar() {
           <Menu />
         </button>
       </div>
-      <MobileMenu open={open} setOpen={setOpen} links={links} user={user} logout={logout} />
+      <MobileMenu open={open} setOpen={setOpen} links={links} publicLinks={publicLinks} user={user} logout={logout} />
     </header>
   );
 }


### PR DESCRIPTION
### Motivation
- Provide quick, compact access to important public/legal pages (Privacy, Terms, Child Safety, Contact) in the main navigation without removing existing items. 
- Keep the UI small and visually neat on desktop and mobile while preserving language toggles and auth links.

### Description
- Added a new `publicLinks` array and an `Explore` inline block to the desktop navbar in `components/layout/NavBar.tsx` that links to `/privacy`, `/terms`, `/child-safety`, and `/contact`.
- Updated `components/layout/MobileMenu.tsx` to accept `publicLinks` and render a compact, scroll-safe `Explore` section with `overflow-y-auto` for mobile drawers.
- Added `explore` i18n keys in `app/lib/i18n.tsx` for English and Arabic and removed a duplicate unused insertion in `pay` scope.
- No database/schema changes were required, so there are no SQL migrations.

### Testing
- Ran integration tests with `npm run test:integration` and all tests passed (`19/19` tests OK).
- Built the production site with `npm run build` and the Next.js build completed successfully (type/lint checks passed during build).
- Started the dev server and verified a response with `curl -I http://127.0.0.1:3000` which returned `HTTP/1.1 200 OK`.
- Attempted a Headless Playwright screenshot test after `npx playwright install chromium`, but launching the browser failed in this environment due to a missing system library (`libatk-1.0.so.0`), so the visual screenshot step did not complete (Playwright install itself succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c87dceffd0832bb1e14f725ee6b1d8)