### PR TITLE
Prevent mobile keyboard auto-zoom on trading inputs (viewport + global CSS fixes)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -18,16 +18,35 @@ body {
   height: 100%;
 }
 
+html {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
 body {
   color: var(--x-text);
   background: var(--x-bg);
   background-image: radial-gradient(circle at 14% 8%, rgba(201, 167, 92, 0.2), transparent 28%),
     radial-gradient(circle at 88% 2%, rgba(244, 222, 154, 0.14), transparent 24%);
   letter-spacing: 0.01em;
+  touch-action: manipulation;
 }
 
 a {
   color: inherit;
+}
+
+@media (max-width: 1024px) {
+  input[type='text'],
+  input[type='number'],
+  input[type='tel'],
+  input[type='password'],
+  input[type='email'],
+  input[type='search'],
+  textarea {
+    font-size: 16px;
+    line-height: 1.35;
+  }
 }
 
 .btn {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import 'server-only';
 import './globals.css';
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { LangProvider } from './lib/i18n';
 import { ToastProvider } from './lib/toast';
 import { AuthProvider } from './lib/auth';
@@ -12,6 +12,14 @@ import AnalyticsRuntime from './AnalyticsRuntime';
 import ActivityTracker from './ActivityTracker';
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://lordai.net';
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+  viewportFit: 'cover',
+};
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -3,7 +3,12 @@ import { Head, Html, Main, NextScript } from 'next/document';
 export default function Document() {
   return (
     <Html lang="en">
-      <Head />
+      <Head>
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+        />
+      </Head>
       <body>
         <Main />
         <NextScript />


### PR DESCRIPTION
### Motivation
- Mobile browsers (iOS Safari / Chrome Mobile) were auto-zooming the entire page when any text/number input received focus on trading pages, breaking UX for Spot / Order Form flows.
- The fix must be global, minimal, and safe for desktop responsiveness while preventing input-triggered zoom on mobile devices.

### Description
- Added a root `viewport` export in `app/layout.tsx` to lock scale (`initialScale:1`, `maximumScale:1`, `userScalable:false`) and include `viewportFit: 'cover'` for safe mobile rendering.
- Added a defensive `<meta name="viewport" ...>` tag in `pages/_document.tsx` to cover legacy/document rendering paths.
- Added global CSS safeguards in `app/globals.css` including `-webkit-text-size-adjust` / `text-size-adjust`, `touch-action: manipulation` on `body`, and a mobile media-query that forces `font-size: 16px` and a stable `line-height` for text-like inputs and `textarea` to prevent iOS auto-zoom.
- Changes are scoped to global layout/CSS only and are minimal to avoid affecting desktop responsiveness or app performance.
- Files modified: `app/layout.tsx`, `app/globals.css`, `pages/_document.tsx`.

### Testing
- Ran `npm run build` and the Next.js production build completed successfully.
- Ran `npm run lint` and there were no ESLint warnings or errors.
- Ran `npm run typecheck` (TypeScript `tsc --noEmit`) and it passed with no errors.
- Ran `npm run test:integration` and all integration tests passed (19/19).
- Attempted automated mobile screenshots via Playwright, but browser launch failed in-container due to missing host libraries (`libatk-1.0.so.0`, etc.), so screenshot generation could not complete; this is an environment limitation rather than a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb62b292c832bb2cb503c850cd003)