### PR TITLE
fix(spot): reserve quote before external market buy routing to prevent balance divergence

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -11268,6 +11268,7 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
     }
 
     let reservedQuote = 0n;
+    let marketBuyReservedQuote = 0n;
     let availableQuote = quoteBalance;
     if (side === 'buy') {
       if (type === 'limit') {
@@ -11289,6 +11290,12 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
           await conn.rollback();
           return next({ status: 400, code: 'INSUFFICIENT_BALANCE', message: 'Insufficient quote balance' });
         }
+        await conn.query('UPDATE user_balances SET balance_wei = balance_wei - ? WHERE user_id=? AND UPPER(asset)=?', [
+          quoteBalance.toString(),
+          userId,
+          quoteAsset,
+        ]);
+        marketBuyReservedQuote = quoteBalance;
         availableQuote = quoteBalance;
       }
     } else {
@@ -11720,16 +11727,20 @@ app.post('/spot/orders', walletLimiter, async (req, res, next) => {
         );
       }
       if (type === 'market') {
-        if (matchResult.spentQuote > 0n) {
-          if (quoteBalance < matchResult.spentQuote) {
-            await conn.rollback();
-            return next({ status: 400, code: 'INSUFFICIENT_BALANCE', message: 'Insufficient quote balance' });
-          }
-          await conn.query('UPDATE user_balances SET balance_wei = balance_wei - ? WHERE user_id=? AND UPPER(asset)=?', [
-            matchResult.spentQuote.toString(),
-            userId,
-            quoteAsset,
-          ]);
+        if (matchResult.spentQuote > marketBuyReservedQuote) {
+          await conn.rollback();
+          return next({
+            status: 500,
+            code: 'SPOT_MARKET_BUY_RESERVE_EXCEEDED',
+            message: 'Market buy execution exceeded reserved quote budget',
+          });
+        }
+        const marketBuyRefund = marketBuyReservedQuote > matchResult.spentQuote ? marketBuyReservedQuote - matchResult.spentQuote : 0n;
+        if (marketBuyRefund > 0n) {
+          await conn.query(
+            'INSERT INTO user_balances (user_id, asset, balance_wei) VALUES (?,?,?) ON DUPLICATE KEY UPDATE balance_wei = balance_wei + VALUES(balance_wei)',
+            [userId, quoteAsset, marketBuyRefund.toString()]
+          );
         }
         remainingQuote = 0n;
       } else if (orderStatus !== 'open' && remainingQuote > 0n) {


### PR DESCRIPTION
### Motivation
- Prevent divergence where an external (Binance) market buy executes while the platform later returns `INSUFFICIENT_BALANCE` because internal quote was not debited before external execution.  
- Make the platform behavior deterministic and safe for market buys by reserving/debiting funds inside the same DB transaction used for matching and external routing.

### Description
- Debit the user's full quote balance up-front for `market`-side `buy` orders and track it in a new local variable `marketBuyReservedQuote` in `api/src/app.js`.  
- Replace the late post-execution `INSUFFICIENT_BALANCE` path with a strict invariant check that fails with `SPOT_MARKET_BUY_RESERVE_EXCEEDED` if the execution would somehow spend more than the reserved quote.  
- Refund any unspent reserved quote after settlement by inserting the remaining amount back into `user_balances` so users only pay the actual `spentQuote + fees`.  
- Scope limited to `POST /spot/orders` market-buy flow; no DB schema/migration changes required.

### Testing
- Ran integration tests with `npm run test:integration` and all tests passed.  
- Built the Next app with `npm run build` and build completed successfully.  
- API smoke: started API in demo mode (`DEMO_MODE=true node api/server.js`) and verified `/wallet/usdt-balance` responded (unauthenticated) with `401`, confirming server is up.  
- Next smoke: started Next with `npm run start` after build and verified `/` returned `200` (server up).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec13a65a7c832b810349d5566a4e22)