### PR TITLE
Fix spot quote minimum validation consistency across API and UI

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -10298,6 +10298,7 @@ app.post('/trade/quote', walletLimiter, async (req, res, next) => {
       return next({ status: 400, code: 'UNSUPPORTED_ASSET', message: 'Asset not supported for swap' });
 
     const assetDecimals = Number(market.quote_decimals || getSymbolDecimals(asset));
+    const quoteDecimals = assetDecimals;
     const targetDecimals = Number(market.base_decimals || getSymbolDecimals(ELTX_SYMBOL));
     const baseAsset = market.base_asset;
     const quoteAsset = market.quote_asset;
@@ -10317,11 +10318,8 @@ app.post('/trade/quote', walletLimiter, async (req, res, next) => {
     if (amountWei <= 0n)
       return next({ status: 400, code: 'INVALID_AMOUNT', message: 'Amount must be greater than zero' });
 
-    const minQuoteStr = (market.min_quote_amount || '0').toString();
-    if (!isZeroDecimal(minQuoteStr)) {
-      const minWei = ethers.parseUnits(minQuoteStr, assetDecimals);
-      if (amountWei < minWei)
-        return next({ status: 400, code: 'AMOUNT_TOO_SMALL', message: 'Amount below minimum' });
+    if (minQuoteWei > 0n && amountWei < minQuoteWei) {
+      return next({ status: 400, code: 'AMOUNT_TOO_SMALL', message: 'Amount below minimum' });
     }
 
     let swapFeeBps = 0n;

--- a/app/(app)/trade/spot/page.tsx
+++ b/app/(app)/trade/spot/page.tsx
@@ -527,7 +527,9 @@ function SpotTradePageContent() {
   const minOrderQuoteValue = useMemo(() => {
     if (!selectedMarketMeta) return null;
     const marketMinQuote = safeDecimal(selectedMarketMeta.min_quote_amount);
-    return Decimal.max(MIN_SPOT_ORDER_VALUE_USDT, marketMinQuote);
+    const quoteAsset = (selectedMarketMeta.quote_asset || '').toString().trim().toUpperCase();
+    const hardMinQuote = quoteAsset === 'USDT' ? MIN_SPOT_ORDER_VALUE_USDT : ZERO;
+    return Decimal.max(hardMinQuote, marketMinQuote);
   }, [selectedMarketMeta]);
 
   const validation = useMemo<ValidationState>(() => {
@@ -656,9 +658,13 @@ function SpotTradePageContent() {
         case 'MARKET_ORDER_DISABLED':
           return t.spotTrade.errors.marketOrderDisabled;
         case 'MIN_ORDER_VALUE':
+          {
+            const effectiveMin = minOrderQuoteValue || MIN_SPOT_ORDER_VALUE_USDT;
+            const effectiveAsset = quoteSymbol || 'USDT';
           return t.spotTrade.errors.minOrderValue
-            .replace('{min}', trimDecimal(MIN_SPOT_ORDER_VALUE_USDT.toFixed(2)))
-            .replace('{asset}', 'USDT');
+            .replace('{min}', trimDecimal(effectiveMin.toFixed(Math.max(2, quoteDecimals))))
+            .replace('{asset}', effectiveAsset);
+          }
         case 'SLIPPAGE_EXCEEDED':
           return t.spotTrade.errors.slippageExceeded;
         case 'PRICE_DEVIATION_EXCEEDED':
@@ -689,6 +695,9 @@ function SpotTradePageContent() {
       t.spotTrade.errors.priceDeviationExceeded,
       t.spotTrade.errors.priceRequired,
       t.spotTrade.errors.slippageExceeded,
+      minOrderQuoteValue,
+      quoteDecimals,
+      quoteSymbol,
     ]
   );
 


### PR DESCRIPTION
### Motivation
- Prevent a runtime error in `POST /trade/quote` caused by using an undefined `quoteDecimals` when parsing minimum amounts. 
- Make minimum-amount validation consistent between the API quote endpoint and the Spot Trade UI so non-USDT quote markets aren't incorrectly hard-limited to a $5 floor. 
- Improve UI error messaging to show the actual effective minimum and quote asset instead of a hardcoded `5 USDT` string. 

### Description
- API: defined `quoteDecimals` and validate against the computed `minQuoteWei` (the max of market `min_quote_amount` and the $5 hard floor applied only when quote asset is `USDT`) in `api/src/app.js` for `/trade/quote` to avoid ReferenceError and enforce the effective minimum. 
- Frontend: updated `minOrderQuoteValue` calculation in `app/(app)/trade/spot/page.tsx` to apply the $5 hard floor only for USDT-quoted markets and to compute the effective minimum correctly. 
- Frontend: enhanced `MIN_ORDER_VALUE` error mapping to display the dynamic minimum value and the actual quote asset (`quoteSymbol`) instead of a fixed `5 USDT`, and added the new reactive dependencies to the `useCallback` hooks. 

### Testing
- Ran `npm run test:integration` and all integration tests passed (19/19). 
- Ran `npm run build` and the Next.js build completed successfully (type checks and linting passed); build-time environment warnings were observed (`[ENV] Missing keys` and `Browserslist` advisories) but did not block the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec057438dc832b9203f37dc3e92637)