### PR TITLE
fix(convert): validate header idempotency key and backfill execution index

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -863,8 +863,10 @@ const ConvertQuoteSchema = z.object({
   amount: z.string().min(1),
 });
 
+const ConvertIdempotencyKeySchema = z.string().trim().min(8).max(128);
+
 const ConvertExecuteSchema = ConvertQuoteSchema.extend({
-  idempotency_key: z.string().trim().min(8).max(128).optional(),
+  idempotency_key: ConvertIdempotencyKeySchema.optional(),
 });
 
 const AdminStripePricingUpdateSchema = z
@@ -10614,7 +10616,22 @@ app.post('/convert/execute', walletLimiter, async (req, res, next) => {
   try {
     userId = await requireUser(req);
     const payload = ConvertExecuteSchema.parse(req.body || {});
-    const idempotencyKey = String(payload.idempotency_key || req.headers['idempotency-key'] || '').trim() || null;
+    const headerIdempotencyRaw = req.headers['idempotency-key'];
+    const headerIdempotency = Array.isArray(headerIdempotencyRaw) ? headerIdempotencyRaw[0] : headerIdempotencyRaw;
+    const idempotencySource = payload.idempotency_key ?? headerIdempotency;
+    let idempotencyKey = null;
+    if (idempotencySource != null && String(idempotencySource).trim() !== '') {
+      const parsedIdempotency = ConvertIdempotencyKeySchema.safeParse(idempotencySource);
+      if (!parsedIdempotency.success) {
+        return next({
+          status: 400,
+          code: 'BAD_INPUT',
+          message: 'Invalid idempotency key',
+          details: parsedIdempotency.error.flatten(),
+        });
+      }
+      idempotencyKey = parsedIdempotency.data;
+    }
     const pair = await getConvertPairBySymbol(payload.symbol, payload.category || null);
     if (!pair) return next({ status: 404, code: 'PAIR_NOT_FOUND', message: 'Convert pair not found' });
     const settings = await readConvertSettings();

--- a/api/tests/integration.test.js
+++ b/api/tests/integration.test.js
@@ -523,6 +523,19 @@ test('POST /convert/execute returns replay response for same idempotency key', a
   assert.equal(res.body?.idempotent_replay, true);
 });
 
+test('POST /convert/execute validates idempotency key header before database insert', async () => {
+  const tooLongKey = 'k'.repeat(129);
+  const beforeCount = testSchema.convertExecutions.length;
+  const res = await request
+    .post('/convert/execute')
+    .set('Cookie', 'sid=valid-session')
+    .set('idempotency-key', tooLongKey)
+    .send({ category: 'crypto', symbol: 'BNB/USDT', side: 'buy', amount: '1' });
+  assert.equal(res.status, 400);
+  assert.equal(res.body?.error?.code, 'BAD_INPUT');
+  assert.equal(testSchema.convertExecutions.length, beforeCount);
+});
+
 test('POST /convert/execute blocks live mode when wallet env is missing and fallback disabled', async () => {
   testSchema.convertSettings.convert_execution_mode = 'live';
   testSchema.convertSettings.convert_live_fallback_mock = '0';

--- a/db/migrations/202604271900_convert_onchain_execution.sql
+++ b/db/migrations/202604271900_convert_onchain_execution.sql
@@ -107,3 +107,19 @@ PREPARE alter_convert_exec_stmt FROM @alter_convert_exec_sql;
 EXECUTE alter_convert_exec_stmt;
 DEALLOCATE PREPARE alter_convert_exec_stmt;
 
+
+SET @has_exec_idempotency_idx := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA=@schema_name
+    AND TABLE_NAME='convert_executions'
+    AND INDEX_NAME='idx_convert_executions_idempotency'
+);
+SET @add_convert_exec_idempotency_idx_sql := IF(
+  @has_exec_idempotency_idx = 0,
+  'ALTER TABLE convert_executions ADD KEY idx_convert_executions_idempotency (user_id, idempotency_key)',
+  'SELECT 1'
+);
+PREPARE add_convert_exec_idempotency_idx_stmt FROM @add_convert_exec_idempotency_idx_sql;
+EXECUTE add_convert_exec_idempotency_idx_stmt;
+DEALLOCATE PREPARE add_convert_exec_idempotency_idx_stmt;
+


### PR DESCRIPTION
### Motivation
- Prevent oversized/invalid `idempotency-key` header values from reaching the DB and causing insert errors by validating headers with the same rules used for body payloads.
- Ensure existing databases that predate the migration have the `idx_convert_executions_idempotency (user_id, idempotency_key)` index to improve lookups and enforce idempotency performance.

### Description
- Add a reusable `ConvertIdempotencyKeySchema` and use it to validate `idempotency_key` from either the request body or the `idempotency-key` header before opening a DB transaction, returning `BAD_INPUT` with validation details on failure.
- Change parsing logic to safely accept a single header value when `idempotency-key` is provided as an array and to `safeParse` it to avoid oversized values being sent to MySQL.
- Update migration `db/migrations/202604271900_convert_onchain_execution.sql` to idempotently add the `idx_convert_executions_idempotency (user_id, idempotency_key)` index when missing.
- Add an integration test `POST /convert/execute validates idempotency key header before database insert` to cover rejection of an oversized header key and verify no execution row is inserted.

### Testing
- Ran `npm run test:integration`; all tests passed (24/24).
- Ran `npm run build`; build succeeded (Next.js build completed) with one existing non-blocking lint warning `@next/next/no-img-element` in `app/(app)/trade/convert/page.tsx` (classified as non-impacting).
- Ran `npm run lint`; linter completed with the same existing warning and no new errors introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef89439390832b9842d308192e7ec2)