### PR TITLE
Show USDT in Wallet, clean Spot UI, move Dashboard Shortcuts and add home trading showcase

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '../../lib/auth';
@@ -24,7 +24,6 @@ import {
   Bot,
   CircleDollarSign,
   Compass,
-  ChevronDown,
 } from 'lucide-react';
 import SectionCard from '../../../components/dashboard/SectionCard';
 import { dict, useLang } from '../../lib/i18n';
@@ -58,7 +57,6 @@ export default function DashboardPage() {
   const { lang } = useLang();
   const t = dict[lang];
   const toast = useToast();
-  const shortcutsRef = useRef<HTMLElement | null>(null);
   const [posts, setPosts] = useState<SocialPost[]>([]);
   const [quickPost, setQuickPost] = useState('');
   const [aiQuestion, setAiQuestion] = useState('');
@@ -128,14 +126,10 @@ export default function DashboardPage() {
     };
   }, [posts, feedSettings]);
 
-  const scrollToShortcuts = () => {
-    shortcutsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  };
-
   return (
     <div className="space-y-2">
       <PageAdInject placement="dashboard" />
-      <div className="grid gap-2 lg:grid-cols-[220px,minmax(0,1fr),290px] lg:items-start">
+      <div className="grid gap-2 lg:grid-cols-[260px,minmax(0,1fr)] lg:items-start">
         <aside className="x-card space-y-2 p-2 lg:sticky lg:top-20">
           <div className="grid grid-cols-3 gap-1.5">
             <SectionCard title={lang === 'ar' ? 'اكسبلور' : 'Explore'} href="/for-you" icon={Compass} compact />
@@ -154,6 +148,24 @@ export default function DashboardPage() {
             <p className="flex items-center gap-1.5 text-[11px] font-semibold text-[#f4deae]"><Bot className="h-3 w-3" /> {lang === 'ar' ? 'اسأل LordAI 🤖' : 'Ask LordAI 🤖'}</p>
             <p className="mt-1 text-[10px] leading-4 text-white/70">{lang === 'ar' ? 'مساعد سريع للأفكار، الإجابات، وتحسين المحتوى.' : 'Fast help for ideas, answers, and content polish.'}</p>
           </button>
+          <section id="dashboard-shortcuts" className="x-card space-y-2 p-2">
+            <h2 className="text-[11px] font-semibold uppercase tracking-wide text-white/65">Shortcuts</h2>
+            <div className="grid grid-cols-3 gap-1.5">
+              <SectionCard title={t.dashboard.cards.transactions.title} href="/transactions" icon={ReceiptText} compact />
+              <SectionCard title={t.dashboard.cards.p2p.title} href="/p2p" icon={Handshake} compact />
+              <SectionCard title="Spot Trade" href="/trade/spot" icon={CandlestickChart} compact />
+              <SectionCard title={t.dashboard.market.title} href="/market" icon={CandlestickChart} compact />
+              <SectionCard title="Staking" href="/staking" icon={Coins} compact />
+              <SectionCard title={t.dashboard.cards.invite.title} href="/referrals" icon={Gift} compact />
+              <SectionCard title={t.dashboard.cards.aiAgent.title} href="/ai" icon={Sparkles} compact />
+              <SectionCard title={lang === 'ar' ? 'بريميم' : 'Premium'} href="/premium" icon={ShieldCheck} compact />
+              <SectionCard title={lang === 'ar' ? 'تحقيق الربح' : 'Monetize'} href="/monetize" icon={CircleDollarSign} compact />
+              <SectionCard title={t.dashboard.cards.settings.title} href="/settings" icon={Settings} compact />
+              <SectionCard title={t.dashboard.cards.faq.title} href="/faq" icon={HelpCircle} compact />
+              <SectionCard title={t.dashboard.cards.support.title} href="/support" icon={LifeBuoy} compact />
+              <SectionCard title={t.dashboard.cards.kyc.title} href="/kyc" icon={ShieldCheck} compact />
+            </div>
+          </section>
         </aside>
 
         <main className="space-y-2">
@@ -303,36 +315,6 @@ export default function DashboardPage() {
           </section>
         </main>
 
-        <aside ref={shortcutsRef} className="space-y-2 lg:sticky lg:top-20">
-          <section id="dashboard-shortcuts" className="x-card space-y-2 p-2">
-            <h2 className="text-[11px] font-semibold uppercase tracking-wide text-white/65">Shortcuts</h2>
-            <div className="grid grid-cols-3 gap-1.5">
-              <SectionCard title={t.dashboard.cards.transactions.title} href="/transactions" icon={ReceiptText} compact />
-              <SectionCard title={t.dashboard.cards.p2p.title} href="/p2p" icon={Handshake} compact />
-              <SectionCard title="Spot Trade" href="/trade/spot" icon={CandlestickChart} compact />
-              <SectionCard title={t.dashboard.market.title} href="/market" icon={CandlestickChart} compact />
-              <SectionCard title="Staking" href="/staking" icon={Coins} compact />
-              <SectionCard title={t.dashboard.cards.invite.title} href="/referrals" icon={Gift} compact />
-              <SectionCard title={t.dashboard.cards.aiAgent.title} href="/ai" icon={Sparkles} compact />
-              <SectionCard title={lang === 'ar' ? 'بريميم' : 'Premium'} href="/premium" icon={ShieldCheck} compact />
-              <SectionCard title={lang === 'ar' ? 'تحقيق الربح' : 'Monetize'} href="/monetize" icon={CircleDollarSign} compact />
-              <SectionCard title={t.dashboard.cards.settings.title} href="/settings" icon={Settings} compact />
-              <SectionCard title={t.dashboard.cards.faq.title} href="/faq" icon={HelpCircle} compact />
-              <SectionCard title={t.dashboard.cards.support.title} href="/support" icon={LifeBuoy} compact />
-              <SectionCard title={t.dashboard.cards.kyc.title} href="/kyc" icon={ShieldCheck} compact />
-              <button
-                type="button"
-                onClick={scrollToShortcuts}
-                className="group relative flex items-center gap-1.5 rounded-xl border border-[#2f3336] bg-black px-1.5 py-1.5 text-left shadow-sm transition hover:border-[#c9a75c]/60 hover:bg-[#16181c]"
-              >
-                <div className="flex h-6 w-6 items-center justify-center rounded-full border border-[#2f3336] bg-[#16181c] text-white transition group-hover:border-[#c9a75c]/70">
-                  <ChevronDown className="h-3 w-3" />
-                </div>
-                <span className="truncate text-[0.72rem] font-semibold leading-tight text-white">{lang === 'ar' ? 'المزيد..' : 'More..'}</span>
-              </button>
-            </div>
-          </section>
-        </aside>
       </div>
 
       <button

--- a/app/(app)/trade/spot/page.tsx
+++ b/app/(app)/trade/spot/page.tsx
@@ -894,7 +894,6 @@ function SpotTradePageContent() {
 
       <div className="space-y-1.5">
         <h1 className="text-lg font-semibold">{t.spotTrade.title}</h1>
-        <p className="text-xs text-white/70">{t.spotTrade.subtitle}</p>
       </div>
 
       {errorBanner && <div className="text-xs text-red-400 bg-red-500/10 border border-red-500/40 rounded p-2.5">{errorBanner}</div>}
@@ -935,14 +934,12 @@ function SpotTradePageContent() {
                     {changePercentLabel}%
                   </span>
                 )}
-                <span
-                  className={`flex items-center gap-1 rounded-full px-2 py-1 border ${
-                    streamConnected ? 'border-[#0ecb81]/40 bg-[#0ecb81]/10 text-[#0ecb81]' : 'border-amber-400/40 bg-amber-500/10 text-amber-100'
-                  }`}
-                >
-                  <span className="h-2 w-2 rounded-full bg-current animate-pulse" />
-                  {streamConnected ? t.trade.liveRate : t.trade.loading}
-                </span>
+                {streamConnected && (
+                  <span className="flex items-center gap-1 rounded-full px-2 py-1 border border-[#0ecb81]/40 bg-[#0ecb81]/10 text-[#0ecb81]">
+                    <span className="h-2 w-2 rounded-full bg-current animate-pulse" />
+                    {t.trade.liveRate}
+                  </span>
+                )}
               </div>
             </div>
 

--- a/app/(app)/wallet/page.tsx
+++ b/app/(app)/wallet/page.tsx
@@ -227,7 +227,7 @@ export default function WalletPage() {
       <PageAdSlot placement="wallet" />
       {hasEltxBalance && (
         <div className="p-4 rounded-2xl bg-white/5">
-          <div className="text-sm opacity-80">{t.dashboard.balanceCard.title}</div>
+          <div className="text-sm opacity-80">{lang === 'ar' ? 'رصيد USDT' : 'USDT Balance'}</div>
           <div className="text-2xl font-bold">{eltxBalanceFormatted}</div>
         </div>
       )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import Hero from '../components/home/Hero';
+import TradingInvestmentShowcase from '../components/home/TradingInvestmentShowcase';
 import HomeForYouPreview from '../components/home/HomeForYouPreview';
 import HomeAuthRepeat from '../components/home/HomeAuthRepeat';
 import ScrollToTopOnLoad from '../components/ScrollToTopOnLoad';
@@ -39,6 +40,7 @@ export default async function Page() {
     <main className="flex flex-col">
       <ScrollToTopOnLoad />
       <Hero />
+      <TradingInvestmentShowcase />
       <HomeForYouPreview />
       <HomeAuthRepeat />
     </main>

--- a/components/home/TradingInvestmentShowcase.tsx
+++ b/components/home/TradingInvestmentShowcase.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import Link from 'next/link';
+import { CandlestickChart, ShieldCheck, Sparkles } from 'lucide-react';
+import { useLang } from '../../app/lib/i18n';
+
+export default function TradingInvestmentShowcase() {
+  const { lang } = useLang();
+  const isArabic = lang === 'ar';
+
+  return (
+    <section className="mx-auto w-full max-w-6xl px-4 py-6 sm:py-8">
+      <div className="relative overflow-hidden rounded-3xl border border-[#c9a75c]/40 bg-gradient-to-br from-[#0b0f18] via-[#121b2e] to-[#0d121f] p-6 shadow-[0_30px_90px_-40px_rgba(201,167,92,0.55)] sm:p-8">
+        <div className="pointer-events-none absolute -right-16 -top-20 h-48 w-48 rounded-full bg-[#c9a75c]/20 blur-3xl" />
+        <div className="pointer-events-none absolute -bottom-20 -left-10 h-52 w-52 rounded-full bg-emerald-400/10 blur-3xl" />
+
+        <div className="relative grid gap-5 md:grid-cols-[1.4fr,0.9fr] md:items-center">
+          <div className="space-y-3.5">
+            <p className="inline-flex items-center gap-2 rounded-full border border-[#f4deae]/35 bg-[#c9a75c]/15 px-3 py-1 text-xs font-semibold text-[#f4deae]">
+              <Sparkles className="h-3.5 w-3.5" />
+              {isArabic ? 'خدمة التداول والاستثمار الذكية' : 'Smart Trading & Investment Service'}
+            </p>
+            <h2 className="text-2xl font-bold leading-tight text-white sm:text-3xl">
+              {isArabic
+                ? 'تداول بسرعة، واستثمر بثقة، ونمّي محفظتك من منصة واحدة.'
+                : 'Trade faster, invest confidently, and grow your portfolio from one platform.'}
+            </h2>
+            <p className="max-w-2xl text-sm leading-6 text-white/75 sm:text-base">
+              {isArabic
+                ? 'منصة LordAi.Net بتجمع بين تنفيذ صفقات سريع، أدوات تحليل واضحة، وتجربة استثمار آمنة باللغة العربية والإنجليزية.'
+                : 'LordAi.Net combines fast execution, clear market tools, and secure investing in both Arabic and English.'}
+            </p>
+            <div className="flex flex-wrap gap-2.5">
+              <Link href="/trade/spot" className="inline-flex items-center gap-2 rounded-xl bg-[#c9a75c] px-4 py-2 text-sm font-semibold text-black transition hover:brightness-110">
+                <CandlestickChart className="h-4 w-4" />
+                {isArabic ? 'ابدأ التداول الفوري' : 'Start Spot Trading'}
+              </Link>
+              <Link href="/wallet" className="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/5 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/10">
+                <ShieldCheck className="h-4 w-4" />
+                {isArabic ? 'إدارة المحفظة' : 'Manage Wallet'}
+              </Link>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-2.5 text-xs sm:text-sm">
+            <div className="rounded-2xl border border-white/10 bg-black/25 p-3.5 text-white/85">
+              <p className="text-[11px] uppercase tracking-wider text-white/50">{isArabic ? 'تنفيذ' : 'Execution'}</p>
+              <p className="mt-1 font-semibold">{isArabic ? 'واجهة سبوت عملية وسريعة' : 'Fast, practical spot interface'}</p>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-black/25 p-3.5 text-white/85">
+              <p className="text-[11px] uppercase tracking-wider text-white/50">{isArabic ? 'ثقة' : 'Trust'}</p>
+              <p className="mt-1 font-semibold">{isArabic ? 'متابعة الرصيد والحركات لحظياً' : 'Live balance and activity tracking'}</p>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-black/25 p-3.5 text-white/85">
+              <p className="text-[11px] uppercase tracking-wider text-white/50">{isArabic ? 'نمو' : 'Growth'}</p>
+              <p className="mt-1 font-semibold">{isArabic ? 'أدوات تساعدك تبني قرار استثماري أوضح' : 'Tools to support smarter investment decisions'}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/layout/MobileMenu.tsx
+++ b/components/layout/MobileMenu.tsx
@@ -11,14 +11,12 @@ export default function MobileMenu({
   open,
   setOpen,
   links,
-  publicLinks,
   user,
   logout,
 }: {
   open: boolean;
   setOpen: Dispatch<SetStateAction<boolean>>;
   links: NavLink[];
-  publicLinks: NavLink[];
   user: any;
   logout: () => Promise<void>;
 }) {
@@ -60,16 +58,6 @@ export default function MobileMenu({
             {l.label}
           </Link>
         ))}
-        <div className="mt-2 rounded-2xl border border-[#2f3336] bg-[#111216]/80 p-3">
-          <p className="px-2 pb-2 text-[10px] uppercase tracking-[0.2em] text-white/50">{t.nav.explore}</p>
-          <div className="flex flex-col gap-1">
-            {publicLinks.map((l) => (
-              <Link key={l.href} href={l.href} onClick={() => setOpen(false)} className="rounded-full px-3 py-2 text-sm text-white/80 hover:bg-white/10 hover:text-white">
-                {l.label}
-              </Link>
-            ))}
-          </div>
-        </div>
         {!user && (
           <>
             <Link href="/login" onClick={() => setOpen(false)} className="rounded-full px-3 py-2 hover:bg-white/10">

--- a/components/layout/NavBar.tsx
+++ b/components/layout/NavBar.tsx
@@ -180,7 +180,7 @@ export default function NavBar() {
           <Menu />
         </button>
       </div>
-      <MobileMenu open={open} setOpen={setOpen} links={links} publicLinks={publicLinks} user={user} logout={logout} />
+      <MobileMenu open={open} setOpen={setOpen} links={links} user={user} logout={logout} />
     </header>
   );
 }


### PR DESCRIPTION
### Motivation
- Make the wallet UI show USDT as the primary balance label and clean up redundant/incorrect text in the Spot trading UI for a clearer user experience.
- Remove unnecessary static UI elements and duplicated links that confuse users on mobile.
- Surface the frequently-used `Shortcuts` area higher on the Dashboard and add a strong promotional section on the homepage to present the platform's trading/investment capabilities bilingually.

### Description
- Changed the Wallet balance card label to `USDT Balance` with Arabic/English support (`app/(app)/wallet/page.tsx`).
- Removed the static subtitle and the always-visible `Loading` badge in the Spot trade header so the live-status badge only appears when the stream is connected (`app/(app)/trade/spot/page.tsx`).
- Moved the `Shortcuts` block to sit directly under the `Ask LordAI` panel and adjusted the grid layout (`app/(app)/dashboard/page.tsx`).
- Removed the duplicated `Explore` section from the mobile side menu and updated the `MobileMenu` and `NavBar` call sites to match (`components/layout/MobileMenu.tsx`, `components/layout/NavBar.tsx`).
- Added a new promotional home section component `TradingInvestmentShowcase` (bilingual EN/AR) and mounted it under the `Hero` on the homepage (`components/home/TradingInvestmentShowcase.tsx`, `app/page.tsx`).
- No database/schema changes were made as part of this PR.

### Testing
- Ran `npm run build` which completed successfully (build passed; note warnings about missing ENV keys which are non-blocking for the build but should be provided in env for full runtime behavior). 
- Ran `npm run test:integration` and all integration tests passed (`19/19`).
- Ran `npm run typecheck` and `npm run lint`, both passed with no errors.
- Started the app and verified basic endpoints with `curl` returning HTTP 200 for `/` and `/api/markets`.
- Generated a headless screenshot of the new home section and saved it to `artifacts/home-trading-section.png` using Playwright tooling after installing browsers and dependencies.
- No SQL migrations are required for these UI changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebf3266610832bbc24539162d8c661)