### PR TITLE
Fix spot Binance fallback reliability + add optional mock liquidity mode

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -2823,10 +2823,12 @@ function getBinanceConfig() {
   const apiKey = process.env.BINANCE_API_KEY || '';
   const apiSecret = process.env.BINANCE_API_SECRET || '';
   const baseUrl = (process.env.BINANCE_BASE_URL || 'https://api.binance.com').replace(/\/+$/, '');
+  const mockMode = process.env.BINANCE_MOCK_MODE === 'true';
   return {
     apiKey,
     apiSecret,
     baseUrl,
+    mockMode,
     configured: !!apiKey && !!apiSecret,
   };
 }
@@ -2837,18 +2839,65 @@ function toBinanceSymbol(symbol) {
     .replace(/[^A-Z0-9]/g, '');
 }
 
+function getSyntheticReferencePriceWei(marketRow) {
+  const key = String(marketRow?.base_asset || '').toUpperCase();
+  const fallbackByAsset = {
+    BTC: '70000',
+    WBTC: '70000',
+    ETH: '2500',
+    BNB: '600',
+    USDT: '1',
+    USDC: '1',
+    ELTX: '1',
+    MCOIN: '1',
+  };
+  const raw = fallbackByAsset[key] || '10';
+  return ethers.parseUnits(raw, 18);
+}
+
+function buildSyntheticDepthSnapshot(marketRow, limit = 50) {
+  const cappedLimit = Math.min(Math.max(Number(limit) || 20, 5), 100);
+  const midPriceWei = getSyntheticReferencePriceWei(marketRow);
+  const baseStepWei = ethers.parseUnits('0.01', marketRow.base_decimals);
+  const spreadStepBps = 12n;
+  const levelsPerSide = Math.min(25, Math.max(5, Math.floor(cappedLimit / 2)));
+  const toLevels = (side) =>
+    Array.from({ length: levelsPerSide }, (_, index) => {
+      const level = BigInt(index + 1);
+      const shiftBps = spreadStepBps * level;
+      const priceWei =
+        side === 'buy'
+          ? mulDiv(midPriceWei, 10_000n - shiftBps, 10_000n)
+          : mulDiv(midPriceWei, 10_000n + shiftBps, 10_000n);
+      const baseWei = baseStepWei * (level * 2n);
+      const quoteWei = computeQuoteAmount(baseWei, priceWei);
+      return {
+        side,
+        price_wei: priceWei,
+        base_amount_wei: baseWei,
+        quote_amount_wei: quoteWei,
+      };
+    });
+  return {
+    bids: toLevels('buy'),
+    asks: toLevels('sell'),
+  };
+}
+
 async function readBinanceLiquidityState(conn = pool) {
   const settings = await readMarketMakerSettings(conn);
   const cfg = getBinanceConfig();
   return {
     enabled: !!settings.binance_liquidity_enabled,
     configured: cfg.configured,
+    mockMode: cfg.mockMode,
     baseUrl: cfg.baseUrl,
   };
 }
 
 async function fetchBinanceDepthSnapshot(marketRow, limit = 50) {
   const cfg = getBinanceConfig();
+  if (cfg.mockMode) return buildSyntheticDepthSnapshot(marketRow, limit);
   const symbol = toBinanceSymbol(marketRow.symbol);
   const url = new URL('/api/v3/depth', cfg.baseUrl);
   url.searchParams.set('symbol', symbol);
@@ -2888,6 +2937,33 @@ async function fetchBinanceDepthSnapshot(marketRow, limit = 50) {
 
 async function executeBinanceMarketOrder(marketRow, side, { quantityWei, quoteOrderQtyWei }) {
   const cfg = getBinanceConfig();
+  if (cfg.mockMode) {
+    const referencePriceWei = getSyntheticReferencePriceWei(marketRow);
+    if (side === 'buy') {
+      const normalizedBaseWei =
+        quantityWei && quantityWei > 0n
+          ? quantityWei
+          : quoteOrderQtyWei && quoteOrderQtyWei > 0n
+            ? mulDiv(quoteOrderQtyWei, PRICE_SCALE, referencePriceWei)
+            : 0n;
+      if (normalizedBaseWei <= 0n) throw new Error('Missing buy quantity');
+      const quoteWithoutFeeWei = computeQuoteAmount(normalizedBaseWei, referencePriceWei);
+      return {
+        executedBaseWei: normalizedBaseWei,
+        quoteWithoutFeeWei,
+        averagePriceWei: referencePriceWei,
+        raw: { mock: true },
+      };
+    }
+    if (!quantityWei || quantityWei <= 0n) throw new Error('Missing sell quantity');
+    const quoteWithoutFeeWei = computeQuoteAmount(quantityWei, referencePriceWei);
+    return {
+      executedBaseWei: quantityWei,
+      quoteWithoutFeeWei,
+      averagePriceWei: referencePriceWei,
+      raw: { mock: true },
+    };
+  }
   if (!cfg.configured) throw new Error('Binance API credentials are not configured');
   const symbol = toBinanceSymbol(marketRow.symbol);
   const params = new URLSearchParams();
@@ -2896,10 +2972,10 @@ async function executeBinanceMarketOrder(marketRow, side, { quantityWei, quoteOr
   params.set('type', 'MARKET');
   params.set('newOrderRespType', 'FULL');
   if (side === 'buy') {
-    if (quoteOrderQtyWei && quoteOrderQtyWei > 0n) {
-      params.set('quoteOrderQty', trimDecimal(formatUnitsStr(quoteOrderQtyWei.toString(), marketRow.quote_decimals)));
-    } else if (quantityWei && quantityWei > 0n) {
+    if (quantityWei && quantityWei > 0n) {
       params.set('quantity', trimDecimal(formatUnitsStr(quantityWei.toString(), marketRow.base_decimals)));
+    } else if (quoteOrderQtyWei && quoteOrderQtyWei > 0n) {
+      params.set('quoteOrderQty', trimDecimal(formatUnitsStr(quoteOrderQtyWei.toString(), marketRow.quote_decimals)));
     } else {
       throw new Error('Missing buy quantity');
     }
@@ -10738,13 +10814,13 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
 
     const isImmediateOrCancel = type === 'market' || timeInForce !== 'gtc';
     const shouldExternalFallback = liquidityState.enabled && isDemoMode !== true;
+    let externalFallbackAttempted = false;
+    let externalFallbackError = null;
     if (shouldExternalFallback && isImmediateOrCancel && taker.remainingBase > 0n) {
       try {
-        const spentBefore = matchResult.spentQuote;
-        const quoteBudgetWei = side === 'buy' ? (quoteBalance > spentBefore ? quoteBalance - spentBefore : 0n) : 0n;
+        externalFallbackAttempted = true;
         const externalOrder = await executeBinanceMarketOrder(market, side, {
-          quantityWei: side === 'sell' ? taker.remainingBase : taker.remainingBase,
-          quoteOrderQtyWei: side === 'buy' ? quoteBudgetWei : 0n,
+          quantityWei: taker.remainingBase,
         });
         if (externalOrder.executedBaseWei > 0n && externalOrder.quoteWithoutFeeWei > 0n) {
           const externalBase = externalOrder.executedBaseWei > taker.remainingBase ? taker.remainingBase : externalOrder.executedBaseWei;
@@ -10798,8 +10874,18 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
           });
         }
       } catch (err) {
+        externalFallbackError = err;
         console.warn('[spot] Binance execution fallback failed:', err.message || err);
       }
+    }
+
+    if (isImmediateOrCancel && matchResult.filledBase <= 0n && externalFallbackAttempted && externalFallbackError) {
+      await conn.rollback();
+      return next({
+        status: 502,
+        code: 'BINANCE_EXECUTION_FAILED',
+        message: `External liquidity execution failed: ${externalFallbackError.message || 'unknown error'}`,
+      });
     }
 
     if (timeInForce === 'fok' && matchResult.filledBase < amountWei) {


### PR DESCRIPTION
### Motivation
- Fix unreliable Binance external-fallback behavior that often resulted in empty fills when bridging liquidity to Binance. 
- Provide a safe, deterministic buy execution path so buy-side external orders do not use the user’s full quote balance as `quoteOrderQty` by mistake. 
- Make the system resilient in environments missing live exchange connectivity by providing a runtime mock/liquidity demo mode. 

### Description
- Changed Binance configuration to expose an optional `BINANCE_MOCK_MODE` flag in `getBinanceConfig()` and surface `mockMode` in `readBinanceLiquidityState()` in `api/src/app.js`.
- Added synthetic helpers `getSyntheticReferencePriceWei()` and `buildSyntheticDepthSnapshot()` and used them in `fetchBinanceDepthSnapshot()` when `BINANCE_MOCK_MODE=true` to generate an orderbook fallback.
- Implemented a mock path in `executeBinanceMarketOrder()` to return deterministic market-execution results when `BINANCE_MOCK_MODE=true`, and otherwise require explicit credentials as before.
- Changed buy-side market order construction to prefer explicit base `quantity` over sending `quoteOrderQty` first, and reordered parameters to avoid sending a user’s full quote balance in fallback flows.
- Improved external-fallback error handling in the spot order endpoint so that if an immediate-or-cancel / market fallback to Binance was attempted and fails without fill, the API now returns a clear `BINANCE_EXECUTION_FAILED` (HTTP 502) instead of silently behaving like a no-op.
- Only `api/src/app.js` was modified; there are no database schema or migration changes, so no SQL to run.

### Testing
- Ran `npm run test:integration` and all tests passed (`19/19` subtests passed). 
- Ran `npm run lint` and the linter returned no ESLint warnings or errors. 
- Ran `npm run build` and the Next.js build completed successfully; build emitted environment warnings about missing runtime env vars and a stale Browserslist notice (classified as non-blocking for the build but relevant for runtime), which do not prevent deployment but should be addressed by providing the missing env keys.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daeef2e8c8832b9b97721e419cb054)