### PR TITLE
feat(ai): add configurable Ollama/OpenAI LLM runtime across AI endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ STRIPE_MAX_PURCHASE_USD=
 STRIPE_SUCCESS_URL=
 STRIPE_CANCEL_URL=
 OPENAI_API_KEY=openai_api_key
+
+# LLM provider switch (Ollama/OpenAI)
+USE_OLLAMA=true
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=qwen3.5:2b
 CHAIN=bsc
 CHAIN_ID=56
 RPC_HTTP=https://bsc-dataseed.binance.org

--- a/README.md
+++ b/README.md
@@ -37,6 +37,23 @@ mysql -u <user> -p <database> < docs/sql/manual_swap_seed.sql
 ### Social platform tables (LordAi.Net)
 - شغّل ترحيل `db/migrations/202504050900_social_core.sql` علشان يتضاف نظام البروفايلات والبوستات والتفاعل و الـ Follow.
 
+
+### AI provider switching (OpenAI ↔ Ollama)
+
+The AI layer can now run through either OpenAI or a local Ollama server.
+
+Add these variables in both `.env` and `api/.env`:
+
+```env
+USE_OLLAMA=true
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=qwen3.5:2b
+```
+
+- `USE_OLLAMA=true` → routes AI calls to Ollama (`/api/chat`, `stream: false`).
+- `USE_OLLAMA=false` → falls back to OpenAI Chat Completions.
+- Admin panel (`/mo` → AI tab) shows the active provider/runtime model so you can verify the current mode quickly.
+
 ### ENV required (names only)
 ```
 CHAIN

--- a/api/.env.example
+++ b/api/.env.example
@@ -29,3 +29,9 @@ GOOGLE_OAUTH_REDIRECT_URI=https://lordai.net/auth/google/callback
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=
+
+
+# LLM provider switch (Ollama/OpenAI)
+USE_OLLAMA=true
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=qwen3.5:2b

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -22,7 +22,7 @@ const {
   isSupportedSwapAsset,
 } = require('./services/pricing');
 const { createDatabasePool } = require('./config/database');
-const { openaiClient } = require('./config/openai');
+const { callLLM, getLlmProviderSettings } = require('./services/llm');
 const { getEmailEnvDefaults } = require('./config/email');
 const { createStripeState, STRIPE_BASE_FALLBACK } = require('./config/stripe');
 const { requestIdMiddleware } = require('./middleware/requestId');
@@ -1063,6 +1063,20 @@ const AI_PRICE_SETTING_LEGACY = 'ai_message_price_eltx';
 const AI_BILLING_SYMBOL = 'USDT';
 const DEFAULT_AI_DAILY_FREE = 10;
 const DEFAULT_AI_PRICE = '1';
+const DEFAULT_AI_TEMPERATURE = 0.3;
+const DEFAULT_AI_TOP_P = 0.9;
+
+function getAiRuntimeConfig() {
+  const llm = getLlmProviderSettings();
+  return {
+    provider: llm.provider,
+    use_ollama: llm.useOllama,
+    ollama_base_url: llm.ollamaBaseUrl,
+    ollama_model: llm.ollamaModel,
+    openai_configured: llm.openaiConfigured,
+  };
+}
+
 const REFERRAL_REWARD_SETTING = 'referral_reward_eltx';
 const REFERRAL_FEE_SHARE_SETTING = 'referral_fee_share_bps';
 const DEFAULT_REFERRAL_REWARD = '0';
@@ -7669,7 +7683,7 @@ app.get('/admin/ai/settings', async (req, res, next) => {
     await requireAdmin(req);
     const today = getTodayDateString();
     const [settings, stats] = await Promise.all([readAiSettings(), readAiUsageSummary(today)]);
-    res.json({ ok: true, settings, stats, today });
+    res.json({ ok: true, settings, stats, today, runtime: getAiRuntimeConfig() });
   } catch (err) {
     next(err);
   }
@@ -7690,7 +7704,7 @@ app.patch('/admin/ai/settings', async (req, res, next) => {
     ]);
     const today = getTodayDateString();
     const [settings, stats] = await Promise.all([readAiSettings(), readAiUsageSummary(today)]);
-    res.json({ ok: true, settings, stats, today });
+    res.json({ ok: true, settings, stats, today, runtime: getAiRuntimeConfig() });
   } catch (err) {
     if (err instanceof z.ZodError)
       return next({ status: 400, code: 'BAD_INPUT', message: 'Invalid AI settings', details: err.flatten() });
@@ -9227,8 +9241,6 @@ app.post('/ai/chat', walletLimiter, async (req, res, next) => {
   let conn;
   try {
     const userId = await requireUser(req);
-    if (!openaiClient)
-      return next({ status: 503, code: 'AI_DISABLED', message: 'AI service is not configured' });
     const payload = AiChatSchema.parse(req.body || {});
     conn = await pool.getConnection();
     await conn.beginTransaction();
@@ -9273,11 +9285,13 @@ app.post('/ai/chat', walletLimiter, async (req, res, next) => {
       chargeType = 'usdt';
     }
 
-    const completion = await openaiClient.chat.completions.create({
-      model: 'gpt-3.5-turbo',
+    const llmResponse = await callLLM({
       messages: payload.messages,
+      temperature: DEFAULT_AI_TEMPERATURE,
+      top_p: DEFAULT_AI_TOP_P,
+      requestTag: `/ai/chat user=${userId}`,
     });
-    const message = completion.choices?.[0]?.message;
+    const message = llmResponse?.message;
     if (!message || !message.content) {
       await conn.rollback();
       return next({ status: 502, code: 'AI_EMPTY_RESPONSE', message: 'AI did not return a message' });
@@ -9327,6 +9341,8 @@ app.post('/ai/chat', walletLimiter, async (req, res, next) => {
     res.json({
       ok: true,
       message,
+      provider: llmResponse.provider,
+      model: llmResponse.model,
       usage,
       charge_type: chargeType,
       pricing: { message_price_usdt: settings.message_price_usdt, message_price_wei: priceWei.toString() },
@@ -9339,6 +9355,12 @@ app.post('/ai/chat', walletLimiter, async (req, res, next) => {
     if (conn) await conn.rollback().catch(() => {});
     if (err instanceof z.ZodError)
       return next({ status: 400, code: 'BAD_INPUT', message: 'Invalid messages payload', details: err.flatten() });
+    if (err?.code === 'OPENAI_DISABLED' || err?.code === 'OLLAMA_UNREACHABLE') {
+      return next({ status: 503, code: err.code, message: err.message, details: err.details || null });
+    }
+    if (err?.code === 'OLLAMA_HTTP_ERROR' || err?.code === 'OLLAMA_BAD_RESPONSE') {
+      return next({ status: 502, code: err.code, message: err.message, details: err.details || null });
+    }
     next(err);
   } finally {
     if (conn) conn.release();

--- a/api/src/services/llm.js
+++ b/api/src/services/llm.js
@@ -1,0 +1,167 @@
+const { openaiClient } = require('../config/openai');
+
+function parseBoolean(value, fallback = false) {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+    if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  }
+  return fallback;
+}
+
+function getLlmProviderSettings() {
+  const useOllama = parseBoolean(process.env.USE_OLLAMA, true);
+  const ollamaBaseUrl = (process.env.OLLAMA_BASE_URL || 'http://localhost:11434').replace(/\/$/, '');
+  const ollamaModel = process.env.OLLAMA_MODEL || 'qwen3.5:2b';
+  return {
+    useOllama,
+    provider: useOllama ? 'ollama' : 'openai',
+    ollamaBaseUrl,
+    ollamaModel,
+    openaiConfigured: !!openaiClient,
+  };
+}
+
+function normalizeMessages({ messages, systemPrompt, userPrompt }) {
+  const normalized = [];
+  if (Array.isArray(messages) && messages.length > 0) {
+    for (const msg of messages) {
+      if (!msg || typeof msg.content !== 'string') continue;
+      const role = msg.role === 'assistant' ? 'assistant' : msg.role === 'system' ? 'system' : 'user';
+      normalized.push({ role, content: msg.content });
+    }
+  }
+  if (!normalized.length && systemPrompt) normalized.push({ role: 'system', content: String(systemPrompt) });
+  if (!normalized.length && userPrompt) normalized.push({ role: 'user', content: String(userPrompt) });
+  if (normalized.length && systemPrompt && normalized[0].role !== 'system') {
+    normalized.unshift({ role: 'system', content: String(systemPrompt) });
+  }
+  if (!normalized.length) throw Object.assign(new Error('No LLM messages provided'), { code: 'LLM_MESSAGES_REQUIRED' });
+  return normalized;
+}
+
+async function callOpenAI({ messages, temperature, top_p, model }) {
+  if (!openaiClient) {
+    throw Object.assign(new Error('OpenAI client is not configured'), { code: 'OPENAI_DISABLED' });
+  }
+
+  const completion = await openaiClient.chat.completions.create({
+    model: model || process.env.OPENAI_MODEL || 'gpt-3.5-turbo',
+    messages,
+    temperature,
+    top_p,
+  });
+
+  const message = completion?.choices?.[0]?.message;
+  const content = typeof message?.content === 'string' ? message.content : '';
+  if (!content.trim()) throw Object.assign(new Error('OpenAI returned an empty response'), { code: 'AI_EMPTY_RESPONSE' });
+
+  return {
+    provider: 'openai',
+    model: completion?.model || model || process.env.OPENAI_MODEL || 'gpt-3.5-turbo',
+    message: { role: message.role || 'assistant', content },
+    raw: completion,
+  };
+}
+
+async function callOllama({ messages, temperature, top_p, model, baseUrl, requestTag }) {
+  const endpoint = `${baseUrl}/api/chat`;
+  const payload = {
+    model,
+    stream: false,
+    messages,
+    options: {
+      temperature: typeof temperature === 'number' ? temperature : 0.2,
+      top_p: typeof top_p === 'number' ? top_p : 0.9,
+    },
+  };
+
+  console.log('[llm] calling Ollama', { endpoint, model, requestTag, messageCount: messages.length, options: payload.options });
+
+  let response;
+  try {
+    response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  } catch (error) {
+    console.error('[llm] Ollama connection failed', { endpoint, model, requestTag, error: error?.message || error });
+    throw Object.assign(new Error('Failed to connect to Ollama service'), {
+      code: 'OLLAMA_UNREACHABLE',
+      details: { endpoint, originalError: error?.message || String(error) },
+    });
+  }
+
+  let data;
+  try {
+    data = await response.json();
+  } catch (error) {
+    console.error('[llm] Ollama invalid JSON response', { endpoint, status: response.status, requestTag });
+    throw Object.assign(new Error('Invalid JSON response from Ollama'), {
+      code: 'OLLAMA_BAD_RESPONSE',
+      details: { endpoint, status: response.status },
+    });
+  }
+
+  if (!response.ok) {
+    console.error('[llm] Ollama non-OK response', { endpoint, status: response.status, requestTag, body: data });
+    throw Object.assign(new Error(data?.error || 'Ollama request failed'), {
+      code: 'OLLAMA_HTTP_ERROR',
+      status: response.status,
+      details: data,
+    });
+  }
+
+  const content = data?.message?.content;
+  if (typeof content !== 'string' || !content.trim()) {
+    console.error('[llm] Ollama empty message content', { endpoint, status: response.status, requestTag, body: data });
+    throw Object.assign(new Error('Ollama returned an empty response'), { code: 'AI_EMPTY_RESPONSE' });
+  }
+
+  return {
+    provider: 'ollama',
+    model,
+    message: { role: 'assistant', content },
+    raw: data,
+  };
+}
+
+async function callLLM({
+  messages,
+  systemPrompt,
+  userPrompt,
+  temperature,
+  top_p,
+  requestTag = 'general',
+  model,
+} = {}) {
+  const providerSettings = getLlmProviderSettings();
+  const normalizedMessages = normalizeMessages({ messages, systemPrompt, userPrompt });
+
+  console.log('[llm] request started', {
+    provider: providerSettings.provider,
+    requestTag,
+    model: providerSettings.useOllama ? providerSettings.ollamaModel : process.env.OPENAI_MODEL || 'gpt-3.5-turbo',
+    messages: normalizedMessages.length,
+  });
+
+  if (!providerSettings.useOllama) {
+    return callOpenAI({ messages: normalizedMessages, temperature, top_p, model });
+  }
+
+  return callOllama({
+    messages: normalizedMessages,
+    temperature,
+    top_p,
+    requestTag,
+    model: model || providerSettings.ollamaModel,
+    baseUrl: providerSettings.ollamaBaseUrl,
+  });
+}
+
+module.exports = {
+  callLLM,
+  getLlmProviderSettings,
+};

--- a/app/api/ai/route.ts
+++ b/app/api/ai/route.ts
@@ -1,31 +1,58 @@
-import OpenAI from 'openai';
+import { callLLM, extractJsonObject } from '../../lib/llm';
+
+const JSON_ONLY_SYSTEM_PROMPT = [
+  'You are a strict JSON generator.',
+  'Return valid JSON only with no markdown and no extra text.',
+  'If unsure, return: {"ok":false,"reason":"not_enough_info"}.',
+  'Example input: "name=Ali, age=21".',
+  'Example output: {"ok":true,"name":"Ali","age":21}.',
+].join(' ');
 
 export async function POST(request: Request) {
-  if (!process.env.OPENAI_API_KEY) {
-    console.error('ai endpoint error', 'OPENAI_API_KEY missing');
-    return new Response(JSON.stringify({ error: 'AI service not configured' }), {
-      status: 500,
-    });
-  }
-
-  const { messages } = await request.json();
-  if (!Array.isArray(messages)) {
-    return new Response(JSON.stringify({ error: 'Invalid messages' }), { status: 400 });
-  }
-
   try {
-    const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
-    const completion = await client.chat.completions.create({
-      model: 'gpt-3.5-turbo',
-      messages,
+    const body = await request.json();
+    const { messages, expect_json } = body || {};
+
+    if (!Array.isArray(messages)) {
+      return new Response(JSON.stringify({ error: 'Invalid messages' }), { status: 400 });
+    }
+
+    const mergedMessages = expect_json
+      ? [{ role: 'system', content: JSON_ONLY_SYSTEM_PROMPT }, ...messages]
+      : messages;
+
+    const result = await callLLM({
+      messages: mergedMessages,
+      temperature: typeof body?.temperature === 'number' ? body.temperature : 0.2,
+      top_p: typeof body?.top_p === 'number' ? body.top_p : 0.9,
     });
 
-    return new Response(
-      JSON.stringify({ message: completion.choices[0].message }),
-      { status: 200 }
-    );
+    if (expect_json) {
+      try {
+        const parsed = extractJsonObject(result.message.content);
+        return new Response(JSON.stringify({ message: result.message, parsed, provider: result.provider, model: result.model }), {
+          status: 200,
+        });
+      } catch (parseError) {
+        console.error('ai endpoint JSON parse error', parseError);
+        return new Response(
+          JSON.stringify({
+            error: 'Model returned invalid JSON',
+            provider: result.provider,
+            model: result.model,
+            raw: result.message.content,
+          }),
+          { status: 502 }
+        );
+      }
+    }
+
+    return new Response(JSON.stringify({ message: result.message, provider: result.provider, model: result.model }), {
+      status: 200,
+    });
   } catch (error) {
     console.error('ai endpoint error', error);
-    return new Response(JSON.stringify({ error: 'AI request failed' }), { status: 500 });
+    const message = error instanceof Error ? error.message : 'AI request failed';
+    return new Response(JSON.stringify({ error: message }), { status: 500 });
   }
 }

--- a/app/lib/llm.ts
+++ b/app/lib/llm.ts
@@ -1,0 +1,133 @@
+const DEFAULT_OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-3.5-turbo';
+
+function parseBoolean(value: string | undefined, fallback: boolean) {
+  if (typeof value !== 'string') return fallback;
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return fallback;
+}
+
+export type LlmMessage = { role: 'system' | 'user' | 'assistant'; content: string };
+
+export function getLlmRuntime() {
+  const useOllama = parseBoolean(process.env.USE_OLLAMA, true);
+  return {
+    useOllama,
+    provider: useOllama ? 'ollama' : 'openai',
+    ollamaBaseUrl: (process.env.OLLAMA_BASE_URL || 'http://localhost:11434').replace(/\/$/, ''),
+    ollamaModel: process.env.OLLAMA_MODEL || 'qwen3.5:2b',
+    hasOpenAiKey: Boolean(process.env.OPENAI_API_KEY),
+  };
+}
+
+function normalizeMessages(messages: unknown): LlmMessage[] {
+  if (!Array.isArray(messages)) return [];
+  return messages
+    .map((msg) => {
+      if (!msg || typeof msg !== 'object') return null;
+      const role = (msg as { role?: string }).role;
+      const content = (msg as { content?: string }).content;
+      if (typeof content !== 'string' || !content.trim()) return null;
+      if (role !== 'system' && role !== 'user' && role !== 'assistant') return null;
+      return { role, content } as LlmMessage;
+    })
+    .filter((msg): msg is LlmMessage => Boolean(msg));
+}
+
+export function extractJsonObject(rawText: string) {
+  const trimmed = rawText.trim();
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const firstBrace = trimmed.indexOf('{');
+    const lastBrace = trimmed.lastIndexOf('}');
+    if (firstBrace >= 0 && lastBrace > firstBrace) {
+      const maybe = trimmed.slice(firstBrace, lastBrace + 1);
+      return JSON.parse(maybe);
+    }
+    throw new Error('Could not parse JSON from model response');
+  }
+}
+
+export async function callLLM({
+  messages,
+  temperature = 0.2,
+  top_p = 0.9,
+}: {
+  messages: unknown;
+  temperature?: number;
+  top_p?: number;
+}) {
+  const runtime = getLlmRuntime();
+  const normalizedMessages = normalizeMessages(messages);
+
+  if (!normalizedMessages.length) {
+    throw Object.assign(new Error('Invalid messages payload'), { code: 'BAD_MESSAGES' });
+  }
+
+  if (runtime.useOllama) {
+    const endpoint = `${runtime.ollamaBaseUrl}/api/chat`;
+    const body = {
+      model: runtime.ollamaModel,
+      stream: false,
+      messages: normalizedMessages,
+      options: { temperature, top_p },
+    };
+
+    console.log('[app/api/ai] Ollama request', { endpoint, model: runtime.ollamaModel, messageCount: normalizedMessages.length });
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await response.json();
+
+    if (!response.ok) {
+      console.error('[app/api/ai] Ollama error', { status: response.status, data });
+      throw Object.assign(new Error(data?.error || 'Ollama request failed'), { code: 'OLLAMA_HTTP_ERROR', status: response.status });
+    }
+
+    const content = data?.message?.content;
+    if (typeof content !== 'string' || !content.trim()) {
+      throw Object.assign(new Error('Ollama returned empty content'), { code: 'AI_EMPTY_RESPONSE' });
+    }
+
+    return {
+      provider: 'ollama' as const,
+      model: runtime.ollamaModel,
+      message: { role: 'assistant' as const, content },
+    };
+  }
+
+  if (!runtime.hasOpenAiKey) {
+    throw Object.assign(new Error('OPENAI_API_KEY missing'), { code: 'OPENAI_DISABLED' });
+  }
+
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+    },
+    body: JSON.stringify({ model: DEFAULT_OPENAI_MODEL, messages: normalizedMessages, temperature, top_p }),
+  });
+  const data = await response.json();
+
+  if (!response.ok) {
+    console.error('[app/api/ai] OpenAI error', { status: response.status, data });
+    throw Object.assign(new Error(data?.error?.message || 'OpenAI request failed'), { code: 'OPENAI_HTTP_ERROR', status: response.status });
+  }
+
+  const content = data?.choices?.[0]?.message?.content;
+  if (typeof content !== 'string' || !content.trim()) {
+    throw Object.assign(new Error('OpenAI returned empty content'), { code: 'AI_EMPTY_RESPONSE' });
+  }
+
+  return {
+    provider: 'openai' as const,
+    model: data?.model || DEFAULT_OPENAI_MODEL,
+    message: { role: 'assistant' as const, content },
+  };
+}

--- a/app/mo/AdminApp.tsx
+++ b/app/mo/AdminApp.tsx
@@ -140,6 +140,13 @@ type FeeSettings = {
 type FeeBalanceRow = { fee_type: 'swap' | 'spot' | 'withdrawal' | string; asset: string; amount: string; amount_wei: string; entries: number };
 
 type AiSettings = { daily_free_messages: number; message_price_usdt: string };
+type AiRuntime = {
+  provider: 'ollama' | 'openai';
+  use_ollama: boolean;
+  ollama_base_url: string;
+  ollama_model: string;
+  openai_configured: boolean;
+};
 type FeedAlgorithmSettings = {
   followingRatio: number;
   forYouRatio: number;
@@ -158,7 +165,7 @@ type FeedAlgorithmSettings = {
   topMonthlyItems: number;
 };
 type AiStats = { messages_used: number; paid_messages: number; free_messages: number; usdt_spent: string; usdt_spent_wei: string };
-type AiSettingsResponse = { settings: AiSettings; stats: AiStats; today?: string };
+type AiSettingsResponse = { settings: AiSettings; stats: AiStats; today?: string; runtime?: AiRuntime };
 
 type ReferralSettings = { reward_eltx: string; fee_share_bps: string };
 type ReferralSettingsPayload = { reward_eltx: string; fee_share_bps: string | number };
@@ -507,6 +514,7 @@ function AiPanel({ onNotify }: { onNotify: (message: string, variant?: 'success'
   const [stats, setStats] = useState<AiStats | null>(null);
   const [today, setToday] = useState<string>('');
   const [form, setForm] = useState<AiSettings>({ daily_free_messages: 10, message_price_usdt: '1' });
+  const [runtime, setRuntime] = useState<AiRuntime | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -516,6 +524,7 @@ function AiPanel({ onNotify }: { onNotify: (message: string, variant?: 'success'
       setStats(res.data.stats);
       setForm(res.data.settings);
       setToday(res.data.today || '');
+      setRuntime(res.data.runtime || null);
     } else {
       onNotify(res.error || 'Failed to load AI settings', 'error');
     }
@@ -540,6 +549,7 @@ function AiPanel({ onNotify }: { onNotify: (message: string, variant?: 'success'
       setStats(res.data.stats);
       setForm(res.data.settings);
       setToday(res.data.today || '');
+      setRuntime(res.data.runtime || null);
       onNotify('AI settings updated');
     } else {
       onNotify(res.error || 'Failed to update AI settings', 'error');
@@ -563,6 +573,21 @@ function AiPanel({ onNotify }: { onNotify: (message: string, variant?: 'success'
           </button>
           {today && <span className="rounded-full border border-white/10 px-3 py-1 text-xs text-white/60">{today}</span>}
         </div>
+      </div>
+
+      <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-white/75">
+        <p className="text-xs uppercase tracking-wide text-white/60">LLM runtime</p>
+        {runtime ? (
+          <div className="mt-2 grid gap-2 sm:grid-cols-2">
+            <p>Provider: <span className="font-semibold text-white">{runtime.provider}</span></p>
+            <p>Ollama mode: <span className="font-semibold text-white">{runtime.use_ollama ? 'enabled' : 'disabled'}</span></p>
+            <p>Ollama URL: <span className="font-semibold text-white">{runtime.ollama_base_url}</span></p>
+            <p>Model: <span className="font-semibold text-white">{runtime.ollama_model}</span></p>
+            <p>OpenAI key: <span className="font-semibold text-white">{runtime.openai_configured ? 'configured' : 'missing'}</span></p>
+          </div>
+        ) : (
+          <p className="mt-2 text-white/60">Runtime details are not available yet.</p>
+        )}
       </div>
 
       <form
@@ -703,7 +728,6 @@ function ReferralPanel({ onNotify }: { onNotify: (message: string, variant?: 'su
           Sync
         </button>
       </div>
-
       <form
         onSubmit={handleSubmit}
         className="space-y-4 rounded-2xl border border-white/10 bg-white/5 p-5 shadow-inner shadow-black/30"


### PR DESCRIPTION
### Motivation

- Replace direct OpenAI Chat Completions calls with a pluggable local LLM (Ollama qwen3.5:2b) while preserving existing behavior and DB shape. 
- Centralize LLM calls so all AI endpoints share consistent message normalization, temperature/top_p control, logging and robust error handling. 
- Expose runtime/provider metadata to the admin UI so operators can verify which backend is active. 
- Keep prompt templates and DB schema unchanged while ensuring JSON-structured outputs are enforced when required.

### Description

- Added new environment toggles in both `./.env.example` and `api/.env.example`: `USE_OLLAMA`, `OLLAMA_BASE_URL`, and `OLLAMA_MODEL` to select Ollama vs OpenAI and configure the local server and model. 
- Introduced a centralized API-side LLM service `api/src/services/llm.js` implementing `callLLM` and `getLlmProviderSettings` that: normalizes messages, supports OpenAI fallback, calls Ollama `/api/chat` with `stream: false`, forwards `temperature` and `top_p`, extracts `response.message.content`, and provides detailed logging and error codes for connection/HTTP/JSON issues. 
- Replaced direct OpenAI usage in the API (`/ai/chat`) with `callLLM`, added `DEFAULT_AI_TEMPERATURE`/`DEFAULT_AI_TOP_P`, returned `provider` and `model` metadata in responses, and mapped Ollama/OpenAI errors to appropriate HTTP responses. 
- Added a frontend LLM helper `app/lib/llm.ts` and migrated `app/api/ai/route.ts` to use it; added an optional strict JSON mode (`expect_json`) that prepends a strong JSON-only `system` prompt and uses a fallback `extractJsonObject` to parse model output. 
- Updated admin UI `app/mo/AdminApp.tsx` to display LLM runtime info (provider, Ollama enabled flag, base URL, model, OpenAI key state) in the AI settings panel. 
- Documented switching in `README.md`. 
- Added detailed console logging in both API and app LLM helpers; preserved all existing prompt templates and database structure (no schema migrations). 
- New/modified files: `api/src/services/llm.js`, `app/lib/llm.ts`, `app/api/ai/route.ts`, `api/src/app.js` (patched), `app/mo/AdminApp.tsx` (patched), `.env.example`, `api/.env.example`, `README.md`.

### Testing

- Ran type checking with `npm run typecheck` and it succeeded. 
- Ran lint with `npm run lint` and it succeeded. 
- Performed a production build with `npm run build` and it completed successfully. 
- Executed integration tests `npm run test:integration` and all tests passed. 
- Started the dev server with `npm run dev` successfully and validated the admin AI panel route; attempted a Playwright screenshot after `npx playwright install chromium` but the screenshot step failed due to a missing system library in the container (`libatk-1.0.so.0`), not due to repository code. 

If you want, I can next harden JSON schema validation for specific rule-generator prompts, add server-side few-shot examples into system prompts for the 2B model, or provide the exact SQL to run if any future DB migration becomes necessary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e29cbaf5b8832b8c3e3426eadce4f4)