### PR TITLE
Fix Binance order fallback visibility and remove Binance spread markup

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -46,7 +46,7 @@ const DEFAULT_MARKET_MAKER_SPREAD_BPS = 200;
 const DEFAULT_MARKET_MAKER_REFRESH_MINUTES = 30;
 const DEFAULT_MARKET_MAKER_TARGET_BASE_PCT = 50;
 const DEFAULT_BINANCE_LIQUIDITY_ENABLED = false;
-const DEFAULT_BINANCE_LIQUIDITY_SPREAD_BPS = 15;
+const DEFAULT_BINANCE_LIQUIDITY_SPREAD_BPS = 0;
 const BINANCE_RECV_WINDOW_MS = 5_000;
 const ELTX_SYMBOL = 'ELTX';
 const STRIPE_SUPPORTED_ASSETS = [ELTX_SYMBOL, 'USDT'];
@@ -10925,9 +10925,12 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
     const shouldExternalFallback = liquidityState.enabled && (liquidityState.configured || liquidityState.mockMode);
     let externalFallbackAttempted = false;
     let externalFallbackError = null;
-    if (shouldExternalFallback && isImmediateOrCancel && taker.remainingBase > 0n) {
+    if (shouldExternalFallback && taker.remainingBase > 0n) {
       try {
         externalFallbackAttempted = true;
+        console.info(
+          `[spot] external fallback start: orderId=${orderId} market=${market.symbol} side=${side} type=${type} tif=${timeInForce} remainingBaseWei=${taker.remainingBase.toString()} spreadBps=${liquidityState.spreadBps} mode=${liquidityState.mockMode ? 'mock' : 'live'}`
+        );
         const externalDepthRaw = await fetchBinanceDepthSnapshot(market, 50);
         const externalDepth = normalizeExternalDepthWithSpread(externalDepthRaw, liquidityState.spreadBps);
         const levels = side === 'buy' ? externalDepth.asks : externalDepth.bids;
@@ -11000,11 +11003,31 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
             maker_fee_wei: 0n,
             external_liquidity: true,
           });
+          console.info(
+            `[spot] external fallback filled: orderId=${orderId} tradeId=${tradeId} executedBaseWei=${externalBase.toString()} executedQuoteWei=${externalQuote.toString()} avgPriceWei=${externalAveragePriceWei.toString()}`
+          );
+        } else {
+          console.info(
+            `[spot] external fallback no-fill: orderId=${orderId} market=${market.symbol} side=${side} type=${type} tif=${timeInForce} reason=limit_or_depth_constraints`
+          );
         }
       } catch (err) {
         externalFallbackError = err;
-        console.warn('[spot] Binance execution fallback failed:', err.message || err);
+        console.warn(
+          `[spot] Binance execution fallback failed: orderId=${orderId} market=${market.symbol} side=${side} type=${type} tif=${timeInForce} error=${
+            err.message || err
+          }`
+        );
       }
+    } else if (taker.remainingBase > 0n) {
+      const reason = !liquidityState.enabled
+        ? 'binance_liquidity_disabled'
+        : !liquidityState.configured && !liquidityState.mockMode
+          ? 'binance_credentials_missing'
+          : 'no_remaining_quantity';
+      console.info(
+        `[spot] external fallback skipped: orderId=${orderId} market=${market.symbol} side=${side} type=${type} tif=${timeInForce} reason=${reason}`
+      );
     }
 
     if (isImmediateOrCancel && matchResult.filledBase <= 0n && externalFallbackAttempted && externalFallbackError) {

--- a/db/migrations/202604121700_disable_binance_liquidity_spread.sql
+++ b/db/migrations/202604121700_disable_binance_liquidity_spread.sql
@@ -1,0 +1,5 @@
+-- Disable Binance liquidity spread so only platform commission applies
+INSERT INTO platform_settings (name, value)
+VALUES ('binance_liquidity_spread_bps', '0')
+ON DUPLICATE KEY UPDATE value = VALUES(value);
+

--- a/db/wallet.sql
+++ b/db/wallet.sql
@@ -796,5 +796,5 @@ INSERT IGNORE INTO platform_settings (name, value) VALUES ('market_maker_user_em
 INSERT IGNORE INTO platform_settings (name, value) VALUES ('market_maker_pairs', 'ETH/USDT,WBTC/USDT,BNB/USDT');
 INSERT IGNORE INTO platform_settings (name, value) VALUES ('market_maker_target_base_pct', '50');
 INSERT IGNORE INTO platform_settings (name, value) VALUES ('binance_liquidity_enabled', '0');
-INSERT IGNORE INTO platform_settings (name, value) VALUES ('binance_liquidity_spread_bps', '15');
+INSERT IGNORE INTO platform_settings (name, value) VALUES ('binance_liquidity_spread_bps', '0');
 INSERT IGNORE INTO platform_settings (name, value) VALUES ('seo_settings_json', '{"sitemapRefreshHours":3,"indexNowEnabled":false,"indexNowKey":"","indexNowKeyLocation":"/indexnow-key.txt","includeRssInSitemap":true,"postPublishPingEnabled":false,"postPublishPingUrls":["https://rpc.pingomatic.com/"]}');


### PR DESCRIPTION
### Motivation
- Orders were remaining open internally without attempting external execution on Binance and there was insufficient server-side logging to diagnose failures. 
- The platform applied an extra Binance spread markup by default which should be removed so only platform fees apply.

### Description
- Set the default Binance liquidity spread to `0` in `api/src/app.js` and updated seed in `db/wallet.sql` so new installs start with no Binance spread.
- Added migration `db/migrations/202604121700_disable_binance_liquidity_spread.sql` to set `binance_liquidity_spread_bps=0` for existing environments (run manually if your deploy does not auto-run migrations). 
- Changed external fallback logic in `api/src/app.js` to attempt Binance execution for remaining quantity even for GTC limit orders (removed the previous restriction that limited attempts to immediate/cancel flows). 
- Added detailed `console.info`/`console.warn` logs around the external fallback lifecycle to improve observability (start, no-fill reason, filled details, skipped reason, and failure message).

### Testing
- Ran `npm run test:integration` and all integration tests passed (`19` tests, `0` failures).
- Ran `npm run build` and the Next.js production build completed successfully.
- Ran `npm run lint` and ESLint reported no warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db03410368832baa7c6b13e71844be)