### PR TITLE
Fix convert reports to respect stored USDT decimals

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -10821,6 +10821,7 @@ app.get('/admin/convert/reports', async (req, res, next) => {
          SUM(CASE WHEN ce.status='completed' THEN 1 ELSE 0 END) AS completed_executions,
          SUM(CASE WHEN ce.status='failed' THEN 1 ELSE 0 END) AS failed_executions,
          COALESCE(SUM(CASE WHEN ce.status='completed' THEN CAST(ce.quote_without_fee_wei AS DECIMAL(65,0)) ELSE 0 END),0) AS quote_without_fee_wei,
+         COALESCE(MAX(ce.quote_decimals), 6) AS quote_decimals,
          COALESCE(SUM(CASE WHEN ce.status='completed' THEN CAST(ce.fee_wei AS DECIMAL(65,0)) ELSE 0 END),0) AS fee_wei
        FROM convert_executions ce`
     );
@@ -10830,6 +10831,7 @@ app.get('/admin/convert/reports', async (req, res, next) => {
               SUM(CASE WHEN ce.status='completed' THEN 1 ELSE 0 END) AS completed,
               SUM(CASE WHEN ce.status='failed' THEN 1 ELSE 0 END) AS failed,
               COALESCE(SUM(CASE WHEN ce.status='completed' THEN CAST(ce.quote_without_fee_wei AS DECIMAL(65,0)) ELSE 0 END),0) AS quote_without_fee_wei,
+              COALESCE(MAX(ce.quote_decimals), 6) AS quote_decimals,
               COALESCE(SUM(CASE WHEN ce.status='completed' THEN CAST(ce.fee_wei AS DECIMAL(65,0)) ELSE 0 END),0) AS fee_wei
          FROM convert_executions ce
          JOIN convert_pairs cp ON cp.id = ce.pair_id
@@ -10841,6 +10843,7 @@ app.get('/admin/convert/reports', async (req, res, next) => {
               cp.symbol,
               COUNT(*) AS executions,
               COALESCE(SUM(CASE WHEN ce.status='completed' THEN CAST(ce.quote_without_fee_wei AS DECIMAL(65,0)) ELSE 0 END),0) AS quote_without_fee_wei,
+              COALESCE(MAX(ce.quote_decimals), 6) AS quote_decimals,
               COALESCE(SUM(CASE WHEN ce.status='completed' THEN CAST(ce.fee_wei AS DECIMAL(65,0)) ELSE 0 END),0) AS fee_wei
          FROM convert_executions ce
          JOIN convert_pairs cp ON cp.id = ce.pair_id
@@ -10852,6 +10855,7 @@ app.get('/admin/convert/reports', async (req, res, next) => {
       `SELECT DATE(ce.created_at) AS day,
               COUNT(*) AS executions,
               COALESCE(SUM(CASE WHEN ce.status='completed' THEN CAST(ce.quote_without_fee_wei AS DECIMAL(65,0)) ELSE 0 END),0) AS quote_without_fee_wei,
+              COALESCE(MAX(ce.quote_decimals), 6) AS quote_decimals,
               COALESCE(SUM(CASE WHEN ce.status='completed' THEN CAST(ce.fee_wei AS DECIMAL(65,0)) ELSE 0 END),0) AS fee_wei
          FROM convert_executions ce
         WHERE ce.created_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 14 DAY)

--- a/app/mo/AdminApp.tsx
+++ b/app/mo/AdminApp.tsx
@@ -145,6 +145,7 @@ type ConvertReportOverview = {
   completed_executions: number;
   failed_executions: number;
   quote_without_fee_wei: string;
+  quote_decimals: number;
   fee_wei: string;
 };
 type ConvertReportCategory = {
@@ -153,6 +154,7 @@ type ConvertReportCategory = {
   completed: number;
   failed: number;
   quote_without_fee_wei: string;
+  quote_decimals: number;
   fee_wei: string;
 };
 type ConvertReportPair = {
@@ -160,12 +162,14 @@ type ConvertReportPair = {
   symbol: string;
   executions: number;
   quote_without_fee_wei: string;
+  quote_decimals: number;
   fee_wei: string;
 };
 type ConvertReportDay = {
   day: string;
   executions: number;
   quote_without_fee_wei: string;
+  quote_decimals: number;
   fee_wei: string;
 };
 type ConvertReportRecent = {
@@ -4865,13 +4869,11 @@ function FeesPanel({ onNotify }: { onNotify: (message: string, variant?: 'succes
     return (Number(convertOverview.completed_executions || 0) / Number(convertOverview.total_executions || 0)) * 100;
   }, [convertOverview]);
 
-  const formatUsdtFromWei = (value: string) => {
-    try {
-      return Number(formatUnits(value || '0', 18)).toLocaleString(undefined, { maximumFractionDigits: 4 });
-    } catch {
-      return '0';
-    }
-  };
+  const fallbackUsdtDecimals = convertReports.recent[0]?.quote_decimals || 6;
+  const formatUsdtFromWei = (value: string, decimals?: number) =>
+    Number(formatReserve(value || '0', decimals ?? fallbackUsdtDecimals)).toLocaleString(undefined, {
+      maximumFractionDigits: 4,
+    });
 
   const updateFees = async () => {
     const payload: Record<string, unknown> = {};
@@ -5317,13 +5319,13 @@ function FeesPanel({ onNotify }: { onNotify: (message: string, variant?: 'succes
               />
               <StatCard
                 title="USDT gross volume"
-                value={`${formatUsdtFromWei(convertOverview?.quote_without_fee_wei || '0')} USDT`}
+                value={`${formatUsdtFromWei(convertOverview?.quote_without_fee_wei || '0', convertOverview?.quote_decimals)} USDT`}
                 subtitle="Before fees"
                 icon={DollarSign}
               />
               <StatCard
                 title="USDT fees"
-                value={`${formatUsdtFromWei(convertOverview?.fee_wei || '0')} USDT`}
+                value={`${formatUsdtFromWei(convertOverview?.fee_wei || '0', convertOverview?.quote_decimals)} USDT`}
                 subtitle="Net platform convert revenue"
                 icon={Coins}
               />
@@ -5343,7 +5345,7 @@ function FeesPanel({ onNotify }: { onNotify: (message: string, variant?: 'succes
                         <span>{Number(row.completed || 0).toLocaleString()} success</span>
                         <span>{Number(row.failed || 0).toLocaleString()} failed</span>
                       </div>
-                      <div className="mt-1 text-white/70">Vol: {formatUsdtFromWei(row.quote_without_fee_wei || '0')} USDT</div>
+                      <div className="mt-1 text-white/70">Vol: {formatUsdtFromWei(row.quote_without_fee_wei || '0', row.quote_decimals)} USDT</div>
                     </div>
                   ))}
                   {!convertReports.categories.length ? <div className="text-xs text-white/55">No convert data yet.</div> : null}
@@ -5369,8 +5371,8 @@ function FeesPanel({ onNotify }: { onNotify: (message: string, variant?: 'succes
                           <td className="px-2 py-2 uppercase text-white/70">{row.category}</td>
                           <td className="px-2 py-2 text-white">{row.symbol}</td>
                           <td className="px-2 py-2 text-white/75">{Number(row.executions || 0).toLocaleString()}</td>
-                          <td className="px-2 py-2 text-white/75">{formatUsdtFromWei(row.quote_without_fee_wei || '0')}</td>
-                          <td className="px-2 py-2 text-emerald-200">{formatUsdtFromWei(row.fee_wei || '0')}</td>
+                          <td className="px-2 py-2 text-white/75">{formatUsdtFromWei(row.quote_without_fee_wei || '0', row.quote_decimals)}</td>
+                          <td className="px-2 py-2 text-emerald-200">{formatUsdtFromWei(row.fee_wei || '0', row.quote_decimals)}</td>
                         </tr>
                       ))}
                     </tbody>
@@ -5398,8 +5400,8 @@ function FeesPanel({ onNotify }: { onNotify: (message: string, variant?: 'succes
                         <tr key={row.day}>
                           <td className="px-2 py-2 text-white">{String(row.day).slice(0, 10)}</td>
                           <td className="px-2 py-2 text-white/70">{Number(row.executions || 0).toLocaleString()}</td>
-                          <td className="px-2 py-2 text-white/70">{formatUsdtFromWei(row.quote_without_fee_wei || '0')}</td>
-                          <td className="px-2 py-2 text-emerald-200">{formatUsdtFromWei(row.fee_wei || '0')}</td>
+                          <td className="px-2 py-2 text-white/70">{formatUsdtFromWei(row.quote_without_fee_wei || '0', row.quote_decimals)}</td>
+                          <td className="px-2 py-2 text-emerald-200">{formatUsdtFromWei(row.fee_wei || '0', row.quote_decimals)}</td>
                         </tr>
                       ))}
                     </tbody>


### PR DESCRIPTION
### Motivation
- Convert reports and admin UI were formatting USDT amounts using a hardcoded 18 decimals which produced incorrect volumes/fee displays for tokens (e.g. USDT with 6 decimals).
- Ensure report aggregates and UI use the stored `quote_decimals` so numbers are consistently scaled and readable across all convert categories (gold/stocks/crypto).

### Description
- API: extended `/admin/convert/reports` aggregate queries to include `quote_decimals` (using `COALESCE(MAX(ce.quote_decimals), 6)` as a safe fallback) for `overview`, `categories`, `top_pairs`, and `daily` result sets in `api/src/app.js`.
- Frontend types: added `quote_decimals` to the convert report TypeScript types in `app/mo/AdminApp.tsx` so the response shape is represented correctly.
- Frontend formatting: replaced the hardcoded 18-decimal formatting with a dynamic `formatUsdtFromWei` that accepts `decimals` and falls back to a safe value derived from recent rows; updated KPI cards, category blocks, top-pairs table, and daily table to pass the correct `quote_decimals` when rendering amounts in `app/mo/AdminApp.tsx`.
- No database schema or migration changes were required, so there is no SQL to run.

### Testing
- Ran `npm run test:integration` and all integration tests passed (24/24).
- Ran `npm run typecheck` (`tsc --noEmit`) which completed successfully with no type errors.
- Ran `npm run build` (Next.js build) which completed successfully; the build produced a non-blocking ESLint warning (`@next/next/no-img-element`) related to an `<img>` usage which is classified as non-blocking and can be fixed by migrating to `next/image`.
- Attempted a headless browser screenshot to verify the Admin page UI; Playwright browser download succeeded but screenshot run failed due to a missing system library (`libatk-1.0.so.0`) in the environment, which is an OS dependency issue and not a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa4feeb8c832ba7e24ea6f519271b)