### PR TITLE
Honor buy quote budget during spot external fallback

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -3769,7 +3769,7 @@ async function simulateSpotMarketBuy(conn, market, quoteAmountWei, takerFeeBps) 
   return result;
 }
 
-function estimateExternalFillFromDepth(levels, { side, maxBaseWei, takerFeeBps, limitPriceWei = 0n }) {
+function estimateExternalFillFromDepth(levels, { side, maxBaseWei, takerFeeBps, limitPriceWei = 0n, maxQuoteWithFeeWei = null }) {
   const result = {
     filledBaseWei: 0n,
     quoteWithoutFeeWei: 0n,
@@ -3779,8 +3779,11 @@ function estimateExternalFillFromDepth(levels, { side, maxBaseWei, takerFeeBps, 
   };
   let remainingBaseWei = bigIntFromValue(maxBaseWei);
   const feeBps = clampBps(bigIntFromValue(takerFeeBps || 0));
+  let remainingQuoteBudgetWei =
+    side === 'buy' && maxQuoteWithFeeWei != null ? bigIntFromValue(maxQuoteWithFeeWei) : null;
   for (const level of levels || []) {
     if (remainingBaseWei <= 0n) break;
+    if (remainingQuoteBudgetWei != null && remainingQuoteBudgetWei <= 0n) break;
     const levelBaseWei = bigIntFromValue(level.base_amount_wei);
     const levelPriceWei = bigIntFromValue(level.price_wei);
     if (levelBaseWei <= 0n || levelPriceWei <= 0n) continue;
@@ -3789,10 +3792,23 @@ function estimateExternalFillFromDepth(levels, { side, maxBaseWei, takerFeeBps, 
       if (side === 'sell' && levelPriceWei < limitPriceWei) continue;
     }
     result.limitMatched = true;
-    const tradeBaseWei = remainingBaseWei < levelBaseWei ? remainingBaseWei : levelBaseWei;
+    let tradeBaseWei = remainingBaseWei < levelBaseWei ? remainingBaseWei : levelBaseWei;
+    if (remainingQuoteBudgetWei != null) {
+      const feeMultiplier = 10000n + feeBps;
+      const costPerBaseWei = mulDiv(levelPriceWei, feeMultiplier, 10000n);
+      if (costPerBaseWei <= 0n) continue;
+      const maxAffordableBaseWei = mulDiv(remainingQuoteBudgetWei, PRICE_SCALE, costPerBaseWei);
+      if (maxAffordableBaseWei <= 0n) break;
+      if (tradeBaseWei > maxAffordableBaseWei) tradeBaseWei = maxAffordableBaseWei;
+    }
     const quoteWithoutFee = computeQuoteAmount(tradeBaseWei, levelPriceWei);
     if (tradeBaseWei <= 0n || quoteWithoutFee <= 0n) continue;
     const takerFee = (quoteWithoutFee * feeBps) / 10000n;
+    if (remainingQuoteBudgetWei != null) {
+      const totalWithFeeWei = quoteWithoutFee + takerFee;
+      if (totalWithFeeWei > remainingQuoteBudgetWei) continue;
+      remainingQuoteBudgetWei -= totalWithFeeWei;
+    }
     result.filledBaseWei += tradeBaseWei;
     result.quoteWithoutFeeWei += quoteWithoutFee;
     result.totalWithFeeWei += side === 'buy' ? quoteWithoutFee + takerFee : quoteWithoutFee - takerFee;
@@ -11395,6 +11411,10 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
     let externalFallbackError = null;
     let externalRestingOrderId = null;
     let externalRestingStatus = null;
+    const getBuyExternalQuoteBudget = () => {
+      if (side !== 'buy') return null;
+      return type === 'limit' ? taker.remainingQuote : taker.availableQuote;
+    };
     if (shouldExternalFallback && taker.remainingBase > 0n) {
       try {
         externalFallbackAttempted = true;
@@ -11404,88 +11424,118 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
         const externalDepthRaw = await fetchBinanceDepthSnapshot(market, 50);
         const externalDepth = normalizeExternalDepthWithSpread(externalDepthRaw, liquidityState.spreadBps);
         const levels = side === 'buy' ? externalDepth.asks : externalDepth.bids;
+        const buyQuoteBudgetWei = getBuyExternalQuoteBudget();
         const externalPlan = estimateExternalFillFromDepth(levels, {
           side,
           maxBaseWei: taker.remainingBase,
           takerFeeBps,
           limitPriceWei: type === 'limit' ? priceWei : 0n,
+          maxQuoteWithFeeWei: buyQuoteBudgetWei,
         });
         if (type === 'limit') {
           let executedBase = 0n;
-          const externalLimitOrder = await executeBinanceLimitOrder(market, side, {
-            quantityWei: taker.remainingBase,
-            priceWei,
-            timeInForce: String(timeInForce || 'gtc').toUpperCase(),
-          });
-          executedBase = bigIntFromValue(externalLimitOrder.executedBaseWei);
-          if (executedBase > 0n) {
-            const externalQuoteRaw = bigIntFromValue(externalLimitOrder.quoteWithoutFeeWei);
-            const externalQuote =
-              externalQuoteRaw > 0n ? externalQuoteRaw : computeQuoteAmount(executedBase, externalLimitOrder.averagePriceWei || priceWei);
-            const externalAveragePriceWei =
-              externalLimitOrder.averagePriceWei && externalLimitOrder.averagePriceWei > 0n
-                ? externalLimitOrder.averagePriceWei
-                : priceWei;
-            const externalFee = (externalQuote * takerFeeBps) / 10000n;
-            const [tradeInsert] = await conn.query(
-              'INSERT INTO spot_trades (market_id, buy_order_id, sell_order_id, price_wei, base_amount_wei, quote_amount_wei, buy_fee_wei, sell_fee_wei, fee_asset, taker_side) VALUES (?,?,?,?,?,?,?,?,?,?)',
-              [
-                market.id,
-                orderId,
-                orderId,
-                externalAveragePriceWei.toString(),
-                executedBase.toString(),
-                externalQuote.toString(),
-                side === 'buy' ? externalFee.toString() : '0',
-                side === 'sell' ? externalFee.toString() : '0',
-                market.quote_asset,
-                side,
-              ]
-            );
-            const tradeId = tradeInsert.insertId;
-            if (externalFee > 0n) {
-              await conn.query('INSERT INTO platform_fees (fee_type, reference, asset, amount_wei) VALUES (?,?,?,?)', [
-                'spot',
-                `trade:${tradeId}:external:taker`,
-                market.quote_asset,
-                externalFee.toString(),
-              ]);
-            }
-            if (side === 'buy') {
-              matchResult.spentQuote += externalQuote + externalFee;
-              matchResult.receivedBase += executedBase;
+          let externalLimitQuantityWei = taker.remainingBase;
+          if (side === 'buy') {
+            if (!buyQuoteBudgetWei || buyQuoteBudgetWei <= 0n) {
+              externalLimitQuantityWei = 0n;
             } else {
-              matchResult.receivedQuote += externalQuote - externalFee;
+              const feeMultiplier = 10000n + takerFeeBps;
+              const costPerBaseWei = mulDiv(priceWei, feeMultiplier, 10000n);
+              if (costPerBaseWei <= 0n) {
+                externalLimitQuantityWei = 0n;
+              } else {
+                const maxAffordableBaseWei = mulDiv(buyQuoteBudgetWei, PRICE_SCALE, costPerBaseWei);
+                if (maxAffordableBaseWei <= 0n) externalLimitQuantityWei = 0n;
+                else if (externalLimitQuantityWei > maxAffordableBaseWei) externalLimitQuantityWei = maxAffordableBaseWei;
+              }
             }
-            matchResult.takerFee += externalFee;
-            matchResult.filledBase += executedBase;
-            taker.remainingBase -= executedBase;
-            matchResult.averagePriceWei = recalculateMatchAveragePrice(matchResult, side);
-            matchResult.trades.push({
-              trade_id: tradeId,
-              maker_order_id: null,
-              maker_user_id: null,
-              price_wei: externalAveragePriceWei,
-              base_amount_wei: executedBase,
-              quote_amount_wei: externalQuote,
-              taker_fee_wei: externalFee,
-              maker_fee_wei: 0n,
-              external_liquidity: true,
-            });
           }
-          const isGtc = timeInForce === 'gtc';
-          if (isGtc && taker.remainingBase > 0n && externalLimitOrder.externalOrderId) {
-            externalRestingOrderId = externalLimitOrder.externalOrderId;
-            externalRestingStatus = externalLimitOrder.status || 'NEW';
-          }
-          if (executedBase <= 0n && !externalRestingOrderId) {
+          if (externalLimitQuantityWei <= 0n) {
             console.info(
-              `[spot] external fallback no-fill: orderId=${orderId} market=${market.symbol} side=${side} type=${type} tif=${timeInForce} reason=limit_or_depth_constraints`
+              `[spot] external fallback skipped: orderId=${orderId} market=${market.symbol} side=${side} type=${type} tif=${timeInForce} reason=insufficient_quote_budget`
             );
           } else {
-            console.info(
-              `[spot] external fallback filled: orderId=${orderId} executedBaseWei=${executedBase.toString()} externalOrderId=${externalLimitOrder.externalOrderId || 'n/a'} status=${externalLimitOrder.status || 'UNKNOWN'}`
-            );
+            const externalLimitOrder = await executeBinanceLimitOrder(market, side, {
+              quantityWei: externalLimitQuantityWei,
+              priceWei,
+              timeInForce: String(timeInForce || 'gtc').toUpperCase(),
+            });
+            executedBase = bigIntFromValue(externalLimitOrder.executedBaseWei);
+            if (executedBase > 0n) {
+              const externalQuoteRaw = bigIntFromValue(externalLimitOrder.quoteWithoutFeeWei);
+              const externalQuote =
+                externalQuoteRaw > 0n
+                  ? externalQuoteRaw
+                  : computeQuoteAmount(executedBase, externalLimitOrder.averagePriceWei || priceWei);
+              const externalAveragePriceWei =
+                externalLimitOrder.averagePriceWei && externalLimitOrder.averagePriceWei > 0n
+                  ? externalLimitOrder.averagePriceWei
+                  : priceWei;
+              const externalFee = (externalQuote * takerFeeBps) / 10000n;
+              const [tradeInsert] = await conn.query(
+                'INSERT INTO spot_trades (market_id, buy_order_id, sell_order_id, price_wei, base_amount_wei, quote_amount_wei, buy_fee_wei, sell_fee_wei, fee_asset, taker_side) VALUES (?,?,?,?,?,?,?,?,?,?)',
+                [
+                  market.id,
+                  orderId,
+                  orderId,
+                  externalAveragePriceWei.toString(),
+                  executedBase.toString(),
+                  externalQuote.toString(),
+                  side === 'buy' ? externalFee.toString() : '0',
+                  side === 'sell' ? externalFee.toString() : '0',
+                  market.quote_asset,
+                  side,
+                ]
+              );
+              const tradeId = tradeInsert.insertId;
+              if (externalFee > 0n) {
+                await conn.query('INSERT INTO platform_fees (fee_type, reference, asset, amount_wei) VALUES (?,?,?,?)', [
+                  'spot',
+                  `trade:${tradeId}:external:taker`,
+                  market.quote_asset,
+                  externalFee.toString(),
+                ]);
+              }
+              if (side === 'buy') {
+                matchResult.spentQuote += externalQuote + externalFee;
+                matchResult.receivedBase += executedBase;
+              } else {
+                matchResult.receivedQuote += externalQuote - externalFee;
+              }
+              matchResult.takerFee += externalFee;
+              matchResult.filledBase += executedBase;
+              taker.remainingBase -= executedBase;
+              if (side === 'buy') {
+                const totalSpentWei = externalQuote + externalFee;
+                taker.remainingQuote = taker.remainingQuote > totalSpentWei ? taker.remainingQuote - totalSpentWei : 0n;
+              }
+              matchResult.averagePriceWei = recalculateMatchAveragePrice(matchResult, side);
+              matchResult.trades.push({
+                trade_id: tradeId,
+                maker_order_id: null,
+                maker_user_id: null,
+                price_wei: externalAveragePriceWei,
+                base_amount_wei: executedBase,
+                quote_amount_wei: externalQuote,
+                taker_fee_wei: externalFee,
+                maker_fee_wei: 0n,
+                external_liquidity: true,
+              });
+            }
+            const isGtc = timeInForce === 'gtc';
+            if (isGtc && taker.remainingBase > 0n && externalLimitOrder.externalOrderId) {
+              externalRestingOrderId = externalLimitOrder.externalOrderId;
+              externalRestingStatus = externalLimitOrder.status || 'NEW';
+            }
+            if (executedBase <= 0n && !externalRestingOrderId) {
+              console.info(
+                `[spot] external fallback no-fill: orderId=${orderId} market=${market.symbol} side=${side} type=${type} tif=${timeInForce} reason=limit_or_depth_constraints`
+              );
+            } else {
+              console.info(
+                `[spot] external fallback filled: orderId=${orderId} executedBaseWei=${executedBase.toString()} externalOrderId=${externalLimitOrder.externalOrderId || 'n/a'} status=${externalLimitOrder.status || 'UNKNOWN'}`
+              );
+            }
           }
         } else if (externalPlan.filledBaseWei > 0n && externalPlan.quoteWithoutFeeWei > 0n) {
           const externalOrder = await executeBinanceMarketOrder(market, side, {
@@ -11538,6 +11588,10 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
           matchResult.takerFee += externalFee;
           matchResult.filledBase += externalBase;
           taker.remainingBase -= externalBase;
+          if (side === 'buy') {
+            const totalSpentWei = externalQuote + externalFee;
+            taker.availableQuote = taker.availableQuote > totalSpentWei ? taker.availableQuote - totalSpentWei : 0n;
+          }
           matchResult.averagePriceWei = recalculateMatchAveragePrice(matchResult, side);
           matchResult.trades.push({
             trade_id: tradeId,


### PR DESCRIPTION
### Motivation
- External fallback could execute Binance buys that exceeded the taker’s remaining/available quote budget, producing a real external fill but later failing local settlement with `INSUFFICIENT_BALANCE` and causing user-visible divergence. 
- The goal is to ensure external planning and actual external orders never spend more quote (including taker fee) than the taker can cover locally.

### Description
- Extended `estimateExternalFillFromDepth` to accept `maxQuoteWithFeeWei` and plan fills that respect a buy quote budget by capping per-level base amounts and decrementing the remaining quote budget (including taker fee).
- Wired external planning in the spot order flow to pass the taker budget (`availableQuote` for market buys, `remainingQuote` for limit buys) into the estimator so internal + external execution cannot overspend.
- For limit external routing, added a pre-check that caps the Binance limit order quantity to the maximum affordable base amount given price + taker fee and skips fallback if the quote budget is insufficient (logging reason `insufficient_quote_budget`).
- After any external fill, update the taker’s local quote budget (`remainingQuote` or `availableQuote`) immediately so subsequent settlement and bookkeeping stay consistent.
- No database schema or migration changes were made (so no SQL changes to run).

### Testing
- Ran `npm run test:integration` and all integration tests passed (19/19 ok). 
- Ran `npm run lint` and `npm run typecheck` with no errors. 
- Ran `npm run build` which completed successfully; noted runtime warnings about missing env keys and outdated `caniuse-lite` as described below.
- Build warnings: missing env keys (`DB_HOST, DB_USER, DB_PASS, DB_NAME, NEXT_PUBLIC_API_BASE, SMTP_*`) classified as "runtime-impactful" and require setting `.env` for production; `caniuse-lite is outdated` classified as non-impactful for correctness and can be fixed with `npx update-browserslist-db@latest`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec091c6db8832b91ef9785c5a28c73)