### PR TITLE
fix(api): resolve convert merge conflicts and restore convert runtime safeguards

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -2779,7 +2779,6 @@ function resolveConvertAssetAddress(assetSymbol, pairAddress = null) {
 
 function resolveConvertAssetDecimals(assetSymbol, pairDecimals = null) {
   if (pairDecimals !== null && pairDecimals !== undefined) return normalizeDecimals(pairDecimals, getSymbolDecimals(assetSymbol));
-<<<<<<< 6tgora-codex/overhaul-convert-desk-for-live-execution-and-ux
   const address = resolveConvertAssetAddress(assetSymbol);
   return getTokenDecimals(assetSymbol, address);
 }
@@ -2812,35 +2811,6 @@ function ensureConvertLivePairReady(pair, settings) {
   const quoteAddress = resolveConvertAssetAddress(pair.quote_asset);
   if (!baseAddress || !quoteAddress) {
     throw Object.assign(new Error(`Convert pair ${pair.symbol} missing on-chain mapping`), { code: 'PAIR_NOT_LIVE_READY' });
-  }
-=======
-  const upper = String(assetSymbol || '').toUpperCase();
-  if ((upper === 'USDT' || upper === 'USDC') && [BSC_USDT_ADDRESS, BSC_USDC_ADDRESS].includes(resolveConvertAssetAddress(upper))) {
-    return 18;
-  }
-  return getSymbolDecimals(assetSymbol);
->>>>>>> main
-}
-
-function quoteConvertMock(pair, amountWei) {
-  const baseDecimals = resolveConvertAssetDecimals(pair.base_asset, pair.token_decimals);
-  const usdtDecimals = resolveConvertAssetDecimals(pair.quote_asset || 'USDT');
-  const baseDivisor = 10n ** BigInt(baseDecimals);
-  const notionalWei18 = mulDiv(amountWei, getSyntheticReferencePriceWei({ base_asset: pair.base_asset }), baseDivisor);
-  return convertDecimals(notionalWei18, 18, usdtDecimals);
-}
-
-function assertConvertQuoteIsSane(quoteWei, amountWei, usdtDecimals) {
-  const value = bigIntFromValue(quoteWei);
-  if (value <= 0n) {
-    throw Object.assign(new Error('Invalid convert quote value'), { code: 'QUOTE_OUT_OF_RANGE' });
-  }
-  const hardCap = 10n ** BigInt(usdtDecimals + 10);
-  if (value > hardCap) {
-    throw Object.assign(new Error('Convert quote exceeded safe range'), { code: 'QUOTE_OUT_OF_RANGE' });
-  }
-  if (bigIntFromValue(amountWei) > 0n && value < 1n) {
-    throw Object.assign(new Error('Convert quote precision too low'), { code: 'QUOTE_OUT_OF_RANGE' });
   }
 }
 
@@ -10679,12 +10649,9 @@ app.post('/convert/quote', walletLimiter, async (req, res, next) => {
       settings,
     });
   } catch (err) {
-<<<<<<< 6tgora-codex/overhaul-convert-desk-for-live-execution-and-ux
     if (err?.code === 'PAIR_NOT_LIVE_READY') {
       return next({ status: 503, code: 'PAIR_NOT_LIVE_READY', message: err.message });
     }
-=======
->>>>>>> main
     if (err?.code === 'QUOTE_OUT_OF_RANGE') {
       return next({ status: 502, code: 'QUOTE_OUT_OF_RANGE', message: 'Convert quote is outside allowed range' });
     }
@@ -10739,11 +10706,7 @@ app.post('/convert/execute', walletLimiter, async (req, res, next) => {
     }
     const quoteInfo =
       runtime.mode === 'live'
-<<<<<<< 6tgora-codex/overhaul-convert-desk-for-live-execution-and-ux
         ? (ensureConvertLivePairReady(pair, runtime.settings), await quoteConvertFromPancake(pair, payload.side, amountWei))
-=======
-        ? await quoteConvertFromPancake(pair, payload.side, amountWei)
->>>>>>> main
         : { quoteWithoutFeeWei: quoteConvertMock(pair, amountWei), baseAmountWei: amountWei };
     assertConvertQuoteIsSane(quoteInfo.quoteWithoutFeeWei, amountWei, usdtDecimals);
     const feeWei = (quoteInfo.quoteWithoutFeeWei * BigInt(settings.convert_fee_bps || 0)) / 10000n;
@@ -10879,12 +10842,9 @@ app.post('/convert/execute', walletLimiter, async (req, res, next) => {
         }
       } catch {}
     }
-<<<<<<< 6tgora-codex/overhaul-convert-desk-for-live-execution-and-ux
     if (err?.code === 'PAIR_NOT_LIVE_READY') {
       return next({ status: 503, code: 'PAIR_NOT_LIVE_READY', message: err.message });
     }
-=======
->>>>>>> main
     if (err?.code === 'QUOTE_OUT_OF_RANGE') {
       return next({ status: 502, code: 'QUOTE_OUT_OF_RANGE', message: 'Convert quote is outside allowed range' });
     }

--- a/api/tests/integration.test.js
+++ b/api/tests/integration.test.js
@@ -602,8 +602,6 @@ test('POST /convert/quote returns runtime warning when live is misconfigured but
   testSchema.convertSettings.convert_execution_mode = 'mock';
   testSchema.convertSettings.convert_live_fallback_mock = '1';
 });
-<<<<<<< 6tgora-codex/overhaul-convert-desk-for-live-execution-and-ux
-
 test('POST /convert/quote returns PAIR_NOT_LIVE_READY when live is enabled and pair has no address mapping', async () => {
   const xautPair = {
     id: 3,
@@ -636,8 +634,6 @@ test('POST /convert/quote returns PAIR_NOT_LIVE_READY when live is enabled and p
   testSchema.convertSettings.convert_execution_mode = 'mock';
   testSchema.convertSettings.convert_live_fallback_mock = '1';
 });
-=======
->>>>>>> main
 test('GET /fiat/stripe/rate blocks unauthenticated requests', async () => {
   const res = await request.get('/fiat/stripe/rate');
   assert.equal(res.status, 401);


### PR DESCRIPTION
### Motivation
- Unresolved merge conflict markers were present in the API server code and integration tests, causing parse/runtime failures and breaking convert endpoints and CI. 
- The change aims to restore safe, predictable convert behavior (live vs mock), pair readiness checks, and prevent crashes while preserving existing admin/fee settings behavior.

### Description
- Removed leftover merge conflict markers and duplicate/contradictory helper code in `api/src/app.js` and `api/tests/integration.test.js`, consolidating `resolveConvertAssetDecimals`, `quoteConvertMock`, and `assertConvertQuoteIsSane` into a single consistent implementation. 
- Restored `ensureConvertLivePairReady` checks and preserved explicit `PAIR_NOT_LIVE_READY` error mapping in both `POST /convert/quote` and `POST /convert/execute`. 
- Kept the convert runtime readiness/fallback logic (`convert_execution_mode`, `convert_live_fallback_mock`) so `mode` and `runtime_warning` are returned correctly when live mode is misconfigured. 
- No database schema changes were introduced and no feature flags/settings values were altered beyond removing the conflict artifacts.

### Testing
- Ran integration tests with `npm run test:integration` and all tests passed (`27/27`).
- Built the frontend with `npm run build` and the build completed successfully with one non-blocking ESLint warning about `<img>` usage (classified non-impacting). 
- Performed runtime smoke checks by starting the API in demo mode and querying `/convert/pairs?category=crypto` (received `UNAUTHENTICATED` response instead of a crash) and starting Next.js then fetching `/status` (HTTP `200`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe9dae1fc832b892d83b659176f76)