### PR TITLE
fix(db): use correct platform_settings column in convert migrations

### DIFF
--- a/db/migrations/202604271500_convert_pairs.sql
+++ b/db/migrations/202604271500_convert_pairs.sql
@@ -1,6 +1,6 @@
 -- Convert pairs and settings
 
-INSERT INTO platform_settings (`key`, `value`) VALUES ('convert_fee_bps','50'), ('convert_min_usdt','10') ON DUPLICATE KEY UPDATE `value`=VALUES(`value`);
+INSERT INTO platform_settings (`name`, `value`) VALUES ('convert_fee_bps','50'), ('convert_min_usdt','10') ON DUPLICATE KEY UPDATE `value`=VALUES(`value`);
 
 CREATE TABLE IF NOT EXISTS convert_pairs (
   id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,

--- a/db/migrations/202604271900_convert_onchain_execution.sql
+++ b/db/migrations/202604271900_convert_onchain_execution.sql
@@ -1,6 +1,6 @@
 -- Convert on-chain execution metadata and runtime settings
 
-INSERT INTO platform_settings (`key`, `value`) VALUES
+INSERT INTO platform_settings (`name`, `value`) VALUES
   ('convert_execution_mode', 'mock'),
   ('convert_slippage_bps', '120')
 ON DUPLICATE KEY UPDATE `value`=VALUES(`value`);


### PR DESCRIPTION
### Motivation
- Migrations inserted into `platform_settings` used the non-existent column ``key`` which causes MySQL `#1054 Unknown column 'key'` on databases that use the `name/value` schema. 
- The change ensures new convert-related migrations are compatible with the existing `platform_settings` table schema so deployments/migration runners won't fail.

### Description
- Replaced `platform_settings (\`key\`, \`value\`)` with `platform_settings (\`name\`, \`value\`)` in the convert migration files. 
- Files updated: `db/migrations/202604271500_convert_pairs.sql` and `db/migrations/202604271900_convert_onchain_execution.sql`.
- Kept all other SQL logic intact (table creation, inserts, updates and `ON DUPLICATE KEY UPDATE` behavior unchanged).

### Testing
- Ran `npm run build` and the production build completed successfully (exit code 0). 
- The build emitted a single existing ESLint warning about using `<img>` instead of `next/image` in `app/(app)/trade/convert/page.tsx`, classified as non-blocking. 
- The build also warned about missing environment keys (`DB_HOST`, `DB_USER`, `DB_PASS`, `DB_NAME`, `NEXT_PUBLIC_API_BASE`, `SMTP_*`) but completed successfully, classified as non-blocking for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef7be332ac832ba66d447d9ef61363)