### PR TITLE
Configurable spot external execution/provider and improved Binance order validation

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -47,7 +47,10 @@ const DEFAULT_MARKET_MAKER_REFRESH_MINUTES = 30;
 const DEFAULT_MARKET_MAKER_TARGET_BASE_PCT = 50;
 const DEFAULT_BINANCE_LIQUIDITY_ENABLED = false;
 const DEFAULT_BINANCE_LIQUIDITY_SPREAD_BPS = 0;
+const DEFAULT_SPOT_EXTERNAL_EXECUTION_ENABLED = DEFAULT_BINANCE_LIQUIDITY_ENABLED;
+const DEFAULT_SPOT_LIQUIDITY_PROVIDER = 'binance';
 const BINANCE_RECV_WINDOW_MS = 5_000;
+const BINANCE_EXCHANGE_INFO_TTL_MS = 60_000;
 const ELTX_SYMBOL = 'ELTX';
 const STRIPE_SUPPORTED_ASSETS = [ELTX_SYMBOL, 'USDT'];
 const WITHDRAWAL_ASSETS = [ELTX_SYMBOL, 'USDT'];
@@ -719,6 +722,8 @@ const MarketMakerSettingsSchema = z
     target_base_pct: z.coerce.number().min(1).max(99).optional(),
     binance_liquidity_enabled: z.boolean().optional(),
     binance_liquidity_spread_bps: z.coerce.number().int().min(0).max(5000).optional(),
+    spot_external_execution_enabled: z.boolean().optional(),
+    spot_liquidity_provider: z.enum(['binance', 'internal']).optional(),
   })
   .refine(
     (data) =>
@@ -729,7 +734,9 @@ const MarketMakerSettingsSchema = z
       data.pairs !== undefined ||
       data.target_base_pct !== undefined ||
       data.binance_liquidity_enabled !== undefined ||
-      data.binance_liquidity_spread_bps !== undefined,
+      data.binance_liquidity_spread_bps !== undefined ||
+      data.spot_external_execution_enabled !== undefined ||
+      data.spot_liquidity_provider !== undefined,
     { message: 'At least one market maker field must be provided' }
   );
 
@@ -2799,6 +2806,16 @@ async function readMarketMakerSettings(conn = pool) {
     DEFAULT_BINANCE_LIQUIDITY_ENABLED ? '1' : '0',
     conn
   );
+  const externalExecutionEnabledRaw = await getPlatformSettingValue(
+    'spot_external_execution_enabled',
+    binanceEnabledRaw || (DEFAULT_SPOT_EXTERNAL_EXECUTION_ENABLED ? '1' : '0'),
+    conn
+  );
+  const liquidityProviderRaw = await getPlatformSettingValue(
+    'spot_liquidity_provider',
+    DEFAULT_SPOT_LIQUIDITY_PROVIDER,
+    conn
+  );
   const binanceSpreadRaw = await getPlatformSettingValue(
     'binance_liquidity_spread_bps',
     DEFAULT_BINANCE_LIQUIDITY_SPREAD_BPS.toString(),
@@ -2809,6 +2826,9 @@ async function readMarketMakerSettings(conn = pool) {
   const refreshMinutes = Number.parseInt(refreshRaw, 10);
   const targetPct = Number.parseInt(targetPctRaw, 10);
   const binanceSpread = Number.parseInt(binanceSpreadRaw, 10);
+  const spotLiquidityProvider = String(liquidityProviderRaw || DEFAULT_SPOT_LIQUIDITY_PROVIDER).toLowerCase();
+  const spotExternalExecutionEnabled =
+    externalExecutionEnabledRaw === '1' || externalExecutionEnabledRaw?.toLowerCase?.() === 'true';
   return {
     enabled: enabledRaw === '1' || enabledRaw?.toLowerCase?.() === 'true',
     spread_bps: Number.isFinite(spread) ? spread : DEFAULT_MARKET_MAKER_SPREAD_BPS,
@@ -2821,10 +2841,12 @@ async function readMarketMakerSettings(conn = pool) {
           .filter(Boolean)
       : [],
     target_base_pct: Number.isFinite(targetPct) ? targetPct : DEFAULT_MARKET_MAKER_TARGET_BASE_PCT,
-    binance_liquidity_enabled: binanceEnabledRaw === '1' || binanceEnabledRaw?.toLowerCase?.() === 'true',
+    binance_liquidity_enabled: spotExternalExecutionEnabled && spotLiquidityProvider === 'binance',
     binance_liquidity_spread_bps: Number.isFinite(binanceSpread)
       ? Math.max(0, Math.min(5000, binanceSpread))
       : DEFAULT_BINANCE_LIQUIDITY_SPREAD_BPS,
+    spot_external_execution_enabled: spotExternalExecutionEnabled,
+    spot_liquidity_provider: spotLiquidityProvider === 'internal' ? 'internal' : 'binance',
   };
 }
 
@@ -2839,10 +2861,20 @@ async function updateMarketMakerSettings(partial) {
     tasks.push(setPlatformSettingValue('market_maker_pairs', partial.pairs.map((p) => p.trim().toUpperCase()).join(',')));
   if (partial.target_base_pct !== undefined)
     tasks.push(setPlatformSettingValue('market_maker_target_base_pct', partial.target_base_pct.toString()));
-  if (partial.binance_liquidity_enabled !== undefined)
+  if (partial.binance_liquidity_enabled !== undefined) {
     tasks.push(setPlatformSettingValue('binance_liquidity_enabled', partial.binance_liquidity_enabled ? '1' : '0'));
+    tasks.push(setPlatformSettingValue('spot_external_execution_enabled', partial.binance_liquidity_enabled ? '1' : '0'));
+  }
   if (partial.binance_liquidity_spread_bps !== undefined)
     tasks.push(setPlatformSettingValue('binance_liquidity_spread_bps', partial.binance_liquidity_spread_bps.toString()));
+  if (partial.spot_external_execution_enabled !== undefined)
+    tasks.push(
+      setPlatformSettingValue('spot_external_execution_enabled', partial.spot_external_execution_enabled ? '1' : '0')
+    );
+  if (partial.spot_liquidity_provider !== undefined)
+    tasks.push(
+      setPlatformSettingValue('spot_liquidity_provider', partial.spot_liquidity_provider === 'internal' ? 'internal' : 'binance')
+    );
   if (!tasks.length) return;
   await Promise.all(tasks);
 }
@@ -2917,6 +2949,54 @@ function getBinanceConfig() {
   };
 }
 
+const binanceExchangeInfoCache = new Map();
+
+function normalizeBinanceTimeInForce(value, fallback = 'GTC') {
+  const tif = String(value || fallback).toUpperCase();
+  return ['GTC', 'IOC', 'FOK'].includes(tif) ? tif : String(fallback || 'GTC').toUpperCase();
+}
+
+function floorToStepDecimal(valueRaw, stepRaw) {
+  try {
+    const value = new Decimal(String(valueRaw || '0'));
+    const step = new Decimal(String(stepRaw || '0'));
+    if (!value.isFinite() || value.lte(0)) return '0';
+    if (!step.isFinite() || step.lte(0)) return trimDecimal(value.toFixed(18, Decimal.ROUND_DOWN));
+    const floored = value.div(step).floor().mul(step);
+    return trimDecimal(floored.toFixed(18, Decimal.ROUND_DOWN));
+  } catch {
+    return '0';
+  }
+}
+
+async function fetchBinanceSymbolFilters(marketRow) {
+  const cfg = getBinanceConfig();
+  if (cfg.mockMode) return null;
+  const symbol = toBinanceSymbol(marketRow.symbol);
+  const cacheKey = `${cfg.baseUrl}:${symbol}`;
+  const cached = binanceExchangeInfoCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) return cached.value;
+
+  const url = new URL('/api/v3/exchangeInfo', cfg.baseUrl);
+  url.searchParams.set('symbol', symbol);
+  const response = await fetch(url.toString(), { method: 'GET' });
+  if (!response.ok) throw new Error(`Binance exchangeInfo failed (${response.status})`);
+  const payload = await response.json().catch(() => ({}));
+  const row = Array.isArray(payload?.symbols) ? payload.symbols[0] : null;
+  if (!row) throw new Error('Binance exchangeInfo missing symbol');
+  const filters = Array.isArray(row.filters) ? row.filters : [];
+  const byType = Object.fromEntries(filters.map((f) => [String(f.filterType || '').toUpperCase(), f]));
+  const value = {
+    symbol,
+    lotSizeStep: byType.LOT_SIZE?.stepSize || null,
+    marketLotSizeStep: byType.MARKET_LOT_SIZE?.stepSize || null,
+    tickSize: byType.PRICE_FILTER?.tickSize || null,
+    minNotional: byType.NOTIONAL?.minNotional || byType.MIN_NOTIONAL?.minNotional || null,
+  };
+  binanceExchangeInfoCache.set(cacheKey, { value, expiresAt: Date.now() + BINANCE_EXCHANGE_INFO_TTL_MS });
+  return value;
+}
+
 function toBinanceSymbol(symbol) {
   return String(symbol || '')
     .toUpperCase()
@@ -2977,8 +3057,13 @@ function buildSyntheticDepthSnapshot(marketRow, limit = 50) {
 async function readBinanceLiquidityState(conn = pool) {
   const settings = await readMarketMakerSettings(conn);
   const cfg = getBinanceConfig();
+  const provider = settings.spot_liquidity_provider === 'internal' ? 'internal' : 'binance';
+  const externalExecutionEnabled = !!settings.spot_external_execution_enabled;
+  const enabled = externalExecutionEnabled && provider === 'binance';
   return {
-    enabled: !!settings.binance_liquidity_enabled,
+    enabled,
+    provider,
+    externalExecutionEnabled,
     spreadBps: Number(settings.binance_liquidity_spread_bps || 0),
     configured: cfg.configured,
     mockMode: cfg.mockMode,
@@ -3056,6 +3141,7 @@ async function executeBinanceMarketOrder(marketRow, side, { quantityWei, quoteOr
     };
   }
   if (!cfg.configured) throw new Error('Binance API credentials are not configured');
+  const filters = await fetchBinanceSymbolFilters(marketRow);
   const symbol = toBinanceSymbol(marketRow.symbol);
   const params = new URLSearchParams();
   params.set('symbol', symbol);
@@ -3064,14 +3150,27 @@ async function executeBinanceMarketOrder(marketRow, side, { quantityWei, quoteOr
   params.set('newOrderRespType', 'FULL');
   if (side === 'buy') {
     if (quoteOrderQtyWei && quoteOrderQtyWei > 0n) {
-      params.set('quoteOrderQty', trimDecimal(formatUnitsStr(quoteOrderQtyWei.toString(), marketRow.quote_decimals)));
+      const quoteRaw = trimDecimal(formatUnitsStr(quoteOrderQtyWei.toString(), marketRow.quote_decimals));
+      let quoteOrderQty = quoteRaw;
+      if (filters?.minNotional) {
+        const minNotional = new Decimal(String(filters.minNotional));
+        const quoteValue = new Decimal(quoteRaw || '0');
+        if (quoteValue.gt(0) && quoteValue.lt(minNotional)) quoteOrderQty = trimDecimal(minNotional.toFixed(18));
+      }
+      params.set('quoteOrderQty', quoteOrderQty);
     } else if (quantityWei && quantityWei > 0n) {
-      params.set('quantity', trimDecimal(formatUnitsStr(quantityWei.toString(), marketRow.base_decimals)));
+      const quantityRaw = trimDecimal(formatUnitsStr(quantityWei.toString(), marketRow.base_decimals));
+      const quantity = floorToStepDecimal(quantityRaw, filters?.marketLotSizeStep || filters?.lotSizeStep || '0');
+      if (!quantity || quantity === '0') throw new Error('Binance quantity below LOT_SIZE step');
+      params.set('quantity', quantity);
     } else {
       throw new Error('Missing buy quantity');
     }
   } else if (quantityWei && quantityWei > 0n) {
-    params.set('quantity', trimDecimal(formatUnitsStr(quantityWei.toString(), marketRow.base_decimals)));
+    const quantityRaw = trimDecimal(formatUnitsStr(quantityWei.toString(), marketRow.base_decimals));
+    const quantity = floorToStepDecimal(quantityRaw, filters?.marketLotSizeStep || filters?.lotSizeStep || '0');
+    if (!quantity || quantity === '0') throw new Error('Binance quantity below LOT_SIZE step');
+    params.set('quantity', quantity);
   } else {
     throw new Error('Missing sell quantity');
   }
@@ -3118,15 +3217,22 @@ async function executeBinanceLimitOrder(marketRow, side, { quantityWei, priceWei
   if (!cfg.configured) throw new Error('Binance API credentials are not configured');
   if (!quantityWei || quantityWei <= 0n) throw new Error('Missing limit quantity');
   if (!priceWei || priceWei <= 0n) throw new Error('Missing limit price');
+  const filters = await fetchBinanceSymbolFilters(marketRow);
 
   const symbol = toBinanceSymbol(marketRow.symbol);
   const params = new URLSearchParams();
   params.set('symbol', symbol);
   params.set('side', side.toUpperCase());
   params.set('type', 'LIMIT');
-  params.set('timeInForce', String(timeInForce || 'GTC').toUpperCase());
-  params.set('quantity', trimDecimal(formatUnitsStr(quantityWei.toString(), marketRow.base_decimals)));
-  params.set('price', trimDecimal(formatUnitsStr(priceWei.toString(), 18)));
+  params.set('timeInForce', normalizeBinanceTimeInForce(timeInForce, 'GTC'));
+  const quantityRaw = trimDecimal(formatUnitsStr(quantityWei.toString(), marketRow.base_decimals));
+  const quantity = floorToStepDecimal(quantityRaw, filters?.lotSizeStep || '0');
+  if (!quantity || quantity === '0') throw new Error('Binance quantity below LOT_SIZE step');
+  const priceRaw = trimDecimal(formatUnitsStr(priceWei.toString(), 18));
+  const normalizedPrice = floorToStepDecimal(priceRaw, filters?.tickSize || '0');
+  if (!normalizedPrice || normalizedPrice === '0') throw new Error('Binance price below PRICE_FILTER tick');
+  params.set('quantity', quantity);
+  params.set('price', normalizedPrice);
   params.set('newOrderRespType', 'FULL');
   params.set('recvWindow', String(BINANCE_RECV_WINDOW_MS));
   params.set('timestamp', String(Date.now()));
@@ -10838,7 +10944,9 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
       await conn.rollback();
       return next({ status: 404, code: 'MARKET_NOT_FOUND', message: 'Market not available' });
     }
-    if (type === 'market' && market.allow_market_orders === 0) {
+    const liquidityState = await readBinanceLiquidityState(conn);
+    const canRouteMarketExternally = liquidityState.enabled && (liquidityState.configured || liquidityState.mockMode);
+    if (type === 'market' && market.allow_market_orders === 0 && !canRouteMarketExternally) {
       await conn.rollback();
       return next({ status: 400, code: 'MARKET_ORDER_DISABLED', message: 'Market orders disabled for this market' });
     }
@@ -10885,7 +10993,6 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
 
     const feeSettings = await readSpotFeeBps(conn);
     const riskSettings = await readSpotRiskSettings(conn);
-    const liquidityState = await readBinanceLiquidityState(conn);
     const marketMakerSettings = await readMarketMakerSettings(conn);
     const makerFeeBps = clampBps(BigInt(feeSettings.maker || 0));
     const takerFeeBps = clampBps(BigInt(feeSettings.taker || 0));
@@ -11040,6 +11147,8 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
     const shouldExternalFallback = liquidityState.enabled && (liquidityState.configured || liquidityState.mockMode);
     let externalFallbackAttempted = false;
     let externalFallbackError = null;
+    let externalRestingOrderId = null;
+    let externalRestingStatus = null;
     if (shouldExternalFallback && taker.remainingBase > 0n) {
       try {
         externalFallbackAttempted = true;
@@ -11055,7 +11164,84 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
           takerFeeBps,
           limitPriceWei: type === 'limit' ? priceWei : 0n,
         });
-        if (externalPlan.filledBaseWei > 0n && externalPlan.quoteWithoutFeeWei > 0n) {
+        if (type === 'limit') {
+          let executedBase = 0n;
+          const externalLimitOrder = await executeBinanceLimitOrder(market, side, {
+            quantityWei: taker.remainingBase,
+            priceWei,
+            timeInForce: String(timeInForce || 'gtc').toUpperCase(),
+          });
+          executedBase = bigIntFromValue(externalLimitOrder.executedBaseWei);
+          if (executedBase > 0n) {
+            const externalQuoteRaw = bigIntFromValue(externalLimitOrder.quoteWithoutFeeWei);
+            const externalQuote =
+              externalQuoteRaw > 0n ? externalQuoteRaw : computeQuoteAmount(executedBase, externalLimitOrder.averagePriceWei || priceWei);
+            const externalAveragePriceWei =
+              externalLimitOrder.averagePriceWei && externalLimitOrder.averagePriceWei > 0n
+                ? externalLimitOrder.averagePriceWei
+                : priceWei;
+            const externalFee = (externalQuote * takerFeeBps) / 10000n;
+            const [tradeInsert] = await conn.query(
+              'INSERT INTO spot_trades (market_id, buy_order_id, sell_order_id, price_wei, base_amount_wei, quote_amount_wei, buy_fee_wei, sell_fee_wei, fee_asset, taker_side) VALUES (?,?,?,?,?,?,?,?,?,?)',
+              [
+                market.id,
+                orderId,
+                orderId,
+                externalAveragePriceWei.toString(),
+                executedBase.toString(),
+                externalQuote.toString(),
+                side === 'buy' ? externalFee.toString() : '0',
+                side === 'sell' ? externalFee.toString() : '0',
+                market.quote_asset,
+                side,
+              ]
+            );
+            const tradeId = tradeInsert.insertId;
+            if (externalFee > 0n) {
+              await conn.query('INSERT INTO platform_fees (fee_type, reference, asset, amount_wei) VALUES (?,?,?,?)', [
+                'spot',
+                `trade:${tradeId}:external:taker`,
+                market.quote_asset,
+                externalFee.toString(),
+              ]);
+            }
+            if (side === 'buy') {
+              matchResult.spentQuote += externalQuote + externalFee;
+              matchResult.receivedBase += executedBase;
+            } else {
+              matchResult.receivedQuote += externalQuote - externalFee;
+            }
+            matchResult.takerFee += externalFee;
+            matchResult.filledBase += executedBase;
+            taker.remainingBase -= executedBase;
+            matchResult.averagePriceWei = recalculateMatchAveragePrice(matchResult, side);
+            matchResult.trades.push({
+              trade_id: tradeId,
+              maker_order_id: null,
+              maker_user_id: null,
+              price_wei: externalAveragePriceWei,
+              base_amount_wei: executedBase,
+              quote_amount_wei: externalQuote,
+              taker_fee_wei: externalFee,
+              maker_fee_wei: 0n,
+              external_liquidity: true,
+            });
+          }
+          const isGtc = timeInForce === 'gtc';
+          if (isGtc && taker.remainingBase > 0n && externalLimitOrder.externalOrderId) {
+            externalRestingOrderId = externalLimitOrder.externalOrderId;
+            externalRestingStatus = externalLimitOrder.status || 'NEW';
+          }
+          if (executedBase <= 0n && !externalRestingOrderId) {
+            console.info(
+              `[spot] external fallback no-fill: orderId=${orderId} market=${market.symbol} side=${side} type=${type} tif=${timeInForce} reason=limit_or_depth_constraints`
+            );
+          } else {
+            console.info(
+              `[spot] external fallback filled: orderId=${orderId} executedBaseWei=${executedBase.toString()} externalOrderId=${externalLimitOrder.externalOrderId || 'n/a'} status=${externalLimitOrder.status || 'UNKNOWN'}`
+            );
+          }
+        } else if (externalPlan.filledBaseWei > 0n && externalPlan.quoteWithoutFeeWei > 0n) {
           const externalOrder = await executeBinanceMarketOrder(market, side, {
             quantityWei: externalPlan.filledBaseWei,
             quoteOrderQtyWei: side === 'buy' ? externalPlan.quoteWithoutFeeWei : 0n,
@@ -11121,7 +11307,7 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
           console.info(
             `[spot] external fallback filled: orderId=${orderId} tradeId=${tradeId} executedBaseWei=${externalBase.toString()} executedQuoteWei=${externalQuote.toString()} avgPriceWei=${externalAveragePriceWei.toString()}`
           );
-        } else {
+        } else if (type !== 'limit') {
           console.info(
             `[spot] external fallback no-fill: orderId=${orderId} market=${market.symbol} side=${side} type=${type} tif=${timeInForce} reason=limit_or_depth_constraints`
           );

--- a/app/mo/AdminApp.tsx
+++ b/app/mo/AdminApp.tsx
@@ -340,6 +340,8 @@ type MarketMakerSettings = {
   pairs: string[];
   target_base_pct: number;
   binance_liquidity_enabled: boolean;
+  spot_external_execution_enabled?: boolean;
+  spot_liquidity_provider?: 'binance' | 'internal';
 };
 
 type P2PPaymentMethod = {
@@ -5165,6 +5167,7 @@ function PricingPanel({ onNotify }: { onNotify: (message: string, variant?: 'suc
   const [makerForm, setMakerForm] = useState({
     enabled: false,
     binanceLiquidityEnabled: false,
+    spotLiquidityProvider: 'binance' as 'binance' | 'internal',
     spreadPct: '2.00',
     refreshMinutes: '30',
     userEmail: 'info.eltx@gmail.com',
@@ -5190,6 +5193,7 @@ function PricingPanel({ onNotify }: { onNotify: (message: string, variant?: 'suc
       setMakerForm({
         enabled: !!makerRes.data.settings.enabled,
         binanceLiquidityEnabled: !!makerRes.data.settings.binance_liquidity_enabled,
+        spotLiquidityProvider: makerRes.data.settings.spot_liquidity_provider === 'internal' ? 'internal' : 'binance',
         spreadPct: (makerRes.data.settings.spread_bps / 100).toFixed(2),
         refreshMinutes: makerRes.data.settings.refresh_minutes.toString(),
         userEmail: makerRes.data.settings.user_email,
@@ -5337,6 +5341,8 @@ function PricingPanel({ onNotify }: { onNotify: (message: string, variant?: 'suc
     const payload = {
       enabled: makerForm.enabled,
       binance_liquidity_enabled: makerForm.binanceLiquidityEnabled,
+      spot_external_execution_enabled: makerForm.binanceLiquidityEnabled,
+      spot_liquidity_provider: makerForm.spotLiquidityProvider,
       spread_bps: Math.round(spread * 100),
       refresh_minutes: Math.round(refresh),
       user_email: makerForm.userEmail.trim(),
@@ -5355,6 +5361,7 @@ function PricingPanel({ onNotify }: { onNotify: (message: string, variant?: 'suc
       setMakerForm({
         enabled: !!res.data.settings.enabled,
         binanceLiquidityEnabled: !!res.data.settings.binance_liquidity_enabled,
+        spotLiquidityProvider: res.data.settings.spot_liquidity_provider === 'internal' ? 'internal' : 'binance',
         spreadPct: (res.data.settings.spread_bps / 100).toFixed(2),
         refreshMinutes: res.data.settings.refresh_minutes.toString(),
         userEmail: res.data.settings.user_email,
@@ -5532,6 +5539,22 @@ function PricingPanel({ onNotify }: { onNotify: (message: string, variant?: 'suc
                 />
                 Enable Binance liquidity bridge
               </label>
+              <div>
+                <label className="text-xs uppercase text-white/60">Spot liquidity provider</label>
+                <select
+                  value={makerForm.spotLiquidityProvider}
+                  onChange={(e) =>
+                    setMakerForm((prev) => ({
+                      ...prev,
+                      spotLiquidityProvider: e.target.value === 'internal' ? 'internal' : 'binance',
+                    }))
+                  }
+                  className="mt-1 w-full rounded-lg border border-white/10 bg-black/40 p-3 focus:border-blue-500 focus:outline-none"
+                >
+                  <option value="binance">Binance</option>
+                  <option value="internal">Internal Orderbook Only</option>
+                </select>
+              </div>
 
               <div>
                 <label className="text-xs uppercase text-white/60">Spread (%)</label>

--- a/db/migrations/202604241200_spot_external_execution_provider.sql
+++ b/db/migrations/202604241200_spot_external_execution_provider.sql
@@ -1,0 +1,8 @@
+-- Add configurable external execution toggle/provider for spot orders
+INSERT INTO platform_settings (name, value)
+VALUES ('spot_external_execution_enabled', '0')
+ON DUPLICATE KEY UPDATE value = value;
+
+INSERT INTO platform_settings (name, value)
+VALUES ('spot_liquidity_provider', 'binance')
+ON DUPLICATE KEY UPDATE value = value;

--- a/db/migrations/202604241430_enable_spot_market_orders.sql
+++ b/db/migrations/202604241430_enable_spot_market_orders.sql
@@ -1,0 +1,6 @@
+-- Re-enable spot market orders globally (admin can still disable per market later)
+UPDATE spot_markets
+   SET allow_market_orders = 1,
+       updated_at = NOW()
+ WHERE active = 1
+   AND COALESCE(allow_market_orders, 0) = 0;

--- a/db/wallet.sql
+++ b/db/wallet.sql
@@ -804,4 +804,13 @@ INSERT IGNORE INTO platform_settings (name, value) VALUES ('market_maker_pairs',
 INSERT IGNORE INTO platform_settings (name, value) VALUES ('market_maker_target_base_pct', '50');
 INSERT IGNORE INTO platform_settings (name, value) VALUES ('binance_liquidity_enabled', '0');
 INSERT IGNORE INTO platform_settings (name, value) VALUES ('binance_liquidity_spread_bps', '0');
+INSERT IGNORE INTO platform_settings (name, value) VALUES ('spot_external_execution_enabled', '0');
+INSERT IGNORE INTO platform_settings (name, value) VALUES ('spot_liquidity_provider', 'binance');
 INSERT IGNORE INTO platform_settings (name, value) VALUES ('seo_settings_json', '{"sitemapRefreshHours":3,"indexNowEnabled":false,"indexNowKey":"","indexNowKeyLocation":"/indexnow-key.txt","includeRssInSitemap":true,"postPublishPingEnabled":false,"postPublishPingUrls":["https://rpc.pingomatic.com/"]}');
+
+-- Re-enable market orders by default (can still be disabled per market from admin)
+UPDATE spot_markets
+   SET allow_market_orders = 1,
+       updated_at = NOW()
+ WHERE active = 1
+   AND COALESCE(allow_market_orders, 0) = 0;


### PR DESCRIPTION
### Motivation

- Add a configurable toggle and provider selection to control routing of spot orders to external liquidity (Binance) vs internal orderbook.
- Harden Binance market/limit order placement by honoring exchange `exchangeInfo` filters (lot size, tick size, min notional) and add caching for exchange info.
- Expose provider settings in the admin UI and persist defaults in DB migrations.

### Description

- Introduced new platform settings and defaults: `spot_external_execution_enabled` and `spot_liquidity_provider` with DB migrations to insert defaults and to re-enable spot market orders globally via `db/migrations/*.sql`.
- Added new defaults and schema fields: `DEFAULT_SPOT_EXTERNAL_EXECUTION_ENABLED`, `DEFAULT_SPOT_LIQUIDITY_PROVIDER`, updated `MarketMakerSettingsSchema`, and read/write handlers in `readMarketMakerSettings` and `updateMarketMakerSettings` to persist and return these settings.
- Updated spot routing and liquidity state: `readBinanceLiquidityState` now returns `provider` and `externalExecutionEnabled`, and spot order handling in `app.post('/spot/orders')` uses these flags to decide whether external routing is allowed even if per-market `allow_market_orders` is disabled.
- Implemented Binance `exchangeInfo` fetching and caching (`fetchBinanceSymbolFilters`, `binanceExchangeInfoCache`, `BINANCE_EXCHANGE_INFO_TTL_MS`) and utilities `normalizeBinanceTimeInForce` and `floorToStepDecimal` to enforce `LOT_SIZE`, `PRICE_FILTER`, and `NOTIONAL` constraints when building order params for `executeBinanceMarketOrder` and `executeBinanceLimitOrder`.
- Enhanced external execution flows: market fallback plans still use depth estimation, and limit orders may be placed externally; when external fills occur they insert `spot_trades` and `platform_fees` rows and update the matching results, with support for recording external resting order id/status for GTC limit orders.
- Admin UI updates in `AdminApp.tsx` to surface a `Spot liquidity provider` select and to include the provider and external execution fields when saving market maker settings.
- Updated initialization SQL (`db/wallet.sql`) to include new platform settings and to re-enable market orders by default for active markets.

### Testing

- Ran the backend and exercised the spot order endpoint with both market and limit orders against mock and live Binance configurations to validate parameter normalization and fallback behavior, and observed expected success flows and graceful failures when constraints were violated.
- Built the frontend and exercised the admin `Pricing` panel to verify the new `Spot liquidity provider` select and settings persist/round-trip via `PATCH /admin/market-maker/settings` (UI build succeeded).
- No new automated unit tests were added in this change; existing lint/build and smoke checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5081e334832b8d60f58545134cfc)