### PR TITLE
Redesign Convert UX and add Admin Convert Reporting Dashboard

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -10812,6 +10812,86 @@ app.get('/admin/convert/pairs', async (req, res, next) => {
   }
 });
 
+app.get('/admin/convert/reports', async (req, res, next) => {
+  try {
+    await requireAdmin(req);
+    const [overviewRows] = await pool.query(
+      `SELECT
+         COUNT(*) AS total_executions,
+         SUM(CASE WHEN ce.status='completed' THEN 1 ELSE 0 END) AS completed_executions,
+         SUM(CASE WHEN ce.status='failed' THEN 1 ELSE 0 END) AS failed_executions,
+         COALESCE(SUM(CASE WHEN ce.status='completed' THEN CAST(ce.quote_without_fee_wei AS DECIMAL(65,0)) ELSE 0 END),0) AS quote_without_fee_wei,
+         COALESCE(SUM(CASE WHEN ce.status='completed' THEN CAST(ce.fee_wei AS DECIMAL(65,0)) ELSE 0 END),0) AS fee_wei
+       FROM convert_executions ce`
+    );
+    const [categoryRows] = await pool.query(
+      `SELECT cp.category,
+              COUNT(*) AS executions,
+              SUM(CASE WHEN ce.status='completed' THEN 1 ELSE 0 END) AS completed,
+              SUM(CASE WHEN ce.status='failed' THEN 1 ELSE 0 END) AS failed,
+              COALESCE(SUM(CASE WHEN ce.status='completed' THEN CAST(ce.quote_without_fee_wei AS DECIMAL(65,0)) ELSE 0 END),0) AS quote_without_fee_wei,
+              COALESCE(SUM(CASE WHEN ce.status='completed' THEN CAST(ce.fee_wei AS DECIMAL(65,0)) ELSE 0 END),0) AS fee_wei
+         FROM convert_executions ce
+         JOIN convert_pairs cp ON cp.id = ce.pair_id
+        GROUP BY cp.category
+        ORDER BY FIELD(cp.category, 'gold', 'stocks', 'crypto')`
+    );
+    const [topPairsRows] = await pool.query(
+      `SELECT cp.category,
+              cp.symbol,
+              COUNT(*) AS executions,
+              COALESCE(SUM(CASE WHEN ce.status='completed' THEN CAST(ce.quote_without_fee_wei AS DECIMAL(65,0)) ELSE 0 END),0) AS quote_without_fee_wei,
+              COALESCE(SUM(CASE WHEN ce.status='completed' THEN CAST(ce.fee_wei AS DECIMAL(65,0)) ELSE 0 END),0) AS fee_wei
+         FROM convert_executions ce
+         JOIN convert_pairs cp ON cp.id = ce.pair_id
+        GROUP BY cp.category, cp.symbol
+        ORDER BY quote_without_fee_wei DESC
+        LIMIT 12`
+    );
+    const [dailyRows] = await pool.query(
+      `SELECT DATE(ce.created_at) AS day,
+              COUNT(*) AS executions,
+              COALESCE(SUM(CASE WHEN ce.status='completed' THEN CAST(ce.quote_without_fee_wei AS DECIMAL(65,0)) ELSE 0 END),0) AS quote_without_fee_wei,
+              COALESCE(SUM(CASE WHEN ce.status='completed' THEN CAST(ce.fee_wei AS DECIMAL(65,0)) ELSE 0 END),0) AS fee_wei
+         FROM convert_executions ce
+        WHERE ce.created_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 14 DAY)
+        GROUP BY DATE(ce.created_at)
+        ORDER BY day DESC`
+    );
+    const [recentRows] = await pool.query(
+      `SELECT ce.id,
+              ce.user_id,
+              cp.category,
+              cp.symbol,
+              ce.side,
+              ce.status,
+              ce.debit_asset,
+              ce.debit_wei,
+              ce.credited_asset,
+              ce.credited_wei,
+              ce.quote_without_fee_wei,
+              ce.quote_decimals,
+              ce.fee_wei,
+              ce.tx_hash,
+              ce.created_at
+         FROM convert_executions ce
+         JOIN convert_pairs cp ON cp.id = ce.pair_id
+        ORDER BY ce.id DESC
+        LIMIT 20`
+    );
+    res.json({
+      ok: true,
+      overview: overviewRows[0] || null,
+      categories: categoryRows,
+      top_pairs: topPairsRows,
+      daily: dailyRows,
+      recent: recentRows,
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
 app.post('/admin/convert/pairs', async (req, res, next) => {
   try {
     await requireAdmin(req);

--- a/app/(app)/trade/convert/page.tsx
+++ b/app/(app)/trade/convert/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowDownUp, RefreshCw } from 'lucide-react';
+import { ArrowDownUp, BadgeDollarSign, RefreshCw, ShieldCheck, Sparkles, Wallet } from 'lucide-react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
@@ -51,6 +51,21 @@ function cleanDisplayName(value: string): string {
   return value.replace(/\bondo\b/gi, '').replace(/\s{2,}/g, ' ').trim();
 }
 
+function categoryStyle(item: Category, active: boolean): string {
+  const base = 'rounded-xl border px-3 py-2 text-center text-sm font-medium transition';
+  if (!active) return `${base} border-white/10 bg-white/[0.03] text-white/70 hover:border-white/25 hover:text-white`;
+  if (item === 'gold') return `${base} border-amber-300/70 bg-amber-500/15 text-amber-100`;
+  if (item === 'stocks') return `${base} border-indigo-300/70 bg-indigo-500/15 text-indigo-100`;
+  return `${base} border-cyan-300/70 bg-cyan-500/15 text-cyan-100`;
+}
+
+function formatPrice(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return '0.0000';
+  if (value >= 1000) return value.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  if (value >= 1) return value.toLocaleString(undefined, { maximumFractionDigits: 4 });
+  return value.toLocaleString(undefined, { maximumFractionDigits: 6 });
+}
+
 function ConvertPageContent() {
   const searchParams = useSearchParams();
   const toast = useToast();
@@ -73,6 +88,29 @@ function ConvertPageContent() {
 
   const selectedPair = useMemo(() => pairs.find((item) => item.symbol === selectedSymbol) || null, [pairs, selectedSymbol]);
   const amountNum = parsePositive(amount);
+
+  const labels = useMemo(
+    () => ({
+      title: isArabic ? 'منصة تحويل احترافية' : 'Professional Convert Desk',
+      subtitle: isArabic
+        ? 'تحويل الذهب، الاسهم، والكريبتو بسرعة مع تجربة احترافية'
+        : 'Convert gold, stocks, and crypto with a polished institutional flow',
+      back: isArabic ? 'رجوع' : 'Back',
+      choosePair: isArabic ? 'اختار الزوج' : 'Choose pair',
+      buy: isArabic ? 'شراء' : 'Buy',
+      sell: isArabic ? 'بيع' : 'Sell',
+      estimate: isArabic ? 'القيمة التقديرية' : 'Estimated value',
+      fee: isArabic ? 'رسوم الكونفرت' : 'Convert fee',
+      execute: isArabic ? 'تنفيذ التحويل' : 'Execute convert',
+      executing: isArabic ? 'جاري التنفيذ...' : 'Executing...',
+      runtimeWarning: isArabic ? 'تحذير تشغيل' : 'Runtime warning',
+      mode: isArabic ? 'وضع التنفيذ' : 'Execution mode',
+      live: isArabic ? 'حي - PancakeSwap' : 'Live - PancakeSwap',
+      mock: isArabic ? 'تجريبي' : 'Mock',
+      quickAmounts: isArabic ? 'مبالغ سريعة' : 'Quick amounts',
+    }),
+    [isArabic]
+  );
 
   const loadPairs = useCallback(async () => {
     setLoading(true);
@@ -105,12 +143,7 @@ function ConvertPageContent() {
       }
       const res = await apiFetch<ConvertQuoteResponse>('/convert/quote', {
         method: 'POST',
-        body: JSON.stringify({
-          category,
-          symbol: selectedPair.symbol,
-          side,
-          amount: amountNum.toString(),
-        }),
+        body: JSON.stringify({ category, symbol: selectedPair.symbol, side, amount: amountNum.toString() }),
       });
       if (!res.ok) {
         setEstimate(0);
@@ -133,9 +166,7 @@ function ConvertPageContent() {
     }
     if (estimate < minUsdt) {
       toast({
-        message: isArabic
-          ? `اقل قيمة تنفيذ حاليا ${minUsdt.toFixed(2)} USDT`
-          : `Minimum convert value is ${minUsdt.toFixed(2)} USDT`,
+        message: isArabic ? `اقل قيمة تنفيذ حاليا ${minUsdt.toFixed(2)} USDT` : `Minimum convert value is ${minUsdt.toFixed(2)} USDT`,
         variant: 'error',
       });
       return;
@@ -144,12 +175,7 @@ function ConvertPageContent() {
     setPlacing(true);
     const res = await apiFetch('/convert/execute', {
       method: 'POST',
-      body: JSON.stringify({
-        category,
-        symbol: selectedPair.symbol,
-        side,
-        amount: amountNum.toString(),
-      }),
+      body: JSON.stringify({ category, symbol: selectedPair.symbol, side, amount: amountNum.toString() }),
     });
     setPlacing(false);
     if (!res.ok) {
@@ -163,40 +189,47 @@ function ConvertPageContent() {
   }, [amountNum, category, estimate, isArabic, minUsdt, selectedPair, side, toast]);
 
   return (
-    <section className="mx-auto w-full max-w-3xl space-y-4 p-4 md:p-6">
-      <div className="flex items-center justify-between gap-3">
-        <h1 className="text-2xl font-bold text-white">{isArabic ? 'Convert Swap' : 'Convert Swap'}</h1>
-        <Link href="/trade" className="rounded-full border border-white/15 px-3 py-1 text-xs text-white/70 hover:text-white">
-          {isArabic ? 'رجوع' : 'Back'}
-        </Link>
+    <section className="mx-auto w-full max-w-5xl space-y-5 px-4 py-4 md:px-6 md:py-6">
+      <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-[#0e1730] via-[#0f243c] to-[#111629] p-5 text-white md:p-7">
+        <div className="absolute -right-12 -top-12 h-40 w-40 rounded-full bg-cyan-400/20 blur-3xl" />
+        <div className="absolute -bottom-16 left-1/4 h-44 w-44 rounded-full bg-indigo-400/10 blur-3xl" />
+        <div className="relative flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-2">
+            <div className="inline-flex items-center gap-2 rounded-full border border-cyan-300/30 bg-cyan-400/10 px-3 py-1 text-xs text-cyan-100">
+              <Sparkles className="h-3.5 w-3.5" /> {isArabic ? 'ELTX Convert Pro' : 'ELTX Convert Pro'}
+            </div>
+            <h1 className="text-2xl font-bold md:text-3xl">{labels.title}</h1>
+            <p className="max-w-2xl text-sm text-white/70 md:text-base">{labels.subtitle}</p>
+          </div>
+          <Link href="/trade" className="rounded-full border border-white/20 bg-black/20 px-3 py-1.5 text-xs text-white/80 transition hover:border-white/40 hover:text-white">
+            {labels.back}
+          </Link>
+        </div>
       </div>
+
       <div className="grid grid-cols-3 gap-2">
         {(['gold', 'stocks', 'crypto'] as Category[]).map((item) => (
-          <Link
-            key={item}
-            href={`/trade/convert?category=${item}`}
-            className={`rounded-xl border px-3 py-2 text-center text-sm ${
-              category === item ? 'border-cyan-300 bg-cyan-500/15 text-cyan-100' : 'border-white/10 text-white/70'
-            }`}
-          >
+          <Link key={item} href={`/trade/convert?category=${item}`} className={categoryStyle(item, category === item)}>
             {item.toUpperCase()}
           </Link>
         ))}
       </div>
 
-      <div className="rounded-3xl border border-white/10 bg-[#111629] p-4 text-white md:p-5">
-        <div className="mb-3 flex items-center justify-between">
-          <div className="text-sm text-white/75">{isArabic ? 'اختار الزوج' : 'Choose pair'}</div>
-          <button onClick={loadPairs} className="rounded-lg border border-white/10 p-1.5 text-white/70 hover:text-white" type="button">
-            <RefreshCw className="h-4 w-4" />
+      <div className="rounded-3xl border border-white/10 bg-[#0e1327]/95 p-4 text-white shadow-2xl shadow-black/20 md:p-6">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-sm text-white/80">
+            <BadgeDollarSign className="h-4 w-4 text-cyan-200" /> {labels.choosePair}
+          </div>
+          <button
+            onClick={loadPairs}
+            className="inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/[0.03] px-3 py-1.5 text-xs text-white/70 transition hover:border-white/25 hover:text-white"
+            type="button"
+          >
+            <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} /> {isArabic ? 'تحديث' : 'Refresh'}
           </button>
         </div>
 
-        <select
-          value={selectedSymbol}
-          onChange={(e) => setSelectedSymbol(e.target.value)}
-          className="w-full rounded-2xl border border-white/10 bg-black/30 p-3"
-        >
+        <select value={selectedSymbol} onChange={(e) => setSelectedSymbol(e.target.value)} className="w-full rounded-2xl border border-white/10 bg-black/30 p-3 text-sm">
           {pairs.map((pair) => (
             <option key={pair.id} value={pair.symbol}>
               {pair.symbol} - {cleanDisplayName(pair.display_name)}
@@ -205,35 +238,45 @@ function ConvertPageContent() {
         </select>
 
         {selectedPair && (
-          <div className="mt-3 flex items-center gap-3 rounded-xl border border-white/10 bg-white/5 p-2.5">
-            <div className="relative h-8 w-8 overflow-hidden rounded-full bg-white/10">
-              {selectedPair.logo_url ? <img src={selectedPair.logo_url} alt={selectedPair.token_symbol} className="h-full w-full object-cover" /> : null}
+          <div className="mt-3 flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/[0.03] p-3">
+            <div className="flex items-center gap-3">
+              <div className="relative h-10 w-10 overflow-hidden rounded-full bg-white/10 ring-1 ring-white/15">
+                {selectedPair.logo_url ? <img src={selectedPair.logo_url} alt={selectedPair.token_symbol} className="h-full w-full object-cover" /> : null}
+              </div>
+              <div>
+                <div className="text-sm font-semibold">{selectedPair.symbol}</div>
+                <div className="text-xs text-white/60">{cleanDisplayName(selectedPair.display_name)}</div>
+              </div>
             </div>
-            <div>
-              <div className="text-sm font-semibold">{selectedPair.symbol}</div>
-              <div className="text-xs text-white/65">{cleanDisplayName(selectedPair.display_name)}</div>
+            <div className="text-right text-xs text-white/60">
+              <div>{labels.mode}</div>
+              <div className="font-semibold text-white/80">{convertMode === 'live' ? labels.live : labels.mock}</div>
             </div>
           </div>
         )}
 
-        <div className="mt-4 flex gap-2">
+        <div className="mt-4 grid grid-cols-2 gap-2">
           <button
             type="button"
             onClick={() => setSide('buy')}
-            className={`flex-1 rounded-xl px-4 py-2 text-sm ${side === 'buy' ? 'bg-emerald-500/20 text-emerald-200' : 'bg-white/5 text-white/70'}`}
+            className={`rounded-xl px-4 py-2.5 text-sm transition ${
+              side === 'buy' ? 'border border-emerald-300/60 bg-emerald-500/20 text-emerald-100' : 'border border-white/10 bg-white/[0.03] text-white/70'
+            }`}
           >
-            {isArabic ? 'شراء' : 'Buy'}
+            {labels.buy}
           </button>
           <button
             type="button"
             onClick={() => setSide('sell')}
-            className={`flex-1 rounded-xl px-4 py-2 text-sm ${side === 'sell' ? 'bg-red-500/20 text-red-200' : 'bg-white/5 text-white/70'}`}
+            className={`rounded-xl px-4 py-2.5 text-sm transition ${
+              side === 'sell' ? 'border border-rose-300/60 bg-rose-500/20 text-rose-100' : 'border border-white/10 bg-white/[0.03] text-white/70'
+            }`}
           >
-            {isArabic ? 'بيع' : 'Sell'}
+            {labels.sell}
           </button>
         </div>
 
-        <div className="mt-4 rounded-2xl border border-white/10 bg-white/5 p-3">
+        <div className="mt-4 rounded-2xl border border-white/10 bg-gradient-to-br from-white/[0.05] to-white/[0.02] p-4">
           <div className="text-xs text-white/60">
             {side === 'buy'
               ? isArabic
@@ -243,7 +286,7 @@ function ConvertPageContent() {
               ? `كمية ${selectedPair?.base_asset || ''} اللي عايز تبيعها`
               : `Amount of ${selectedPair?.base_asset || ''} to sell`}
           </div>
-          <div className="mt-2 flex items-center gap-2">
+          <div className="mt-2 flex items-center gap-2 rounded-xl border border-white/10 bg-black/20 px-3 py-2.5">
             <input
               type="number"
               min="0"
@@ -255,18 +298,44 @@ function ConvertPageContent() {
             />
             <ArrowDownUp className="h-4 w-4 text-white/40" />
           </div>
-          <div className="mt-2 text-xs text-white/60">
-            {isArabic ? 'تقدير قيمة الصفقة' : 'Estimated quote value'}: <span className="font-semibold">{estimate.toFixed(4)} USDT</span>
+
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <span className="text-xs text-white/55">{labels.quickAmounts}:</span>
+            {['10', '25', '50', '100'].map((quick) => (
+              <button
+                key={quick}
+                type="button"
+                onClick={() => setAmount(quick)}
+                className="rounded-full border border-white/15 bg-white/[0.04] px-2.5 py-1 text-xs text-white/75 transition hover:border-white/30 hover:text-white"
+              >
+                {quick}
+              </button>
+            ))}
           </div>
-          <div className="mt-1 text-xs text-white/60">
-            {isArabic ? 'رسوم الكونفرت' : 'Convert fee'}: {(feeBps / 100).toFixed(2)}% ({feeUsdt.toFixed(4)} USDT) · {isArabic ? 'حد ادني' : 'Min'} {minUsdt} USDT
+
+          <div className="mt-4 grid gap-2 sm:grid-cols-3">
+            <div className="rounded-xl border border-white/10 bg-black/20 p-2.5 text-xs text-white/70">
+              <div className="text-white/50">{labels.estimate}</div>
+              <div className="mt-1 text-sm font-semibold text-white">{formatPrice(estimate)} USDT</div>
+            </div>
+            <div className="rounded-xl border border-white/10 bg-black/20 p-2.5 text-xs text-white/70">
+              <div className="text-white/50">{labels.fee}</div>
+              <div className="mt-1 text-sm font-semibold text-white">{(feeBps / 100).toFixed(2)}% ({formatPrice(feeUsdt)} USDT)</div>
+            </div>
+            <div className="rounded-xl border border-white/10 bg-black/20 p-2.5 text-xs text-white/70">
+              <div className="text-white/50">{isArabic ? 'الحد الادنى' : 'Minimum'}</div>
+              <div className="mt-1 text-sm font-semibold text-white">{minUsdt.toFixed(2)} USDT</div>
+            </div>
           </div>
-          <div className="mt-1 text-xs text-white/50">
-            {isArabic ? 'وضع التنفيذ' : 'Execution mode'}: {convertMode === 'live' ? (isArabic ? 'حي - PancakeSwap' : 'Live - PancakeSwap') : isArabic ? 'تجريبي' : 'Mock'}
+
+          <div className="mt-3 flex items-center gap-2 rounded-xl border border-emerald-300/20 bg-emerald-500/10 p-2.5 text-xs text-emerald-100">
+            <ShieldCheck className="h-3.5 w-3.5" />
+            <span>{isArabic ? 'تنفيذ مع فحص الرسوم والحد الادنى قبل الارسال' : 'Execution validates fee and minimum threshold before submit'}</span>
           </div>
+
           {runtimeWarning ? (
             <div className="mt-2 rounded-lg border border-amber-500/40 bg-amber-500/10 p-2 text-xs text-amber-200">
-              {isArabic ? 'تحذير تشغيل' : 'Runtime warning'}: {runtimeWarning}
+              {labels.runtimeWarning}: {runtimeWarning}
             </div>
           ) : null}
         </div>
@@ -275,9 +344,9 @@ function ConvertPageContent() {
           type="button"
           onClick={executeSwap}
           disabled={placing || loading || !selectedPair}
-          className="mt-4 w-full rounded-2xl bg-cyan-500 py-3 text-center font-semibold text-black transition hover:bg-cyan-400 disabled:opacity-60"
+          className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-cyan-500 py-3 text-center font-semibold text-black transition hover:bg-cyan-400 disabled:opacity-60"
         >
-          {placing ? (isArabic ? 'جاري التنفيذ...' : 'Executing...') : isArabic ? 'تنفيذ التحويل' : 'Execute Convert'}
+          <Wallet className="h-4 w-4" /> {placing ? labels.executing : labels.execute}
         </button>
       </div>
     </section>

--- a/app/mo/AdminApp.tsx
+++ b/app/mo/AdminApp.tsx
@@ -140,6 +140,58 @@ type FeeSettings = {
 };
 
 type FeeBalanceRow = { fee_type: 'swap' | 'spot' | 'withdrawal' | string; asset: string; amount: string; amount_wei: string; entries: number };
+type ConvertReportOverview = {
+  total_executions: number;
+  completed_executions: number;
+  failed_executions: number;
+  quote_without_fee_wei: string;
+  fee_wei: string;
+};
+type ConvertReportCategory = {
+  category: 'gold' | 'stocks' | 'crypto' | string;
+  executions: number;
+  completed: number;
+  failed: number;
+  quote_without_fee_wei: string;
+  fee_wei: string;
+};
+type ConvertReportPair = {
+  category: 'gold' | 'stocks' | 'crypto' | string;
+  symbol: string;
+  executions: number;
+  quote_without_fee_wei: string;
+  fee_wei: string;
+};
+type ConvertReportDay = {
+  day: string;
+  executions: number;
+  quote_without_fee_wei: string;
+  fee_wei: string;
+};
+type ConvertReportRecent = {
+  id: number;
+  user_id: number;
+  category: 'gold' | 'stocks' | 'crypto' | string;
+  symbol: string;
+  side: 'buy' | 'sell' | string;
+  status: 'completed' | 'failed' | 'processing' | string;
+  debit_asset: string;
+  debit_wei: string;
+  credited_asset: string | null;
+  credited_wei: string | null;
+  quote_without_fee_wei: string;
+  quote_decimals: number;
+  fee_wei: string;
+  tx_hash: string | null;
+  created_at: string;
+};
+type ConvertReportsResponse = {
+  overview: ConvertReportOverview | null;
+  categories: ConvertReportCategory[];
+  top_pairs: ConvertReportPair[];
+  daily: ConvertReportDay[];
+  recent: ConvertReportRecent[];
+};
 
 type AiSettings = { daily_free_messages: number; message_price_usdt: string };
 type AiRuntime = {
@@ -4691,6 +4743,13 @@ function FeesPanel({ onNotify }: { onNotify: (message: string, variant?: 'succes
     candleFetchCap: '0',
   });
   const [savingProtection, setSavingProtection] = useState(false);
+  const [convertReports, setConvertReports] = useState<ConvertReportsResponse>({
+    overview: null,
+    categories: [],
+    top_pairs: [],
+    daily: [],
+    recent: [],
+  });
 
   const syncFormWithSettings = useCallback((next: FeeSettings) => {
     const makerBps = next.spot_maker_fee_bps ?? next.spot_trade_fee_bps ?? 0;
@@ -4710,9 +4769,10 @@ function FeesPanel({ onNotify }: { onNotify: (message: string, variant?: 'succes
 
   const load = useCallback(async () => {
     setLoading(true);
-    const [feeRes, protectionRes] = await Promise.all([
+    const [feeRes, protectionRes, convertReportsRes] = await Promise.all([
       apiFetch<{ settings: FeeSettings; balances: FeeBalanceRow[] }>('/admin/fees'),
       apiFetch<{ settings: SpotProtectionSettings }>('/admin/spot/protection'),
+      apiFetch<ConvertReportsResponse>('/admin/convert/reports'),
     ]);
 
     if (feeRes.ok) {
@@ -4736,6 +4796,18 @@ function FeesPanel({ onNotify }: { onNotify: (message: string, variant?: 'succes
       });
     } else {
       onNotify(protectionRes.error || 'Failed to load spot protection settings', 'error');
+    }
+
+    if (convertReportsRes.ok) {
+      setConvertReports({
+        overview: convertReportsRes.data.overview || null,
+        categories: Array.isArray(convertReportsRes.data.categories) ? convertReportsRes.data.categories : [],
+        top_pairs: Array.isArray(convertReportsRes.data.top_pairs) ? convertReportsRes.data.top_pairs : [],
+        daily: Array.isArray(convertReportsRes.data.daily) ? convertReportsRes.data.daily : [],
+        recent: Array.isArray(convertReportsRes.data.recent) ? convertReportsRes.data.recent : [],
+      });
+    } else {
+      onNotify(convertReportsRes.error || 'Failed to load convert reports', 'error');
     }
     setLoading(false);
   }, [onNotify, syncFormWithSettings]);
@@ -4786,6 +4858,20 @@ function FeesPanel({ onNotify }: { onNotify: (message: string, variant?: 'succes
       { swap: [] as FeeBalanceRow[], spot: [] as FeeBalanceRow[], withdrawal: [] as FeeBalanceRow[] }
     );
   }, [balances]);
+
+  const convertOverview = convertReports.overview;
+  const convertSuccessRate = useMemo(() => {
+    if (!convertOverview || !Number(convertOverview.total_executions || 0)) return 0;
+    return (Number(convertOverview.completed_executions || 0) / Number(convertOverview.total_executions || 0)) * 100;
+  }, [convertOverview]);
+
+  const formatUsdtFromWei = (value: string) => {
+    try {
+      return Number(formatUnits(value || '0', 18)).toLocaleString(undefined, { maximumFractionDigits: 4 });
+    } catch {
+      return '0';
+    }
+  };
 
   const updateFees = async () => {
     const payload: Record<string, unknown> = {};
@@ -5203,6 +5289,166 @@ function FeesPanel({ onNotify }: { onNotify: (message: string, variant?: 'succes
             {renderBalanceTable('Swap fees collected', groupedBalances.swap)}
             {renderBalanceTable('Spot fees collected', groupedBalances.spot)}
             {renderBalanceTable('Withdrawal fees collected', groupedBalances.withdrawal)}
+          </div>
+
+          <div className="rounded-2xl border border-cyan-400/20 bg-gradient-to-br from-cyan-500/10 via-slate-900/60 to-indigo-500/10 p-6">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h4 className="text-md font-semibold text-cyan-100">Convert intelligence dashboard</h4>
+                <p className="mt-1 text-sm text-white/65">Multi-category reporting for Gold, Stocks, and Crypto convert activity.</p>
+              </div>
+              <span className="rounded-full border border-cyan-300/30 bg-cyan-400/10 px-3 py-1 text-xs text-cyan-100">
+                Last 14 days + realtime totals
+              </span>
+            </div>
+
+            <div className="mt-4 grid gap-3 md:grid-cols-4">
+              <StatCard
+                title="Total executions"
+                value={(convertOverview?.total_executions || 0).toLocaleString()}
+                subtitle="Across all convert categories"
+                icon={Sparkles}
+              />
+              <StatCard
+                title="Success rate"
+                value={`${convertSuccessRate.toFixed(1)}%`}
+                subtitle={`${(convertOverview?.completed_executions || 0).toLocaleString()} completed / ${(convertOverview?.failed_executions || 0).toLocaleString()} failed`}
+                icon={ShieldCheck}
+              />
+              <StatCard
+                title="USDT gross volume"
+                value={`${formatUsdtFromWei(convertOverview?.quote_without_fee_wei || '0')} USDT`}
+                subtitle="Before fees"
+                icon={DollarSign}
+              />
+              <StatCard
+                title="USDT fees"
+                value={`${formatUsdtFromWei(convertOverview?.fee_wei || '0')} USDT`}
+                subtitle="Net platform convert revenue"
+                icon={Coins}
+              />
+            </div>
+
+            <div className="mt-5 grid gap-4 xl:grid-cols-3">
+              <div className="rounded-xl border border-white/10 bg-black/20 p-4 xl:col-span-1">
+                <h5 className="text-sm font-semibold text-white/85">Category breakdown</h5>
+                <div className="mt-3 space-y-2">
+                  {convertReports.categories.map((row) => (
+                    <div key={row.category} className="rounded-lg border border-white/10 bg-white/[0.02] p-2.5 text-xs">
+                      <div className="flex items-center justify-between text-white/80">
+                        <span className="uppercase">{row.category}</span>
+                        <span>{Number(row.executions || 0).toLocaleString()} exec</span>
+                      </div>
+                      <div className="mt-1 flex items-center justify-between text-white/60">
+                        <span>{Number(row.completed || 0).toLocaleString()} success</span>
+                        <span>{Number(row.failed || 0).toLocaleString()} failed</span>
+                      </div>
+                      <div className="mt-1 text-white/70">Vol: {formatUsdtFromWei(row.quote_without_fee_wei || '0')} USDT</div>
+                    </div>
+                  ))}
+                  {!convertReports.categories.length ? <div className="text-xs text-white/55">No convert data yet.</div> : null}
+                </div>
+              </div>
+
+              <div className="rounded-xl border border-white/10 bg-black/20 p-4 xl:col-span-2">
+                <h5 className="text-sm font-semibold text-white/85">Top pairs by volume</h5>
+                <div className="mt-3 overflow-x-auto">
+                  <table className="min-w-full divide-y divide-white/10 text-xs">
+                    <thead className="bg-white/5 text-white/60">
+                      <tr>
+                        <th className="px-2 py-2 text-left">Category</th>
+                        <th className="px-2 py-2 text-left">Pair</th>
+                        <th className="px-2 py-2 text-left">Executions</th>
+                        <th className="px-2 py-2 text-left">Volume (USDT)</th>
+                        <th className="px-2 py-2 text-left">Fees (USDT)</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-white/10">
+                      {convertReports.top_pairs.map((row) => (
+                        <tr key={`${row.category}-${row.symbol}`}>
+                          <td className="px-2 py-2 uppercase text-white/70">{row.category}</td>
+                          <td className="px-2 py-2 text-white">{row.symbol}</td>
+                          <td className="px-2 py-2 text-white/75">{Number(row.executions || 0).toLocaleString()}</td>
+                          <td className="px-2 py-2 text-white/75">{formatUsdtFromWei(row.quote_without_fee_wei || '0')}</td>
+                          <td className="px-2 py-2 text-emerald-200">{formatUsdtFromWei(row.fee_wei || '0')}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                  {!convertReports.top_pairs.length ? <div className="py-3 text-xs text-white/55">No pair performance data yet.</div> : null}
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-4 grid gap-4 xl:grid-cols-2">
+              <div className="rounded-xl border border-white/10 bg-black/20 p-4">
+                <h5 className="text-sm font-semibold text-white/85">Daily throughput (14d)</h5>
+                <div className="mt-3 overflow-x-auto">
+                  <table className="min-w-full divide-y divide-white/10 text-xs">
+                    <thead className="bg-white/5 text-white/60">
+                      <tr>
+                        <th className="px-2 py-2 text-left">Day</th>
+                        <th className="px-2 py-2 text-left">Executions</th>
+                        <th className="px-2 py-2 text-left">Volume (USDT)</th>
+                        <th className="px-2 py-2 text-left">Fees (USDT)</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-white/10">
+                      {convertReports.daily.map((row) => (
+                        <tr key={row.day}>
+                          <td className="px-2 py-2 text-white">{String(row.day).slice(0, 10)}</td>
+                          <td className="px-2 py-2 text-white/70">{Number(row.executions || 0).toLocaleString()}</td>
+                          <td className="px-2 py-2 text-white/70">{formatUsdtFromWei(row.quote_without_fee_wei || '0')}</td>
+                          <td className="px-2 py-2 text-emerald-200">{formatUsdtFromWei(row.fee_wei || '0')}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                  {!convertReports.daily.length ? <div className="py-3 text-xs text-white/55">No daily convert trend yet.</div> : null}
+                </div>
+              </div>
+
+              <div className="rounded-xl border border-white/10 bg-black/20 p-4">
+                <h5 className="text-sm font-semibold text-white/85">Latest executions</h5>
+                <div className="mt-3 overflow-x-auto">
+                  <table className="min-w-full divide-y divide-white/10 text-xs">
+                    <thead className="bg-white/5 text-white/60">
+                      <tr>
+                        <th className="px-2 py-2 text-left">ID</th>
+                        <th className="px-2 py-2 text-left">Pair</th>
+                        <th className="px-2 py-2 text-left">Side</th>
+                        <th className="px-2 py-2 text-left">Status</th>
+                        <th className="px-2 py-2 text-left">Time</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-white/10">
+                      {convertReports.recent.map((row) => (
+                        <tr key={row.id}>
+                          <td className="px-2 py-2 text-white/75">#{row.id}</td>
+                          <td className="px-2 py-2 text-white">{row.symbol}</td>
+                          <td className="px-2 py-2 uppercase text-white/70">{row.side}</td>
+                          <td className="px-2 py-2">
+                            <span
+                              className={`rounded-full px-2 py-0.5 ${
+                                row.status === 'completed'
+                                  ? 'bg-emerald-500/20 text-emerald-200'
+                                  : row.status === 'failed'
+                                  ? 'bg-rose-500/20 text-rose-200'
+                                  : 'bg-amber-500/20 text-amber-200'
+                              }`}
+                            >
+                              {row.status}
+                            </span>
+                          </td>
+                          <td className="px-2 py-2 text-white/60">{new Date(row.created_at).toLocaleString()}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                  {!convertReports.recent.length ? <div className="py-3 text-xs text-white/55">No recent executions yet.</div> : null}
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
### Motivation
- Improve user experience of the Convert/Swap flow (gold, stocks, crypto) with a modern, clearer, bilingual UI and clearer execution feedback. 
- Provide operators with accurate, platform-level intelligence for convert activity so admins can monitor volume, fees, and health per category and pair. 
- Surface convert KPIs inside the existing Admin panel so reporting is available alongside fees and protection controls.

### Description
- Reworked the front-end Convert page with a refreshed hero, color-coded category buttons, quick-amount chips, compact KPI cards for estimate/fee/minimum, improved execution button and bilingual labels in `app/(app)/trade/convert/page.tsx`.
- Added a new admin API endpoint `GET /admin/convert/reports` that returns overview totals, category breakdown (gold/stocks/crypto), top pairs by USDT volume, 14-day daily throughput, and latest executions in `api/src/app.js`.
- Extended the Admin Fees panel to fetch the new reports and render a "Convert intelligence dashboard" with KPI StatCards and tables for categories, top pairs, daily trends and recent executions in `app/mo/AdminApp.tsx`.
- No schema migrations or DB changes were introduced; reports are derived from existing `convert_executions` and `convert_pairs` tables.

### Testing
- Ran type checking with `npm run typecheck` and it completed successfully. 
- Executed integration tests with `npm run test:integration` and all integration tests passed (24/24). 
- Ran linter with `npm run lint` (one existing Next.js warning for use of `<img>` was reported; classified as non-breaking and recommended to replace with `next/image`).
- Built the Next app with `npm run build` successfully; attempted headless screenshots via Playwright but the environment lacked required system libs (`libatk-1.0.so.0`), so screenshot capture failed while `npx playwright install chromium` did run successfully in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef9052b564832b8eafbe2bbd9c2080)