### PR TITLE
Add Binance liquidity bridge fallback for spot trading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,11 @@ MARKET_MAKER_CF_CLEARANCE=
 MARKET_MAKER_EXTRA_COOKIES=
 MARKET_MAKER_USER_AGENT=eltx-market-maker/0.1
 
+# Binance spot liquidity bridge (used by API fallback / hedging)
+BINANCE_API_KEY=
+BINANCE_API_SECRET=
+BINANCE_BASE_URL=https://api.binance.com
+
 # Google OAuth
 GOOGLE_OAUTH_CLIENT_ID=
 GOOGLE_OAUTH_CLIENT_SECRET=

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -45,6 +45,8 @@ const WITHDRAWAL_CHAINS = ['Ethereum', 'BNB', 'Solana', 'Base'];
 const DEFAULT_MARKET_MAKER_SPREAD_BPS = 200;
 const DEFAULT_MARKET_MAKER_REFRESH_MINUTES = 30;
 const DEFAULT_MARKET_MAKER_TARGET_BASE_PCT = 50;
+const DEFAULT_BINANCE_LIQUIDITY_ENABLED = false;
+const BINANCE_RECV_WINDOW_MS = 5_000;
 const ELTX_SYMBOL = 'ELTX';
 const STRIPE_SUPPORTED_ASSETS = [ELTX_SYMBOL, 'USDT'];
 const WITHDRAWAL_ASSETS = [ELTX_SYMBOL, 'USDT'];
@@ -714,6 +716,7 @@ const MarketMakerSettingsSchema = z
     user_email: z.string().email().optional(),
     pairs: z.union([z.string(), z.array(z.string().min(3))]).optional(),
     target_base_pct: z.coerce.number().min(1).max(99).optional(),
+    binance_liquidity_enabled: z.boolean().optional(),
   })
   .refine(
     (data) =>
@@ -722,7 +725,8 @@ const MarketMakerSettingsSchema = z
       data.refresh_minutes !== undefined ||
       data.user_email !== undefined ||
       data.pairs !== undefined ||
-      data.target_base_pct !== undefined,
+      data.target_base_pct !== undefined ||
+      data.binance_liquidity_enabled !== undefined,
     { message: 'At least one market maker field must be provided' }
   );
 
@@ -2773,6 +2777,11 @@ async function readMarketMakerSettings(conn = pool) {
     DEFAULT_MARKET_MAKER_TARGET_BASE_PCT.toString(),
     conn
   );
+  const binanceEnabledRaw = await getPlatformSettingValue(
+    'binance_liquidity_enabled',
+    DEFAULT_BINANCE_LIQUIDITY_ENABLED ? '1' : '0',
+    conn
+  );
 
   const spread = Number.parseInt(spreadRaw, 10);
   const refreshMinutes = Number.parseInt(refreshRaw, 10);
@@ -2789,6 +2798,7 @@ async function readMarketMakerSettings(conn = pool) {
           .filter(Boolean)
       : [],
     target_base_pct: Number.isFinite(targetPct) ? targetPct : DEFAULT_MARKET_MAKER_TARGET_BASE_PCT,
+    binance_liquidity_enabled: binanceEnabledRaw === '1' || binanceEnabledRaw?.toLowerCase?.() === 'true',
   };
 }
 
@@ -2803,8 +2813,127 @@ async function updateMarketMakerSettings(partial) {
     tasks.push(setPlatformSettingValue('market_maker_pairs', partial.pairs.map((p) => p.trim().toUpperCase()).join(',')));
   if (partial.target_base_pct !== undefined)
     tasks.push(setPlatformSettingValue('market_maker_target_base_pct', partial.target_base_pct.toString()));
+  if (partial.binance_liquidity_enabled !== undefined)
+    tasks.push(setPlatformSettingValue('binance_liquidity_enabled', partial.binance_liquidity_enabled ? '1' : '0'));
   if (!tasks.length) return;
   await Promise.all(tasks);
+}
+
+function getBinanceConfig() {
+  const apiKey = process.env.BINANCE_API_KEY || '';
+  const apiSecret = process.env.BINANCE_API_SECRET || '';
+  const baseUrl = (process.env.BINANCE_BASE_URL || 'https://api.binance.com').replace(/\/+$/, '');
+  return {
+    apiKey,
+    apiSecret,
+    baseUrl,
+    configured: !!apiKey && !!apiSecret,
+  };
+}
+
+function toBinanceSymbol(symbol) {
+  return String(symbol || '')
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, '');
+}
+
+async function readBinanceLiquidityState(conn = pool) {
+  const settings = await readMarketMakerSettings(conn);
+  const cfg = getBinanceConfig();
+  return {
+    enabled: !!settings.binance_liquidity_enabled,
+    configured: cfg.configured,
+    baseUrl: cfg.baseUrl,
+  };
+}
+
+async function fetchBinanceDepthSnapshot(marketRow, limit = 50) {
+  const cfg = getBinanceConfig();
+  const symbol = toBinanceSymbol(marketRow.symbol);
+  const url = new URL('/api/v3/depth', cfg.baseUrl);
+  url.searchParams.set('symbol', symbol);
+  url.searchParams.set('limit', String(Math.min(Math.max(limit, 5), 100)));
+  const response = await fetch(url.toString(), { method: 'GET' });
+  if (!response.ok) throw new Error(`Binance depth failed (${response.status})`);
+  const payload = await response.json();
+  const formatLevels = (levels, side) =>
+    (Array.isArray(levels) ? levels : [])
+      .map((level) => {
+        if (!Array.isArray(level) || level.length < 2) return null;
+        const [priceRaw, qtyRaw] = level;
+        let priceWei;
+        let baseWei;
+        try {
+          priceWei = ethers.parseUnits(String(priceRaw), 18);
+          baseWei = ethers.parseUnits(String(qtyRaw), marketRow.base_decimals);
+        } catch {
+          return null;
+        }
+        if (priceWei <= 0n || baseWei <= 0n) return null;
+        const quoteWei = computeQuoteAmount(baseWei, priceWei);
+        return {
+          side,
+          price_wei: priceWei,
+          base_amount_wei: baseWei,
+          quote_amount_wei: quoteWei,
+        };
+      })
+      .filter(Boolean);
+
+  return {
+    bids: formatLevels(payload.bids, 'buy'),
+    asks: formatLevels(payload.asks, 'sell'),
+  };
+}
+
+async function executeBinanceMarketOrder(marketRow, side, { quantityWei, quoteOrderQtyWei }) {
+  const cfg = getBinanceConfig();
+  if (!cfg.configured) throw new Error('Binance API credentials are not configured');
+  const symbol = toBinanceSymbol(marketRow.symbol);
+  const params = new URLSearchParams();
+  params.set('symbol', symbol);
+  params.set('side', side.toUpperCase());
+  params.set('type', 'MARKET');
+  params.set('newOrderRespType', 'FULL');
+  if (side === 'buy') {
+    if (quoteOrderQtyWei && quoteOrderQtyWei > 0n) {
+      params.set('quoteOrderQty', trimDecimal(formatUnitsStr(quoteOrderQtyWei.toString(), marketRow.quote_decimals)));
+    } else if (quantityWei && quantityWei > 0n) {
+      params.set('quantity', trimDecimal(formatUnitsStr(quantityWei.toString(), marketRow.base_decimals)));
+    } else {
+      throw new Error('Missing buy quantity');
+    }
+  } else if (quantityWei && quantityWei > 0n) {
+    params.set('quantity', trimDecimal(formatUnitsStr(quantityWei.toString(), marketRow.base_decimals)));
+  } else {
+    throw new Error('Missing sell quantity');
+  }
+  params.set('recvWindow', String(BINANCE_RECV_WINDOW_MS));
+  params.set('timestamp', String(Date.now()));
+  const signature = crypto.createHmac('sha256', cfg.apiSecret).update(params.toString()).digest('hex');
+  params.set('signature', signature);
+
+  const response = await fetch(`${cfg.baseUrl}/api/v3/order`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'X-MBX-APIKEY': cfg.apiKey,
+    },
+    body: params.toString(),
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(payload?.msg || `Binance order failed (${response.status})`);
+
+  const executedQty = ethers.parseUnits(String(payload.executedQty || '0'), marketRow.base_decimals);
+  const cummulativeQuoteQty = ethers.parseUnits(String(payload.cummulativeQuoteQty || '0'), marketRow.quote_decimals);
+  const averagePriceWei =
+    executedQty > 0n && cummulativeQuoteQty > 0n ? mulDiv(cummulativeQuoteQty, PRICE_SCALE, executedQty) : 0n;
+  return {
+    executedBaseWei: executedQty,
+    quoteWithoutFeeWei: cummulativeQuoteQty,
+    averagePriceWei,
+    raw: payload,
+  };
 }
 
 async function readSpotOrderbookVersion(conn, marketRow) {
@@ -2898,6 +3027,32 @@ async function readSpotOrderbookSnapshot(conn, marketRow) {
       quote_amount_wei: quoteWei.toString(),
     };
   };
+  if (!bidRows.length && !askRows.length) {
+    try {
+      const external = await readBinanceLiquidityState(conn);
+      if (external.enabled) {
+        const depth = await fetchBinanceDepthSnapshot(marketRow, 50);
+        if (depth.bids.length || depth.asks.length) {
+          const extFormat = (row) => ({
+            price: trimDecimal(formatUnitsStr(row.price_wei.toString(), 18)),
+            price_wei: row.price_wei.toString(),
+            base_amount: trimDecimal(formatUnitsStr(row.base_amount_wei.toString(), marketRow.base_decimals)),
+            base_amount_wei: row.base_amount_wei.toString(),
+            quote_amount: trimDecimal(formatUnitsStr(row.quote_amount_wei.toString(), marketRow.quote_decimals)),
+            quote_amount_wei: row.quote_amount_wei.toString(),
+          });
+          return {
+            orderbookVersion: await readSpotOrderbookVersion(conn, marketRow),
+            lastTradeId: tradeRows.length ? Number(tradeRows[0].id || 0) : 0,
+            orderbook: { bids: depth.bids.map(extFormat), asks: depth.asks.map(extFormat) },
+            trades: tradeRows.map((row) => formatSpotTrade(row, marketRow)),
+          };
+        }
+      }
+    } catch (err) {
+      console.warn('[spot] Binance orderbook fallback failed:', err.message || err);
+    }
+  }
   const trades = tradeRows.map((row) => formatSpotTrade(row, marketRow));
   const orderbookVersion = await readSpotOrderbookVersion(conn, marketRow);
   const lastTradeId = trades.length ? trades[0].id : 0;
@@ -3242,6 +3397,7 @@ async function matchSpotOrder(conn, market, taker, { feeType = 'spot' } = {}) {
     result.trades.push({
       trade_id: tradeId,
       maker_order_id: maker.id,
+      maker_user_id: maker.user_id,
       price_wei: makerPriceWei,
       base_amount_wei: tradeBase,
       quote_amount_wei: quoteWithoutFee,
@@ -10429,6 +10585,8 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
 
     const feeSettings = await readSpotFeeBps(conn);
     const riskSettings = await readSpotRiskSettings(conn);
+    const liquidityState = await readBinanceLiquidityState(conn);
+    const marketMakerSettings = await readMarketMakerSettings(conn);
     const makerFeeBps = clampBps(BigInt(feeSettings.maker || 0));
     const takerFeeBps = clampBps(BigInt(feeSettings.taker || 0));
     const topOfBook = await getSpotTopOfBook(conn, market.id, { forUpdate: true });
@@ -10488,15 +10646,36 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
       ]);
     }
 
+    let bestReferenceForRisk = side === 'buy' ? topOfBook.ask : topOfBook.bid;
     if (type === 'market') {
-      const bestReference = side === 'buy' ? topOfBook.ask : topOfBook.bid;
-      if (!bestReference || bestReference <= 0n) {
-        await conn.rollback();
-        return next({ status: 400, code: 'NO_LIQUIDITY', message: 'Insufficient orderbook liquidity' });
+      let estimate = await estimateSpotMarketFill(conn, market, { side, baseAmountWei: amountWei });
+      if (estimate.filledBase <= 0n && liquidityState.enabled) {
+        try {
+          const externalDepth = await fetchBinanceDepthSnapshot(market, 50);
+          const levels = side === 'buy' ? externalDepth.asks : externalDepth.bids;
+          let remainingBase = amountWei;
+          let totalQuote = 0n;
+          for (const level of levels) {
+            if (remainingBase <= 0n) break;
+            const tradeBase = remainingBase < level.base_amount_wei ? remainingBase : level.base_amount_wei;
+            if (tradeBase <= 0n) continue;
+            totalQuote += computeQuoteAmount(tradeBase, level.price_wei);
+            remainingBase -= tradeBase;
+          }
+          const filledBase = amountWei - remainingBase;
+          estimate = {
+            filledBase,
+            totalQuote,
+            averagePriceWei: filledBase > 0n ? mulDiv(totalQuote, PRICE_SCALE, filledBase) : 0n,
+          };
+          if (!bestReferenceForRisk || bestReferenceForRisk <= 0n) {
+            bestReferenceForRisk = levels[0]?.price_wei || 0n;
+          }
+        } catch (err) {
+          console.warn('[spot] Binance estimate fallback failed:', err.message || err);
+        }
       }
-
-      const estimate = await estimateSpotMarketFill(conn, market, { side, baseAmountWei: amountWei });
-      if (estimate.filledBase <= 0n) {
+      if (bestReferenceForRisk <= 0n || estimate.filledBase <= 0n) {
         await conn.rollback();
         return next({ status: 400, code: 'NO_LIQUIDITY', message: 'Insufficient orderbook liquidity' });
       }
@@ -10504,7 +10683,7 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
         await conn.rollback();
         return next({ status: 400, code: 'FOK_INCOMPLETE', message: 'Order could not be fully filled immediately' });
       }
-      const expectedSlippageBps = computeRelativeBps(estimate.averagePriceWei, bestReference);
+      const expectedSlippageBps = computeRelativeBps(estimate.averagePriceWei, bestReferenceForRisk);
       if (expectedSlippageBps > riskSettings.maxSlippageBps) {
         await conn.rollback();
         return next({ status: 400, code: 'SLIPPAGE_EXCEEDED', message: 'Expected slippage exceeds max limit' });
@@ -10551,6 +10730,77 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
     };
 
     const matchResult = await matchSpotOrder(conn, market, taker);
+    const marketMakerUserRow =
+      marketMakerSettings.user_email
+        ? (await conn.query('SELECT id FROM users WHERE email=? LIMIT 1', [marketMakerSettings.user_email]))[0]?.[0]
+        : null;
+    const marketMakerUserId = marketMakerUserRow ? Number(marketMakerUserRow.id) : null;
+
+    const isImmediateOrCancel = type === 'market' || timeInForce !== 'gtc';
+    const shouldExternalFallback = liquidityState.enabled && isDemoMode !== true;
+    if (shouldExternalFallback && isImmediateOrCancel && taker.remainingBase > 0n) {
+      try {
+        const spentBefore = matchResult.spentQuote;
+        const quoteBudgetWei = side === 'buy' ? (quoteBalance > spentBefore ? quoteBalance - spentBefore : 0n) : 0n;
+        const externalOrder = await executeBinanceMarketOrder(market, side, {
+          quantityWei: side === 'sell' ? taker.remainingBase : taker.remainingBase,
+          quoteOrderQtyWei: side === 'buy' ? quoteBudgetWei : 0n,
+        });
+        if (externalOrder.executedBaseWei > 0n && externalOrder.quoteWithoutFeeWei > 0n) {
+          const externalBase = externalOrder.executedBaseWei > taker.remainingBase ? taker.remainingBase : externalOrder.executedBaseWei;
+          const externalQuote = computeQuoteAmount(externalBase, externalOrder.averagePriceWei);
+          const externalFee = (externalQuote * takerFeeBps) / 10000n;
+          const buyOrderId = side === 'buy' ? orderId : orderId;
+          const sellOrderId = side === 'sell' ? orderId : orderId;
+          const [tradeInsert] = await conn.query(
+            'INSERT INTO spot_trades (market_id, buy_order_id, sell_order_id, price_wei, base_amount_wei, quote_amount_wei, buy_fee_wei, sell_fee_wei, fee_asset, taker_side) VALUES (?,?,?,?,?,?,?,?,?,?)',
+            [
+              market.id,
+              buyOrderId,
+              sellOrderId,
+              externalOrder.averagePriceWei.toString(),
+              externalBase.toString(),
+              externalQuote.toString(),
+              side === 'buy' ? externalFee.toString() : '0',
+              side === 'sell' ? externalFee.toString() : '0',
+              market.quote_asset,
+              side,
+            ]
+          );
+          const tradeId = tradeInsert.insertId;
+          if (externalFee > 0n) {
+            await conn.query('INSERT INTO platform_fees (fee_type, reference, asset, amount_wei) VALUES (?,?,?,?)', [
+              'spot',
+              `trade:${tradeId}:external:taker`,
+              market.quote_asset,
+              externalFee.toString(),
+            ]);
+          }
+          if (side === 'buy') {
+            matchResult.spentQuote += externalQuote + externalFee;
+            matchResult.receivedBase += externalBase;
+          } else {
+            matchResult.receivedQuote += externalQuote - externalFee;
+          }
+          matchResult.takerFee += externalFee;
+          matchResult.filledBase += externalBase;
+          taker.remainingBase -= externalBase;
+          matchResult.trades.push({
+            trade_id: tradeId,
+            maker_order_id: null,
+            maker_user_id: null,
+            price_wei: externalOrder.averagePriceWei,
+            base_amount_wei: externalBase,
+            quote_amount_wei: externalQuote,
+            taker_fee_wei: externalFee,
+            maker_fee_wei: 0n,
+            external_liquidity: true,
+          });
+        }
+      } catch (err) {
+        console.warn('[spot] Binance execution fallback failed:', err.message || err);
+      }
+    }
 
     if (timeInForce === 'fok' && matchResult.filledBase < amountWei) {
       await conn.rollback();
@@ -10559,7 +10809,7 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
 
     if (type === 'market' && matchResult.filledBase > 0n) {
       const averagePriceWei = matchResult.averagePriceWei;
-      const referencePrice = side === 'buy' ? topOfBook.ask : topOfBook.bid;
+      const referencePrice = bestReferenceForRisk;
       if (!referencePrice || referencePrice <= 0n) {
         await conn.rollback();
         return next({ status: 400, code: 'NO_LIQUIDITY', message: 'Orderbook reference price missing' });
@@ -10579,7 +10829,6 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
       }
     }
 
-    const isImmediateOrCancel = type === 'market' || timeInForce !== 'gtc';
     let orderStatus = 'open';
     if (isImmediateOrCancel) {
       orderStatus = matchResult.filledBase > 0n ? 'filled' : 'cancelled';
@@ -10648,6 +10897,23 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
     ]);
 
     await conn.commit();
+
+    if (shouldExternalFallback && marketMakerUserId && matchResult.trades.length) {
+      const hedgeBaseWei = matchResult.trades
+        .filter((trade) => Number(trade.maker_user_id || 0) === marketMakerUserId)
+        .reduce((acc, trade) => acc + bigIntFromValue(trade.base_amount_wei), 0n);
+      if (hedgeBaseWei > 0n) {
+        executeBinanceMarketOrder(market, side === 'buy' ? 'sell' : 'buy', { quantityWei: hedgeBaseWei })
+          .then(() => {
+            console.log(
+              `[spot] hedged market-maker fill via Binance: market=${market.symbol} side=${side === 'buy' ? 'sell' : 'buy'} baseWei=${hedgeBaseWei.toString()}`
+            );
+          })
+          .catch((err) => {
+            console.warn('[spot] market-maker hedge failed:', err.message || err);
+          });
+      }
+    }
 
     const trades = matchResult.trades.map((trade) => ({
       trade_id: trade.trade_id,

--- a/app/mo/AdminApp.tsx
+++ b/app/mo/AdminApp.tsx
@@ -332,6 +332,7 @@ type MarketMakerSettings = {
   user_email: string;
   pairs: string[];
   target_base_pct: number;
+  binance_liquidity_enabled: boolean;
 };
 
 type P2PPaymentMethod = {
@@ -5139,6 +5140,7 @@ function PricingPanel({ onNotify }: { onNotify: (message: string, variant?: 'suc
   const [makerSettings, setMakerSettings] = useState<MarketMakerSettings | null>(null);
   const [makerForm, setMakerForm] = useState({
     enabled: false,
+    binanceLiquidityEnabled: false,
     spreadPct: '2.00',
     refreshMinutes: '30',
     userEmail: 'info.eltx@gmail.com',
@@ -5163,6 +5165,7 @@ function PricingPanel({ onNotify }: { onNotify: (message: string, variant?: 'suc
       setMakerSettings(makerRes.data.settings);
       setMakerForm({
         enabled: !!makerRes.data.settings.enabled,
+        binanceLiquidityEnabled: !!makerRes.data.settings.binance_liquidity_enabled,
         spreadPct: (makerRes.data.settings.spread_bps / 100).toFixed(2),
         refreshMinutes: makerRes.data.settings.refresh_minutes.toString(),
         userEmail: makerRes.data.settings.user_email,
@@ -5309,6 +5312,7 @@ function PricingPanel({ onNotify }: { onNotify: (message: string, variant?: 'suc
 
     const payload = {
       enabled: makerForm.enabled,
+      binance_liquidity_enabled: makerForm.binanceLiquidityEnabled,
       spread_bps: Math.round(spread * 100),
       refresh_minutes: Math.round(refresh),
       user_email: makerForm.userEmail.trim(),
@@ -5326,6 +5330,7 @@ function PricingPanel({ onNotify }: { onNotify: (message: string, variant?: 'suc
       setMakerSettings(res.data.settings);
       setMakerForm({
         enabled: !!res.data.settings.enabled,
+        binanceLiquidityEnabled: !!res.data.settings.binance_liquidity_enabled,
         spreadPct: (res.data.settings.spread_bps / 100).toFixed(2),
         refreshMinutes: res.data.settings.refresh_minutes.toString(),
         userEmail: res.data.settings.user_email,
@@ -5493,6 +5498,15 @@ function PricingPanel({ onNotify }: { onNotify: (message: string, variant?: 'suc
                   className="h-4 w-4 rounded border-white/30 bg-black/40"
                 />
                 Enable bot
+              </label>
+              <label className="flex items-center gap-3 text-sm font-medium text-white/80">
+                <input
+                  type="checkbox"
+                  checked={makerForm.binanceLiquidityEnabled}
+                  onChange={(e) => setMakerForm((prev) => ({ ...prev, binanceLiquidityEnabled: e.target.checked }))}
+                  className="h-4 w-4 rounded border-white/30 bg-black/40"
+                />
+                Enable Binance liquidity bridge
               </label>
 
               <div>

--- a/db/migrations/202604111100_binance_liquidity_bridge.sql
+++ b/db/migrations/202604111100_binance_liquidity_bridge.sql
@@ -1,0 +1,4 @@
+-- Binance liquidity bridge runtime toggle
+INSERT INTO platform_settings (name, value)
+VALUES ('binance_liquidity_enabled', '0')
+ON DUPLICATE KEY UPDATE value = VALUES(value);

--- a/db/wallet.sql
+++ b/db/wallet.sql
@@ -795,4 +795,5 @@ INSERT IGNORE INTO platform_settings (name, value) VALUES ('market_maker_refresh
 INSERT IGNORE INTO platform_settings (name, value) VALUES ('market_maker_user_email', 'info.eltx@gmail.com');
 INSERT IGNORE INTO platform_settings (name, value) VALUES ('market_maker_pairs', 'ETH/USDT,WBTC/USDT,BNB/USDT');
 INSERT IGNORE INTO platform_settings (name, value) VALUES ('market_maker_target_base_pct', '50');
+INSERT IGNORE INTO platform_settings (name, value) VALUES ('binance_liquidity_enabled', '0');
 INSERT IGNORE INTO platform_settings (name, value) VALUES ('seo_settings_json', '{"sitemapRefreshHours":3,"indexNowEnabled":false,"indexNowKey":"","indexNowKeyLocation":"/indexnow-key.txt","includeRssInSitemap":true,"postPublishPingEnabled":false,"postPublishPingUrls":["https://rpc.pingomatic.com/"]}');


### PR DESCRIPTION
### Motivation
- Provide an external liquidity fallback (Binance) for spot market orders when internal orderbook / market-maker liquidity is not available. 
- Preserve existing internal orderbook, fee model and UI while making external fills transparent to end-users.
- Allow operators to enable/disable the Binance bridge at runtime from the admin panel.

### Description
- Added Binance integration and runtime config in `api/src/app.js` including `getBinanceConfig`, `fetchBinanceDepthSnapshot`, and `executeBinanceMarketOrder`, plus constants `DEFAULT_BINANCE_LIQUIDITY_ENABLED` and `BINANCE_RECV_WINDOW_MS`.
- Integrated Binance depth fallback into `GET /spot/orderbook` to return external bids/asks when the local orderbook is empty, and into `POST /spot/orders` to estimate and execute market/IOC remainder via Binance when enabled and safe to do so, while preserving internal fee recording (`platform_fees`) and trade records.
- Added `maker_user_id` to match results to identify market-maker fills for optional asynchronous hedging, and added admin schema/API/UI changes to expose `binance_liquidity_enabled` with a checkbox in the pricing/market-maker panel (`app/mo/AdminApp.tsx`).
- Added `.env.example` Binance keys (`BINANCE_API_KEY`, `BINANCE_API_SECRET`, `BINANCE_BASE_URL`) and a DB migration/seed (`db/migrations/202604111100_binance_liquidity_bridge.sql` and `db/wallet.sql`) to introduce the `binance_liquidity_enabled` platform setting.

### Testing
- Ran `npm run build` and the Next build completed successfully (with non-blocking warnings about Browserslist and an npm env config warning).
- Ran `npm run test:integration` and all integration tests passed (19 tests, 0 failures).
- Ran `npm run lint` and there were no ESLint warnings or errors.
- Attempted a Playwright headless screenshot of the admin page; `npx playwright install chromium` completed successfully but the headless run failed due to missing system library `libatk-1.0.so.0` in the environment, so a screenshot could not be produced here (environment limitation).
- DB migration to apply manually: run `INSERT INTO platform_settings (name, value) VALUES ('binance_liquidity_enabled', '0') ON DUPLICATE KEY UPDATE value = VALUES(value);` or apply the provided migration file `db/migrations/202604111100_binance_liquidity_bridge.sql`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dacee14f2c832ba057dc6a88b99de0)