### PR TITLE
Fix USDT admin decimals and replace dashboard Trade shortcut with Gold/Stocks/Crypto

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -1167,6 +1167,16 @@ function getSymbolDecimals(symbol) {
   return DEFAULT_ELTX_DECIMALS;
 }
 
+function getTokenDecimals(symbol, tokenAddress, amountWei = 0) {
+  const normalizedSymbol = String(symbol || '').toUpperCase();
+  const normalizedAddress = typeof tokenAddress === 'string' ? tokenAddress.trim().toLowerCase() : '';
+  if (normalizedAddress && tokenMeta[normalizedAddress]?.decimals !== undefined && tokenMeta[normalizedAddress]?.decimals !== null) {
+    return normalizeDecimals(tokenMeta[normalizedAddress].decimals, getSymbolDecimals(normalizedSymbol));
+  }
+  const fallbackDecimals = getSymbolDecimals(normalizedSymbol);
+  return resolveStablecoinLedgerDecimals(normalizedSymbol, amountWei, fallbackDecimals);
+}
+
 function normalizeDecimals(value, fallback = DEFAULT_ELTX_DECIMALS) {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 36) return fallback;
@@ -8939,8 +8949,8 @@ app.get('/admin/users/:id', async (req, res, next) => {
 
     const deposits = depositRows.map((row) => {
       const symbol = (row.token_symbol || 'ELTX').toUpperCase();
-      const decimals = getSymbolDecimals(symbol);
       const wei = bigIntFromValue(row.amount_wei || 0);
+      const decimals = getTokenDecimals(symbol, row.token_address, wei);
       return {
         id: row.id,
         asset: symbol,
@@ -8964,8 +8974,8 @@ app.get('/admin/users/:id', async (req, res, next) => {
 
     const transfers = transferRows.map((row) => {
       const symbol = (row.asset || 'ELTX').toUpperCase();
-      const decimals = getSymbolDecimals(symbol);
       const wei = bigIntFromValue(row.amount_wei || 0);
+      const decimals = resolveStablecoinLedgerDecimals(symbol, wei, getSymbolDecimals(symbol));
       return {
         id: row.id,
         asset: symbol,
@@ -9262,14 +9272,14 @@ app.get('/admin/transactions', async (req, res, next) => {
       );
       results = rows.map((row) => {
         const symbol = (row.token_symbol || 'ELTX').toUpperCase();
-        const decimals = getSymbolDecimals(symbol);
         const wei = bigIntFromValue(row.amount_wei || 0);
+        const decimals = getTokenDecimals(symbol, row.token_address, wei);
         return {
           id: row.id,
           user_id: row.user_id,
           asset: symbol,
-          amount_wei: wei.toString(),
           amount: trimDecimal(formatUnitsStr(wei.toString(), decimals)),
+          amount_wei: wei.toString(),
           confirmations: row.confirmations,
           status: row.status,
           source: row.source,
@@ -9286,15 +9296,15 @@ app.get('/admin/transactions', async (req, res, next) => {
       );
       results = rows.map((row) => {
         const symbol = (row.asset || 'ELTX').toUpperCase();
-        const decimals = getSymbolDecimals(symbol);
         const wei = bigIntFromValue(row.amount_wei || 0);
+        const decimals = resolveStablecoinLedgerDecimals(symbol, wei, getSymbolDecimals(symbol));
         return {
           id: row.id,
           from_user_id: row.from_user_id,
           to_user_id: row.to_user_id,
           asset: symbol,
-          amount_wei: wei.toString(),
           amount: trimDecimal(formatUnitsStr(wei.toString(), decimals)),
+          amount_wei: wei.toString(),
           fee_wei: bigIntFromValue(row.fee_wei || 0).toString(),
           created_at: row.created_at,
         };

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -146,7 +146,24 @@ export default function DashboardPage() {
             <h2 className="text-[11px] font-semibold uppercase tracking-wide text-white/65">Trade</h2>
             <div className="grid grid-cols-3 gap-1.5">
               <SectionCard title={t.dashboard.cards.wallet.title} href="/wallet" icon={Wallet} compact />
-              <SectionCard title={lang === 'ar' ? 'تداول' : 'Trade'} href="/trade" icon={CandlestickChart} compact />
+              <SectionCard
+                title={lang === 'ar' ? 'الذهب' : 'Gold'}
+                href="/trade/convert?category=gold"
+                icon={Coins}
+                compact
+              />
+              <SectionCard
+                title={lang === 'ar' ? 'الاسهم' : 'Stocks'}
+                href="/trade/convert?category=stocks"
+                icon={ReceiptText}
+                compact
+              />
+              <SectionCard
+                title={lang === 'ar' ? 'كريبتو' : 'Crypto'}
+                href="/trade/convert?category=crypto"
+                icon={CandlestickChart}
+                compact
+              />
               <SectionCard title={t.dashboard.cards.transactions.title} href="/transactions" icon={ReceiptText} compact />
               <SectionCard title={t.dashboard.market.title} href="/market" icon={CandlestickChart} compact />
             </div>


### PR DESCRIPTION
### Motivation
- Admin screens were showing incorrect USDT/USDC amounts because decimals were resolved only by symbol, causing wrong human-readable `amount` values. 
- The dashboard had a single `Trade` shortcut which should be three direct shortcuts (`Gold`, `Stocks`, `Crypto`) that open the appropriate convert pages for clarity and faster navigation.

### Description
- Added a new helper `getTokenDecimals(symbol, tokenAddress, amountWei)` to resolve decimals from `token_address` metadata when available and fall back to stablecoin-ledger logic (`resolveStablecoinLedgerDecimals`) otherwise in `api/src/app.js`.
- Replaced usages of `getSymbolDecimals` with the new `getTokenDecimals` (or the stablecoin-ledger fallback) when formatting `deposits`, `transfers`, and admin `transactions` to ensure `amount` is calculated with correct decimals. 
- Reordered the `admin/transactions` payload so the formatted `amount` appears before `amount_wei` to improve readability. 
- Replaced the single `Trade` `SectionCard` in `app/(app)/dashboard/page.tsx` with three `SectionCard`s (`Gold`, `Stocks`, `Crypto`) linking to `/trade/convert?category=gold|stocks|crypto` respectively.
- No database schema changes were made.

### Testing
- Ran type checking with `npm run typecheck` and it passed successfully. 
- Ran integration tests with `npm run test:integration` and all tests passed (24/24). 
- Ran linter with `npm run lint` and it completed with a single `no-img-element` warning in the convert page (non-blocking). 
- Built the frontend with `npm run build` and the build completed successfully while reporting the `img` lint warning as noted. 
- Attempted to take runtime screenshots using Playwright after `npm run dev`, but the Playwright browser binary is not installed in this environment so the screenshot step failed with an executable missing error; all other runtime checks (server start) completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efacf607d8832bac86a0d3eb6c4b54)