### PR TITLE
fix(convert): live-first runtime, sane quote math, and cleaned convert desk UX

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -954,6 +954,8 @@ const ERC20_ABI = [
   'function allowance(address owner, address spender) external view returns (uint256)',
 ];
 const BSC_WBNB_ADDRESS = (process.env.TOKEN_WBNB || '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c').toLowerCase();
+const BSC_USDT_ADDRESS = (process.env.TOKEN_USDT || '0x55d398326f99059fF775485246999027B3197955').toLowerCase();
+const BSC_USDC_ADDRESS = (process.env.TOKEN_USDC || '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d').toLowerCase();
 const PANCAKE_V2_ROUTER_ADDRESS = (
   process.env.PANCAKE_V2_ROUTER || '0x10ED43C718714eb63d5aA57B78B54704E256024E'
 ).toLowerCase();
@@ -2714,7 +2716,7 @@ async function readPlatformFeeBalances(conn = pool) {
 async function readConvertSettings(conn = pool) {
   const feeVal = await getPlatformSettingValue('convert_fee_bps', '50', conn);
   const minVal = await getPlatformSettingValue('convert_min_usdt', '10', conn);
-  const modeVal = await getPlatformSettingValue('convert_execution_mode', 'mock', conn);
+  const modeVal = await getPlatformSettingValue('convert_execution_mode', 'live', conn);
   const slippageVal = await getPlatformSettingValue('convert_slippage_bps', '120', conn);
   const fallbackVal = await getPlatformSettingValue('convert_live_fallback_mock', '1', conn);
   const feeBps = clampBps(BigInt(Number.parseInt(feeVal, 10) || 0));
@@ -2767,13 +2769,41 @@ function resolveConvertAssetAddress(assetSymbol, pairAddress = null) {
   const upper = String(assetSymbol || '').toUpperCase();
   if (pairAddress) return String(pairAddress).toLowerCase();
   if (upper === 'BNB') return BSC_WBNB_ADDRESS;
+  if (upper === 'USDT') return BSC_USDT_ADDRESS;
+  if (upper === 'USDC') return BSC_USDC_ADDRESS;
   const meta = tokenMetaBySymbol[upper];
   return meta?.contract ? String(meta.contract).toLowerCase() : null;
 }
 
 function resolveConvertAssetDecimals(assetSymbol, pairDecimals = null) {
   if (pairDecimals !== null && pairDecimals !== undefined) return normalizeDecimals(pairDecimals, getSymbolDecimals(assetSymbol));
+  const upper = String(assetSymbol || '').toUpperCase();
+  if ((upper === 'USDT' || upper === 'USDC') && [BSC_USDT_ADDRESS, BSC_USDC_ADDRESS].includes(resolveConvertAssetAddress(upper))) {
+    return 18;
+  }
   return getSymbolDecimals(assetSymbol);
+}
+
+function quoteConvertMock(pair, amountWei) {
+  const baseDecimals = resolveConvertAssetDecimals(pair.base_asset, pair.token_decimals);
+  const usdtDecimals = resolveConvertAssetDecimals(pair.quote_asset || 'USDT');
+  const baseDivisor = 10n ** BigInt(baseDecimals);
+  const notionalWei18 = mulDiv(amountWei, getSyntheticReferencePriceWei({ base_asset: pair.base_asset }), baseDivisor);
+  return convertDecimals(notionalWei18, 18, usdtDecimals);
+}
+
+function assertConvertQuoteIsSane(quoteWei, amountWei, usdtDecimals) {
+  const value = bigIntFromValue(quoteWei);
+  if (value <= 0n) {
+    throw Object.assign(new Error('Invalid convert quote value'), { code: 'QUOTE_OUT_OF_RANGE' });
+  }
+  const hardCap = 10n ** BigInt(usdtDecimals + 10);
+  if (value > hardCap) {
+    throw Object.assign(new Error('Convert quote exceeded safe range'), { code: 'QUOTE_OUT_OF_RANGE' });
+  }
+  if (bigIntFromValue(amountWei) > 0n && value < 1n) {
+    throw Object.assign(new Error('Convert quote precision too low'), { code: 'QUOTE_OUT_OF_RANGE' });
+  }
 }
 
 async function getConvertPairBySymbol(symbol, category = null, conn = pool) {
@@ -10584,14 +10614,15 @@ app.post('/convert/quote', walletLimiter, async (req, res, next) => {
       runtime.mode === 'live'
         ? await quoteConvertFromPancake(pair, payload.side, amountWei)
         : {
-            quoteWithoutFeeWei: payload.side === 'buy' ? amountWei : amountWei,
+            quoteWithoutFeeWei: quoteConvertMock(pair, amountWei),
             baseAmountWei: amountWei,
             direction: payload.side === 'buy' ? 'quote_to_base' : 'base_to_quote',
             path: [],
           };
     const settings = runtime.settings;
     const feeWei = (quoteInfo.quoteWithoutFeeWei * BigInt(settings.convert_fee_bps || 0)) / 10000n;
-    const usdtDecimals = resolveConvertAssetDecimals('USDT');
+    const usdtDecimals = resolveConvertAssetDecimals(pair.quote_asset || 'USDT');
+    assertConvertQuoteIsSane(quoteInfo.quoteWithoutFeeWei, amountWei, usdtDecimals);
     res.json({
       ok: true,
       mode: runtime.mode,
@@ -10610,6 +10641,9 @@ app.post('/convert/quote', walletLimiter, async (req, res, next) => {
       settings,
     });
   } catch (err) {
+    if (err?.code === 'QUOTE_OUT_OF_RANGE') {
+      return next({ status: 502, code: 'QUOTE_OUT_OF_RANGE', message: 'Convert quote is outside allowed range' });
+    }
     if (err instanceof z.ZodError) {
       return next({ status: 400, code: 'BAD_INPUT', message: 'Invalid input', details: err.flatten() });
     }
@@ -10645,7 +10679,7 @@ app.post('/convert/execute', walletLimiter, async (req, res, next) => {
     const pair = await getConvertPairBySymbol(payload.symbol, payload.category || null);
     if (!pair) return next({ status: 404, code: 'PAIR_NOT_FOUND', message: 'Convert pair not found' });
     const settings = await readConvertSettings();
-    const usdtDecimals = resolveConvertAssetDecimals('USDT');
+    const usdtDecimals = resolveConvertAssetDecimals(pair.quote_asset || 'USDT');
     const baseDecimals = resolveConvertAssetDecimals(pair.base_asset, pair.token_decimals);
     const amountWeiStr = decimalToWeiString(payload.amount, baseDecimals);
     if (!amountWeiStr) return next({ status: 400, code: 'INVALID_AMOUNT', message: 'Invalid amount' });
@@ -10662,7 +10696,8 @@ app.post('/convert/execute', walletLimiter, async (req, res, next) => {
     const quoteInfo =
       runtime.mode === 'live'
         ? await quoteConvertFromPancake(pair, payload.side, amountWei)
-        : { quoteWithoutFeeWei: amountWei, baseAmountWei: amountWei };
+        : { quoteWithoutFeeWei: quoteConvertMock(pair, amountWei), baseAmountWei: amountWei };
+    assertConvertQuoteIsSane(quoteInfo.quoteWithoutFeeWei, amountWei, usdtDecimals);
     const feeWei = (quoteInfo.quoteWithoutFeeWei * BigInt(settings.convert_fee_bps || 0)) / 10000n;
     const minWeiStr = decimalToWeiString(String(settings.convert_min_usdt || 10), usdtDecimals) || '0';
     if (quoteInfo.quoteWithoutFeeWei < BigInt(minWeiStr)) {
@@ -10795,6 +10830,9 @@ app.post('/convert/execute', walletLimiter, async (req, res, next) => {
           refundConn.release();
         }
       } catch {}
+    }
+    if (err?.code === 'QUOTE_OUT_OF_RANGE') {
+      return next({ status: 502, code: 'QUOTE_OUT_OF_RANGE', message: 'Convert quote is outside allowed range' });
     }
     if (err instanceof z.ZodError) {
       return next({ status: 400, code: 'BAD_INPUT', message: 'Invalid input', details: err.flatten() });

--- a/api/tests/integration.test.js
+++ b/api/tests/integration.test.js
@@ -491,14 +491,45 @@ test('POST /convert/quote returns mock quote and fee details', async () => {
   assert.equal(res.status, 200);
   assert.equal(res.body?.ok, true);
   assert.equal(res.body?.mode, 'mock');
-  assert.equal(res.body?.quote?.total_usdt, '10.05');
+  assert.equal(res.body?.quote?.quote_without_fee, '6000');
+  assert.equal(res.body?.quote?.fee_usdt, '30');
+  assert.equal(res.body?.quote?.total_usdt, '6030');
+});
+
+test('POST /convert/quote uses sane mock reference pricing for XAUT/USDT', async () => {
+  const xautPair = {
+    id: 2,
+    category: 'gold',
+    symbol: 'XAUT/USDT',
+    base_asset: 'XAUT',
+    quote_asset: 'USDT',
+    token_symbol: 'XAUT',
+    token_address: null,
+    token_decimals: 18,
+    display_name: 'Tether Gold',
+    logo_url: null,
+    sort_order: 2,
+    active: 1,
+  };
+  testSchema.convertPairs.push(xautPair);
+  testSchema.convertSettings.convert_execution_mode = 'mock';
+  const res = await request
+    .post('/convert/quote')
+    .set('Cookie', 'sid=valid-session')
+    .send({ category: 'gold', symbol: 'XAUT/USDT', side: 'buy', amount: '1' });
+  assert.equal(res.status, 200);
+  assert.equal(res.body?.ok, true);
+  assert.equal(res.body?.mode, 'mock');
+  assert.equal(res.body?.quote?.quote_without_fee, '3300');
+  assert.equal(res.body?.quote?.total_usdt, '3316.5');
+  testSchema.convertPairs.pop();
 });
 
 test('POST /convert/execute performs debit/credit lifecycle in mock mode', async () => {
   testSchema.convertExecutions.length = 0;
   testSchema.convertSettings.convert_execution_mode = 'mock';
   testSchema.convertSettings.convert_live_fallback_mock = '1';
-  testSchema.balances['1:USDT'] = '11000000000000000000';
+  testSchema.balances['1:USDT'] = '11000000000000000000000';
   testSchema.balances['1:BNB'] = '0';
 
   const res = await request
@@ -510,7 +541,7 @@ test('POST /convert/execute performs debit/credit lifecycle in mock mode', async
   assert.equal(res.body?.ok, true);
   assert.equal(testSchema.convertExecutions.length, 1);
   assert.equal(testSchema.convertExecutions[0].status, 'completed');
-  assert.equal(testSchema.balances['1:USDT'], '950000000000000000');
+  assert.equal(testSchema.balances['1:USDT'], '4970000000000000000000');
   assert.equal(testSchema.balances['1:BNB'], '10000000000000000000');
 });
 
@@ -545,6 +576,29 @@ test('POST /convert/execute blocks live mode when wallet env is missing and fall
     .send({ category: 'crypto', symbol: 'BNB/USDT', side: 'buy', amount: '1', idempotency_key: 'exec-live-missing-1' });
   assert.equal(res.status, 503);
   assert.equal(res.body?.error?.code, 'CONVERT_LIVE_NOT_READY');
+  testSchema.convertSettings.convert_execution_mode = 'mock';
+  testSchema.convertSettings.convert_live_fallback_mock = '1';
+});
+
+test('POST /convert/quote returns runtime warning when live is misconfigured but fallback is enabled', async () => {
+  testSchema.convertSettings.convert_execution_mode = 'live';
+  testSchema.convertSettings.convert_live_fallback_mock = '1';
+  const originalPk = process.env.CONVERT_HOT_WALLET_PK;
+  const originalAddress = process.env.CONVERT_HOT_WALLET_ADDRESS;
+  const originalRpc = process.env.BSC_RPC_URL;
+  delete process.env.CONVERT_HOT_WALLET_PK;
+  delete process.env.CONVERT_HOT_WALLET_ADDRESS;
+  delete process.env.BSC_RPC_URL;
+  const res = await request
+    .post('/convert/quote')
+    .set('Cookie', 'sid=valid-session')
+    .send({ category: 'crypto', symbol: 'BNB/USDT', side: 'buy', amount: '1' });
+  assert.equal(res.status, 200);
+  assert.equal(res.body?.mode, 'mock');
+  assert.ok(res.body?.runtime_warning);
+  process.env.CONVERT_HOT_WALLET_PK = originalPk;
+  process.env.CONVERT_HOT_WALLET_ADDRESS = originalAddress;
+  process.env.BSC_RPC_URL = originalRpc;
   testSchema.convertSettings.convert_execution_mode = 'mock';
   testSchema.convertSettings.convert_live_fallback_mock = '1';
 });

--- a/app/(app)/trade/convert/page.tsx
+++ b/app/(app)/trade/convert/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowDownUp, BadgeDollarSign, RefreshCw, ShieldCheck, Sparkles, Wallet } from 'lucide-react';
+import { ArrowDownUp, BadgeDollarSign, ChevronLeft, RefreshCw, Wallet } from 'lucide-react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
@@ -51,12 +51,31 @@ function cleanDisplayName(value: string): string {
   return value.replace(/\bondo\b/gi, '').replace(/\s{2,}/g, ' ').trim();
 }
 
+function assetIconFallback(symbol: string): string {
+  const upper = symbol.toUpperCase();
+  const map: Record<string, string> = {
+    BNB: 'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/smartchain/assets/0x0000000000000000000000000000000000000000/logo.png',
+    WBTC: 'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/smartchain/assets/0x7130d2A12B9BCBfAe4f2634d864A1Ee1Ce3Ead9c/logo.png',
+    XRP: 'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/xrp/info/logo.png',
+    SOL: 'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/solana/info/logo.png',
+    LINK: 'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/smartchain/assets/0xF8A0BF9cF54Bb92F17374d9e9A321E6a111a51bD/logo.png',
+    XAUT: 'https://assets.coingecko.com/coins/images/10481/standard/Tether_Gold.png',
+    NVDA: 'https://logo.clearbit.com/nvidia.com',
+    TSLA: 'https://logo.clearbit.com/tesla.com',
+    AAPL: 'https://logo.clearbit.com/apple.com',
+    MSFT: 'https://logo.clearbit.com/microsoft.com',
+    AMZN: 'https://logo.clearbit.com/amazon.com',
+    GOOGL: 'https://logo.clearbit.com/google.com',
+  };
+  return map[upper] || '';
+}
+
 function categoryStyle(item: Category, active: boolean): string {
   const base = 'rounded-xl border px-3 py-2 text-center text-sm font-medium transition';
-  if (!active) return `${base} border-white/10 bg-white/[0.03] text-white/70 hover:border-white/25 hover:text-white`;
-  if (item === 'gold') return `${base} border-amber-300/70 bg-amber-500/15 text-amber-100`;
-  if (item === 'stocks') return `${base} border-indigo-300/70 bg-indigo-500/15 text-indigo-100`;
-  return `${base} border-cyan-300/70 bg-cyan-500/15 text-cyan-100`;
+  if (!active) return `${base} border-white/10 bg-[#111a30] text-white/70 hover:border-cyan-400/40 hover:text-white`;
+  if (item === 'gold') return `${base} border-amber-400/50 bg-amber-500/10 text-amber-200`;
+  if (item === 'stocks') return `${base} border-blue-400/50 bg-blue-500/10 text-blue-200`;
+  return `${base} border-cyan-400/60 bg-cyan-500/10 text-cyan-200`;
 }
 
 function formatPrice(value: number): string {
@@ -79,7 +98,7 @@ function ConvertPageContent() {
   const [amount, setAmount] = useState('');
   const [estimate, setEstimate] = useState(0);
   const [feeUsdt, setFeeUsdt] = useState(0);
-  const [convertMode, setConvertMode] = useState<'mock' | 'live'>('mock');
+  const [convertMode, setConvertMode] = useState<'mock' | 'live'>('live');
   const [minUsdt, setMinUsdt] = useState(10);
   const [feeBps, setFeeBps] = useState(50);
   const [loading, setLoading] = useState(true);
@@ -91,10 +110,6 @@ function ConvertPageContent() {
 
   const labels = useMemo(
     () => ({
-      title: isArabic ? 'منصة تحويل احترافية' : 'Professional Convert Desk',
-      subtitle: isArabic
-        ? 'تحويل الذهب، الاسهم، والكريبتو بسرعة مع تجربة احترافية'
-        : 'Convert gold, stocks, and crypto with a polished institutional flow',
       back: isArabic ? 'رجوع' : 'Back',
       choosePair: isArabic ? 'اختار الزوج' : 'Choose pair',
       buy: isArabic ? 'شراء' : 'Buy',
@@ -105,7 +120,7 @@ function ConvertPageContent() {
       executing: isArabic ? 'جاري التنفيذ...' : 'Executing...',
       runtimeWarning: isArabic ? 'تحذير تشغيل' : 'Runtime warning',
       mode: isArabic ? 'وضع التنفيذ' : 'Execution mode',
-      live: isArabic ? 'حي - PancakeSwap' : 'Live - PancakeSwap',
+      live: isArabic ? 'حي' : 'Live',
       mock: isArabic ? 'تجريبي' : 'Mock',
       quickAmounts: isArabic ? 'مبالغ سريعة' : 'Quick amounts',
     }),
@@ -123,7 +138,7 @@ function ConvertPageContent() {
     setPairs(res.data.pairs || []);
     setMinUsdt(res.data.settings?.convert_min_usdt || 10);
     setFeeBps(res.data.settings?.convert_fee_bps || 0);
-    setConvertMode(res.data.settings?.convert_execution_mode || 'mock');
+    setConvertMode(res.data.settings?.convert_execution_mode || 'live');
     setRuntimeWarning('');
     if ((res.data.pairs || []).length) {
       setSelectedSymbol((prev) => (prev && res.data.pairs.some((item) => item.symbol === prev) ? prev : res.data.pairs[0].symbol));
@@ -150,7 +165,7 @@ function ConvertPageContent() {
         setFeeUsdt(0);
         return;
       }
-      setConvertMode(res.data.mode || 'mock');
+      setConvertMode(res.data.mode || 'live');
       setRuntimeWarning(String(res.data.runtime_warning || ''));
       setEstimate(parsePositive(res.data.quote.total_usdt));
       setFeeUsdt(parsePositive(res.data.quote.fee_usdt));
@@ -189,22 +204,11 @@ function ConvertPageContent() {
   }, [amountNum, category, estimate, isArabic, minUsdt, selectedPair, side, toast]);
 
   return (
-    <section className="mx-auto w-full max-w-5xl space-y-5 px-4 py-4 md:px-6 md:py-6">
-      <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-[#0e1730] via-[#0f243c] to-[#111629] p-5 text-white md:p-7">
-        <div className="absolute -right-12 -top-12 h-40 w-40 rounded-full bg-cyan-400/20 blur-3xl" />
-        <div className="absolute -bottom-16 left-1/4 h-44 w-44 rounded-full bg-indigo-400/10 blur-3xl" />
-        <div className="relative flex flex-wrap items-start justify-between gap-4">
-          <div className="space-y-2">
-            <div className="inline-flex items-center gap-2 rounded-full border border-cyan-300/30 bg-cyan-400/10 px-3 py-1 text-xs text-cyan-100">
-              <Sparkles className="h-3.5 w-3.5" /> {isArabic ? 'ELTX Convert Pro' : 'ELTX Convert Pro'}
-            </div>
-            <h1 className="text-2xl font-bold md:text-3xl">{labels.title}</h1>
-            <p className="max-w-2xl text-sm text-white/70 md:text-base">{labels.subtitle}</p>
-          </div>
-          <Link href="/trade" className="rounded-full border border-white/20 bg-black/20 px-3 py-1.5 text-xs text-white/80 transition hover:border-white/40 hover:text-white">
-            {labels.back}
-          </Link>
-        </div>
+    <section className="mx-auto w-full max-w-5xl space-y-4 px-4 py-4 md:px-6 md:py-6">
+      <div className="flex items-center">
+        <Link href="/trade" className="inline-flex items-center gap-2 rounded-xl border border-white/15 bg-[#11172a] px-3 py-2 text-xs text-white/80 transition hover:border-cyan-400/50 hover:text-white">
+          <ChevronLeft className="h-4 w-4" /> {labels.back}
+        </Link>
       </div>
 
       <div className="grid grid-cols-3 gap-2">
@@ -215,16 +219,12 @@ function ConvertPageContent() {
         ))}
       </div>
 
-      <div className="rounded-3xl border border-white/10 bg-[#0e1327]/95 p-4 text-white shadow-2xl shadow-black/20 md:p-6">
+      <div className="rounded-3xl border border-white/10 bg-[#0f172a] p-4 text-white shadow-xl shadow-black/20 md:p-6">
         <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
           <div className="flex items-center gap-2 text-sm text-white/80">
             <BadgeDollarSign className="h-4 w-4 text-cyan-200" /> {labels.choosePair}
           </div>
-          <button
-            onClick={loadPairs}
-            className="inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/[0.03] px-3 py-1.5 text-xs text-white/70 transition hover:border-white/25 hover:text-white"
-            type="button"
-          >
+          <button onClick={loadPairs} className="inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/[0.03] px-3 py-1.5 text-xs text-white/70 transition hover:border-cyan-400/50 hover:text-white" type="button">
             <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} /> {isArabic ? 'تحديث' : 'Refresh'}
           </button>
         </div>
@@ -238,10 +238,20 @@ function ConvertPageContent() {
         </select>
 
         {selectedPair && (
-          <div className="mt-3 flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/[0.03] p-3">
+          <div className="mt-3 flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-[#111a30] p-3">
             <div className="flex items-center gap-3">
               <div className="relative h-10 w-10 overflow-hidden rounded-full bg-white/10 ring-1 ring-white/15">
-                {selectedPair.logo_url ? <img src={selectedPair.logo_url} alt={selectedPair.token_symbol} className="h-full w-full object-cover" /> : null}
+                <img
+                  src={selectedPair.logo_url || assetIconFallback(selectedPair.token_symbol)}
+                  alt={`${selectedPair.token_symbol} icon`}
+                  className="h-full w-full object-cover"
+                  onError={(e) => {
+                    const fallback = assetIconFallback(selectedPair.token_symbol);
+                    const target = e.currentTarget;
+                    if (fallback && target.src !== fallback) target.src = fallback;
+                    else target.src = 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48"><rect width="48" height="48" rx="24" fill="%23111f34"/><text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="16" fill="%23ffffff" font-family="Arial">%</text></svg>';
+                  }}
+                />
               </div>
               <div>
                 <div className="text-sm font-semibold">{selectedPair.symbol}</div>
@@ -250,7 +260,7 @@ function ConvertPageContent() {
             </div>
             <div className="text-right text-xs text-white/60">
               <div>{labels.mode}</div>
-              <div className="font-semibold text-white/80">{convertMode === 'live' ? labels.live : labels.mock}</div>
+              <div className={`font-semibold ${convertMode === 'live' ? 'text-emerald-300' : 'text-amber-300'}`}>{convertMode === 'live' ? labels.live : labels.mock}</div>
             </div>
           </div>
         )}
@@ -276,7 +286,7 @@ function ConvertPageContent() {
           </button>
         </div>
 
-        <div className="mt-4 rounded-2xl border border-white/10 bg-gradient-to-br from-white/[0.05] to-white/[0.02] p-4">
+        <div className="mt-4 rounded-2xl border border-white/10 bg-[#111a2e] p-4">
           <div className="text-xs text-white/60">
             {side === 'buy'
               ? isArabic
@@ -326,11 +336,6 @@ function ConvertPageContent() {
               <div className="text-white/50">{isArabic ? 'الحد الادنى' : 'Minimum'}</div>
               <div className="mt-1 text-sm font-semibold text-white">{minUsdt.toFixed(2)} USDT</div>
             </div>
-          </div>
-
-          <div className="mt-3 flex items-center gap-2 rounded-xl border border-emerald-300/20 bg-emerald-500/10 p-2.5 text-xs text-emerald-100">
-            <ShieldCheck className="h-3.5 w-3.5" />
-            <span>{isArabic ? 'تنفيذ مع فحص الرسوم والحد الادنى قبل الارسال' : 'Execution validates fee and minimum threshold before submit'}</span>
           </div>
 
           {runtimeWarning ? (

--- a/db/migrations/202604271930_convert_defaults_live_icons.sql
+++ b/db/migrations/202604271930_convert_defaults_live_icons.sql
@@ -1,0 +1,22 @@
+-- Convert defaults: live-first execution and reliable icon URLs
+
+INSERT INTO platform_settings (`name`, `value`)
+VALUES ('convert_execution_mode', 'live')
+ON DUPLICATE KEY UPDATE `value` = VALUES(`value`);
+
+UPDATE convert_pairs
+SET logo_url = CASE UPPER(token_symbol)
+  WHEN 'XAUT' THEN 'https://assets.coingecko.com/coins/images/10481/standard/Tether_Gold.png'
+  WHEN 'BNB' THEN 'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/smartchain/assets/0x0000000000000000000000000000000000000000/logo.png'
+  WHEN 'WBTC' THEN 'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/smartchain/assets/0x7130d2A12B9BCBfAe4f2634d864A1Ee1Ce3Ead9c/logo.png'
+  WHEN 'SOL' THEN 'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/solana/info/logo.png'
+  WHEN 'XRP' THEN 'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/xrp/info/logo.png'
+  WHEN 'NVDA' THEN 'https://logo.clearbit.com/nvidia.com'
+  WHEN 'TSLA' THEN 'https://logo.clearbit.com/tesla.com'
+  WHEN 'AAPL' THEN 'https://logo.clearbit.com/apple.com'
+  WHEN 'MSFT' THEN 'https://logo.clearbit.com/microsoft.com'
+  WHEN 'AMZN' THEN 'https://logo.clearbit.com/amazon.com'
+  WHEN 'GOOGL' THEN 'https://logo.clearbit.com/google.com'
+  ELSE logo_url
+END
+WHERE active = 1;


### PR DESCRIPTION
### Motivation
- Users reported unrealistic XAUT/USDT quotes, misleading mock-first behavior, weak icons, and an unnecessary hero block on the Convert Desk that hurt UX and trust. 
- The change moves the product to a safe live-first execution policy while preserving a clearly signaled mock fallback and strict numeric guards to prevent absurd quotes.
- Admins need runtime control for convert fee and minimums that apply immediately, and the frontend must present real asset icons with robust fallbacks and bilingual labels.

### Description
- Backend: defaulted convert runtime to `live` in `readConvertSettings`, added reliable BSC addresses for USDT/USDC, implemented `quoteConvertMock()` to produce deterministic, asset-based mock reference prices, and added `assertConvertQuoteIsSane()` to guard quote ranges and produce `QUOTE_OUT_OF_RANGE` errors; applied these changes to `/convert/quote` and `/convert/execute` while keeping idempotency and refund flows intact (files: `api/src/app.js`).
- Frontend: removed decorative hero block, kept a compact Back button, harmonized category/button colors to platform tokens, removed helper banner text, made execution mode default to `live` client-side until API returns, and added curated icon mapping with onError fallback and accessible alt text (file: `app/(app)/trade/convert/page.tsx`).
- Admin/DB: added a migration that sets `convert_execution_mode=live` and seeds reliable logo URLs for key convert assets (file: `db/migrations/202604271930_convert_defaults_live_icons.sql`).
- Tests: extended integration tests to assert sane mock pricing for XAUT and adjusted quote/execute expected values and runtime-warning coverage (file: `api/tests/integration.test.js`).

### Testing
- Ran `npm ci` which completed successfully (packages installed; audit reported vulnerabilities to review). 
- Ran `npm test -- --runInBand`: integration tests passed (integration subtests 26/26); e2e tests were blocked by missing system libraries required by headless Chromium in this environment (Playwright reported missing runtime libs like `libatk-1.0.so.0`), causing the full `npm test` to exit non-zero for the e2e stage. 
- Ran `npm run lint`: succeeded with a single non-blocking ESLint warning about using `<img>` instead of `next/image` on the convert page. 
- Ran `npm run build`: production build succeeded; build-time notes include the same `@next/next/no-img-element` warning and an outdated browserslist advisory. 

All integration assertions (quote math, XAUT reference price, convert execute lifecycle and idempotency, and live-misconfigured fallback warnings) were executed and passed in CI simulation; e2e / screenshots could not be fully captured due to missing system shared libraries in the runner (recommend installing required libs in CI to enable Playwright headless runs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efba251154832ba0de12158f2589d6)