### PR TITLE
fix(convert): enforce backend-driven live mode, normalize hot-wallet PK, add Pancake V3 quoter/router & health endpoint

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -949,9 +949,19 @@ const PANCAKE_V2_ROUTER_ABI = [
   'function swapExactTokensForTokens(uint amountIn,uint amountOutMin,address[] calldata path,address to,uint deadline) external returns (uint[] memory amounts)',
   'function swapTokensForExactTokens(uint amountOut,uint amountInMax,address[] calldata path,address to,uint deadline) external returns (uint[] memory amounts)',
 ];
+const PANCAKE_SMART_ROUTER_ABI = [
+  'function exactInputSingle((address tokenIn,address tokenOut,uint24 fee,address recipient,uint256 amountIn,uint256 amountOutMinimum,uint160 sqrtPriceLimitX96)) payable returns (uint256 amountOut)',
+  'function exactOutputSingle((address tokenIn,address tokenOut,uint24 fee,address recipient,uint256 amountOut,uint256 amountInMaximum,uint160 sqrtPriceLimitX96)) payable returns (uint256 amountIn)',
+];
+const PANCAKE_QUOTER_V2_ABI = [
+  'function quoteExactInputSingle((address tokenIn,address tokenOut,uint256 amountIn,uint24 fee,uint160 sqrtPriceLimitX96)) external returns (uint256 amountOut,uint160,uint32,uint256)',
+  'function quoteExactOutputSingle((address tokenIn,address tokenOut,uint256 amountOut,uint24 fee,uint160 sqrtPriceLimitX96)) external returns (uint256 amountIn,uint160,uint32,uint256)',
+];
 const ERC20_ABI = [
   'function approve(address spender, uint256 value) external returns (bool)',
   'function allowance(address owner, address spender) external view returns (uint256)',
+  'function balanceOf(address owner) external view returns (uint256)',
+  'function decimals() external view returns (uint8)',
 ];
 const BSC_WBNB_ADDRESS = (process.env.TOKEN_WBNB || '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c').toLowerCase();
 const BSC_USDT_ADDRESS = (process.env.TOKEN_USDT || '0x55d398326f99059fF775485246999027B3197955').toLowerCase();
@@ -959,6 +969,17 @@ const BSC_USDC_ADDRESS = (process.env.TOKEN_USDC || '0x8ac76a51cc950d9822d68b83f
 const PANCAKE_V2_ROUTER_ADDRESS = (
   process.env.PANCAKE_V2_ROUTER || '0x10ED43C718714eb63d5aA57B78B54704E256024E'
 ).toLowerCase();
+const PANCAKE_SMART_ROUTER_ADDRESS = (process.env.PANCAKE_SMART_ROUTER || '0x13f4EA83D0bd40E75C8222255bc855a974568Dd4').toLowerCase();
+const PANCAKE_QUOTER_V2_ADDRESS = (process.env.PANCAKE_QUOTER_V2 || '0xB048Bbc1Ee6b733FFfCFb9e9CeF7375518e25997').toLowerCase();
+const CONVERT_V3_FEES = [100, 500, 2500, 10000];
+const CONVERT_PRICE_MAX_DEVIATION_BPS = Number(process.env.CONVERT_PRICE_MAX_DEVIATION_BPS || 700);
+const CONVERT_CHAIN_ID = 56;
+const CONVERT_TOKEN_REGISTRY = {
+  56: {
+    XAUT: { address: '0x21cAef8A43163Eea865baeE23b9C2E327696A3bf'.toLowerCase(), decimals: 6 },
+    USDT: { address: '0x55d398326f99059ff775485246999027b3197955'.toLowerCase(), decimals: 18 },
+  },
+};
 
 // token metadata from registry files (all supported chains) and env
 const tokenMeta = {};
@@ -2718,18 +2739,22 @@ async function readConvertSettings(conn = pool) {
   const minVal = await getPlatformSettingValue('convert_min_usdt', '10', conn);
   const modeVal = await getPlatformSettingValue('convert_execution_mode', 'live', conn);
   const slippageVal = await getPlatformSettingValue('convert_slippage_bps', '120', conn);
-  const fallbackVal = await getPlatformSettingValue('convert_live_fallback_mock', '1', conn);
+  const fallbackVal = await getPlatformSettingValue('convert_live_fallback_mock', '0', conn);
   const requirePairAddressVal = await getPlatformSettingValue('convert_require_pair_address_live', '1', conn);
   const feeBps = clampBps(BigInt(Number.parseInt(feeVal, 10) || 0));
   const minUsdt = Number.parseFloat(minVal || '10');
   const slippageBps = clampBps(BigInt(Number.parseInt(slippageVal, 10) || 0));
+  const requestedMode = modeVal === 'mock' ? 'mock' : 'live';
+  const mockPermittedByEnv = process.env.NODE_ENV !== 'production' && process.env.CONVERT_ALLOW_MOCK === 'true';
   return {
     convert_fee_bps: Number(feeBps),
     convert_min_usdt: Number.isFinite(minUsdt) && minUsdt >= 0 ? minUsdt : 10,
-    convert_execution_mode: modeVal === 'live' ? 'live' : 'mock',
+    convert_execution_mode: process.env.NODE_ENV === 'production' ? 'live' : requestedMode,
+    convert_requested_mode: requestedMode,
     convert_slippage_bps: Number(slippageBps),
-    convert_live_fallback_mock: fallbackVal === '0' ? 0 : 1,
+    convert_live_fallback_mock: fallbackVal === '1' && mockPermittedByEnv ? 1 : 0,
     convert_require_pair_address_live: requirePairAddressVal === '0' ? 0 : 1,
+    convert_mock_allowed: mockPermittedByEnv,
   };
 }
 
@@ -2769,6 +2794,8 @@ async function listConvertPairs(category, conn = pool, { includeInactive = false
 
 function resolveConvertAssetAddress(assetSymbol, pairAddress = null) {
   const upper = String(assetSymbol || '').toUpperCase();
+  const registryMeta = CONVERT_TOKEN_REGISTRY[CONVERT_CHAIN_ID]?.[upper];
+  if (registryMeta?.address) return registryMeta.address;
   if (pairAddress) return String(pairAddress).toLowerCase();
   if (upper === 'BNB') return BSC_WBNB_ADDRESS;
   if (upper === 'USDT') return BSC_USDT_ADDRESS;
@@ -2778,6 +2805,9 @@ function resolveConvertAssetAddress(assetSymbol, pairAddress = null) {
 }
 
 function resolveConvertAssetDecimals(assetSymbol, pairDecimals = null) {
+  const upper = String(assetSymbol || '').toUpperCase();
+  const registryMeta = CONVERT_TOKEN_REGISTRY[CONVERT_CHAIN_ID]?.[upper];
+  if (registryMeta?.decimals !== undefined && registryMeta?.decimals !== null) return normalizeDecimals(registryMeta.decimals, getSymbolDecimals(assetSymbol));
   if (pairDecimals !== null && pairDecimals !== undefined) return normalizeDecimals(pairDecimals, getSymbolDecimals(assetSymbol));
   const address = resolveConvertAssetAddress(assetSymbol);
   return getTokenDecimals(assetSymbol, address);
@@ -2809,8 +2839,12 @@ function ensureConvertLivePairReady(pair, settings) {
   if (Number(settings?.convert_require_pair_address_live || 0) !== 1) return;
   const baseAddress = resolveConvertAssetAddress(pair.base_asset, pair.token_address);
   const quoteAddress = resolveConvertAssetAddress(pair.quote_asset);
-  if (!baseAddress || !quoteAddress) {
+  const registryBase = CONVERT_TOKEN_REGISTRY[CONVERT_CHAIN_ID]?.[String(pair.base_asset || '').toUpperCase()]?.address || null;
+  if (!pair.token_address || !baseAddress || !quoteAddress) {
     throw Object.assign(new Error(`Convert pair ${pair.symbol} missing on-chain mapping`), { code: 'PAIR_NOT_LIVE_READY' });
+  }
+  if (registryBase && String(pair.token_address).toLowerCase() !== registryBase) {
+    throw Object.assign(new Error(`Convert pair ${pair.symbol} address mismatch with registry`), { code: 'PAIR_NOT_LIVE_READY' });
   }
 }
 
@@ -2830,21 +2864,40 @@ async function getConvertPairBySymbol(symbol, category = null, conn = pool) {
   return rows[0] ? mapConvertPairRow(rows[0]) : null;
 }
 
+function normalizeConvertPrivateKey(rawPk) {
+  const value = String(rawPk || '')
+    .replace(/^\uFEFF/, '')
+    .replace(/\r/g, '')
+    .replace(/["']/g, '')
+    .trim();
+  if (!value) return { normalizedPk: '', valid: false, reason: 'empty' };
+  if (value.startsWith('0x')) {
+    return { normalizedPk: value, valid: /^0x[0-9a-fA-F]{64}$/.test(value), reason: '0x-prefixed' };
+  }
+  if (/^[0-9a-fA-F]{64}$/.test(value)) {
+    return { normalizedPk: `0x${value}`, valid: true, reason: 'hex-normalized' };
+  }
+  return { normalizedPk: value, valid: false, reason: 'bad-format' };
+}
+
 function summarizeConvertRuntimeReadiness(settings) {
   const rpcUrl = process.env.BSC_RPC_URL || process.env.BSC_RPC_HTTP || '';
-  const pk = process.env.CONVERT_HOT_WALLET_PK || '';
+  const rawPk = process.env.CONVERT_HOT_WALLET_PK || '';
+  const normalizedPk = normalizeConvertPrivateKey(rawPk);
   const configuredHotWalletAddress = (process.env.CONVERT_HOT_WALLET_ADDRESS || '').toLowerCase();
   const missingEnv = [];
+  const invalidEnv = [];
   if (!rpcUrl) missingEnv.push('BSC_RPC_URL (or BSC_RPC_HTTP)');
-  if (!pk) missingEnv.push('CONVERT_HOT_WALLET_PK');
+  if (!rawPk) missingEnv.push('CONVERT_HOT_WALLET_PK');
   if (!configuredHotWalletAddress) missingEnv.push('CONVERT_HOT_WALLET_ADDRESS');
+  if (rawPk && !normalizedPk.valid) invalidEnv.push('CONVERT_HOT_WALLET_PK (invalid private key)');
 
   let resolvedWalletAddress = '';
-  if (pk) {
+  if (normalizedPk.valid) {
     try {
-      resolvedWalletAddress = ethers.computeAddress(pk).toLowerCase();
+      resolvedWalletAddress = ethers.computeAddress(normalizedPk.normalizedPk).toLowerCase();
     } catch {
-      missingEnv.push('CONVERT_HOT_WALLET_PK (invalid private key)');
+      invalidEnv.push('CONVERT_HOT_WALLET_PK (invalid private key)');
     }
   }
   if (
@@ -2852,27 +2905,36 @@ function summarizeConvertRuntimeReadiness(settings) {
     resolvedWalletAddress &&
     configuredHotWalletAddress !== resolvedWalletAddress
   ) {
-    missingEnv.push('CONVERT_HOT_WALLET_ADDRESS mismatch with CONVERT_HOT_WALLET_PK');
+    invalidEnv.push('CONVERT_HOT_WALLET_ADDRESS mismatch with CONVERT_HOT_WALLET_PK');
   }
-  const envReady = missingEnv.length === 0;
-  const liveRequested = settings.convert_execution_mode === 'live';
+  const envReady = missingEnv.length === 0 && invalidEnv.length === 0;
+  const liveRequested = settings.convert_execution_mode === 'live' || settings.convert_requested_mode === 'live';
   const fallbackEnabled = Number(settings.convert_live_fallback_mock || 0) === 1;
-  const mode = liveRequested && envReady ? 'live' : 'mock';
+  const mode = liveRequested && envReady ? 'live' : fallbackEnabled ? 'mock' : 'live';
   const warning =
     liveRequested && !envReady
-      ? `[convert] live mode requested but not ready; missing/invalid: ${missingEnv.join(', ')}. fallback_to_mock=${fallbackEnabled ? '1' : '0'}`
+      ? `[convert] live mode requested but not ready; missing/invalid: ${missingEnv.concat(invalidEnv).join(', ')}. fallback_to_mock=${fallbackEnabled ? '1' : '0'}`
       : '';
+  const normalizedFingerprint = normalizedPk.normalizedPk
+    ? `${normalizedPk.normalizedPk.slice(0, 6)}...${normalizedPk.normalizedPk.slice(-4)}`
+    : 'empty';
+  console.info(
+    `[convert] hot wallet key normalized=${normalizedPk.valid ? '1' : '0'} source=${normalizedPk.reason} fingerprint=${normalizedFingerprint} derived=${resolvedWalletAddress ? `${resolvedWalletAddress.slice(0, 6)}...${resolvedWalletAddress.slice(-4)}` : 'n/a'}`
+  );
   return {
     mode,
     envReady,
     settings,
     rpcUrl,
-    pk,
+    pk: normalizedPk.valid ? normalizedPk.normalizedPk : '',
     resolvedWalletAddress: resolvedWalletAddress || configuredHotWalletAddress || null,
     missingEnv,
+    invalidEnv,
     warning,
     fallbackEnabled,
     liveRequested,
+    derivedAddressMatches: !configuredHotWalletAddress || !resolvedWalletAddress ? false : configuredHotWalletAddress === resolvedWalletAddress,
+    requestedMode: settings.convert_requested_mode || settings.convert_execution_mode,
   };
 }
 
@@ -2883,28 +2945,71 @@ async function buildConvertRuntime(conn = pool) {
   return runtime;
 }
 
-async function quoteConvertFromPancake(pair, side, amountWei) {
-  const provider = new ethers.JsonRpcProvider(process.env.BSC_RPC_URL || process.env.BSC_RPC_HTTP);
-  const router = new ethers.Contract(PANCAKE_V2_ROUTER_ADDRESS, PANCAKE_V2_ROUTER_ABI, provider);
+async function readConvertTokenDecimals(provider, tokenAddress) {
+  const token = new ethers.Contract(tokenAddress, ERC20_ABI, provider);
+  return Number(await token.decimals());
+}
+
+async function readConvertTokenBalance(provider, tokenAddress, walletAddress) {
+  const token = new ethers.Contract(tokenAddress, ERC20_ABI, provider);
+  return bigIntFromValue(await token.balanceOf(walletAddress));
+}
+
+async function readGlobalGoldPriceUsdt() {
+  const fallback = Number(trimDecimal(formatUnitsStr(getSyntheticReferencePriceWei({ base_asset: 'XAUT' }).toString(), 18)));
+  try {
+    const response = await fetch('https://api.coingecko.com/api/v3/simple/price?ids=tether-gold&vs_currencies=usd', { method: 'GET' });
+    if (!response.ok) return fallback;
+    const json = await response.json();
+    const price = Number(json?.['tether-gold']?.usd || 0);
+    return Number.isFinite(price) && price > 0 ? price : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function assertQuoteDeviationSafe(quoteInfo, amountWei, pair, side, usdtDecimals, globalPrice) {
+  const amountBase = Number(trimDecimal(formatUnitsStr(amountWei.toString(), resolveConvertAssetDecimals(pair.base_asset, pair.token_decimals))));
+  const amountUsdt = Number(trimDecimal(formatUnitsStr(quoteInfo.quoteWithoutFeeWei.toString(), usdtDecimals)));
+  if (!Number.isFinite(amountBase) || amountBase <= 0 || !Number.isFinite(amountUsdt) || amountUsdt <= 0) {
+    throw Object.assign(new Error('Invalid quote amount'), { code: 'QUOTE_OUT_OF_RANGE' });
+  }
+  const effective = side === 'buy' ? amountUsdt / amountBase : amountUsdt / amountBase;
+  const deviationBps = Math.abs((effective - globalPrice) / globalPrice) * 10000;
+  if (deviationBps > CONVERT_PRICE_MAX_DEVIATION_BPS) {
+    throw Object.assign(new Error('price deviation too high'), { code: 'PRICE_DEVIATION' });
+  }
+}
+
+async function quoteConvertFromPancake(pair, side, amountWei, provider) {
+  const quoter = new ethers.Contract(PANCAKE_QUOTER_V2_ADDRESS, PANCAKE_QUOTER_V2_ABI, provider);
   const baseAddress = resolveConvertAssetAddress(pair.base_asset, pair.token_address);
   const quoteAddress = resolveConvertAssetAddress(pair.quote_asset);
   if (!baseAddress || !quoteAddress) throw new Error(`Missing token address mapping for ${pair.symbol}`);
-  if (side === 'buy') {
-    const amounts = await router.getAmountsIn(amountWei, [quoteAddress, baseAddress]);
-    return {
-      quoteWithoutFeeWei: bigIntFromValue(amounts[0]),
-      baseAmountWei: bigIntFromValue(amountWei),
-      direction: 'quote_to_base',
-      path: [quoteAddress, baseAddress],
-    };
+  let best = null;
+  let quoteErr = null;
+  for (const fee of CONVERT_V3_FEES) {
+    try {
+      if (side === 'buy') {
+        const quoted = await quoter.quoteExactOutputSingle.staticCall([quoteAddress, baseAddress, amountWei, fee, 0]);
+        const quotedIn = bigIntFromValue(Array.isArray(quoted) ? quoted[0] : quoted.amountIn || 0);
+        if (quotedIn > 0n && (!best || quotedIn < best.quoteWithoutFeeWei)) {
+          best = { quoteWithoutFeeWei: quotedIn, baseAmountWei: bigIntFromValue(amountWei), direction: 'quote_to_base', fee, path: [quoteAddress, baseAddress] };
+        }
+      } else {
+        const quoted = await quoter.quoteExactInputSingle.staticCall([baseAddress, quoteAddress, amountWei, fee, 0]);
+        const quotedOut = bigIntFromValue(Array.isArray(quoted) ? quoted[0] : quoted.amountOut || 0);
+        if (quotedOut > 0n && (!best || quotedOut > best.quoteWithoutFeeWei)) {
+          best = { quoteWithoutFeeWei: quotedOut, baseAmountWei: bigIntFromValue(amountWei), direction: 'base_to_quote', fee, path: [baseAddress, quoteAddress] };
+        }
+      }
+    } catch (err) {
+      quoteErr = err;
+    }
   }
-  const amounts = await router.getAmountsOut(amountWei, [baseAddress, quoteAddress]);
-  return {
-    quoteWithoutFeeWei: bigIntFromValue(amounts[1]),
-    baseAmountWei: bigIntFromValue(amountWei),
-    direction: 'base_to_quote',
-    path: [baseAddress, quoteAddress],
-  };
+  if (best) return best;
+  if (quoteErr) throw quoteErr;
+  throw new Error(`No PancakeSwap route found for ${pair.symbol}`);
 }
 
 async function ensureErc20Allowance(tokenAddress, wallet, spender, minWei) {
@@ -2917,6 +3022,7 @@ async function ensureErc20Allowance(tokenAddress, wallet, spender, minWei) {
 
 async function executeConvertOnPancake(pair, side, amountWei, quoteWei, runtime) {
   if (runtime.mode !== 'live') {
+    if (!runtime.fallbackEnabled) throw new Error('Live execution is required for convert');
     return {
       txHash: `mock-${Date.now()}`,
       spentQuoteWei: quoteWei,
@@ -2927,35 +3033,33 @@ async function executeConvertOnPancake(pair, side, amountWei, quoteWei, runtime)
   }
   const provider = new ethers.JsonRpcProvider(runtime.rpcUrl);
   const wallet = new ethers.Wallet(runtime.pk, provider);
-  const router = new ethers.Contract(PANCAKE_V2_ROUTER_ADDRESS, PANCAKE_V2_ROUTER_ABI, wallet);
+  const router = new ethers.Contract(PANCAKE_SMART_ROUTER_ADDRESS, PANCAKE_SMART_ROUTER_ABI, wallet);
   const baseAddress = resolveConvertAssetAddress(pair.base_asset, pair.token_address);
   const quoteAddress = resolveConvertAssetAddress(pair.quote_asset);
   if (!baseAddress || !quoteAddress) throw new Error(`Missing token address mapping for ${pair.symbol}`);
-  const deadline = Math.floor(Date.now() / 1000) + 180;
+  const feeTier = Number(runtime.quoteFeeTier || CONVERT_V3_FEES[1]);
   const slippageBps = Number(runtime.settings.convert_slippage_bps || 0);
   if (side === 'buy') {
     const maxIn = quoteWei + (quoteWei * BigInt(slippageBps)) / 10000n;
-    await ensureErc20Allowance(quoteAddress, wallet, PANCAKE_V2_ROUTER_ADDRESS, maxIn);
-    const tx = await router.swapTokensForExactTokens(amountWei, maxIn, [quoteAddress, baseAddress], wallet.address, deadline);
+    await ensureErc20Allowance(quoteAddress, wallet, PANCAKE_SMART_ROUTER_ADDRESS, maxIn);
+    const tx = await router.exactOutputSingle([quoteAddress, baseAddress, feeTier, wallet.address, amountWei, maxIn, 0]);
     const receipt = await tx.wait();
-    const out = await router.getAmountsIn(amountWei, [quoteAddress, baseAddress]);
     return {
       txHash: receipt?.hash || tx.hash,
-      spentQuoteWei: bigIntFromValue(out[0]),
+      spentQuoteWei: maxIn,
       receivedBaseWei: amountWei,
       receivedQuoteWei: 0n,
       mode: 'live',
     };
   }
   const minOut = quoteWei - (quoteWei * BigInt(slippageBps)) / 10000n;
-  await ensureErc20Allowance(baseAddress, wallet, PANCAKE_V2_ROUTER_ADDRESS, amountWei);
-  const tx = await router.swapExactTokensForTokens(amountWei, minOut > 0n ? minOut : 0n, [baseAddress, quoteAddress], wallet.address, deadline);
+  await ensureErc20Allowance(baseAddress, wallet, PANCAKE_SMART_ROUTER_ADDRESS, amountWei);
+  const tx = await router.exactInputSingle([baseAddress, quoteAddress, feeTier, wallet.address, amountWei, minOut > 0n ? minOut : 0n, 0]);
   const receipt = await tx.wait();
-  const out = await router.getAmountsOut(amountWei, [baseAddress, quoteAddress]);
   return {
     txHash: receipt?.hash || tx.hash,
     spentQuoteWei: 0n,
-    receivedQuoteWei: bigIntFromValue(out[1]),
+    receivedQuoteWei: minOut > 0n ? minOut : 0n,
     receivedBaseWei: amountWei,
     mode: 'live',
   };
@@ -10588,8 +10692,98 @@ app.get('/convert/pairs', walletLimiter, async (req, res, next) => {
   try {
     await requireUser(req);
     const { category } = ConvertPairsQuerySchema.parse(req.query || {});
-    const [pairs, settings] = await Promise.all([listConvertPairs(category), readConvertSettings()]);
+    const [pairs, settings, runtime] = await Promise.all([listConvertPairs(category), readConvertSettings(), buildConvertRuntime()]);
     res.json({ ok: true, category: category || null, pairs, settings });
+    if (runtime.liveRequested && !runtime.envReady) {
+      console.warn('[convert] pairs requested while live runtime is not ready');
+    }
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return next({ status: 400, code: 'BAD_INPUT', message: 'Invalid query', details: err.flatten() });
+    }
+    next(err);
+  }
+});
+
+app.get('/convert/health', walletLimiter, async (req, res, next) => {
+  try {
+    await requireUser(req);
+    const { category, symbol } = ConvertQuoteSchema.pick({ category: true, symbol: true }).parse(req.query || {});
+    const pair = await getConvertPairBySymbol(symbol, category || null);
+    if (!pair) return next({ status: 404, code: 'PAIR_NOT_FOUND', message: 'Convert pair not found' });
+    const runtime = await buildConvertRuntime();
+    const tokenIn = resolveConvertAssetAddress(pair.quote_asset);
+    const tokenOut = resolveConvertAssetAddress(pair.base_asset, pair.token_address);
+    const quoteDecimals = resolveConvertAssetDecimals(pair.quote_asset);
+    const baseDecimals = resolveConvertAssetDecimals(pair.base_asset, pair.token_decimals);
+    const provider = runtime.rpcUrl ? new ethers.JsonRpcProvider(runtime.rpcUrl) : null;
+    let rpcReady = false;
+    let quoteReady = false;
+    let liquidityRouteFound = false;
+    let lastError = runtime.warning || '';
+    let bnbBalance = '0';
+    let usdtBalance = '0';
+    let xautBalance = '0';
+    let decimalsMatch = true;
+    if (provider && runtime.envReady) {
+      try {
+        await provider.getBlockNumber();
+        rpcReady = true;
+        const walletAddress = runtime.resolvedWalletAddress;
+        const [nativeWei, usdtWei, xautWei, onchainXautDecimals, onchainUsdtDecimals] = await Promise.all([
+          provider.getBalance(walletAddress),
+          readConvertTokenBalance(provider, CONVERT_TOKEN_REGISTRY[56].USDT.address, walletAddress),
+          readConvertTokenBalance(provider, CONVERT_TOKEN_REGISTRY[56].XAUT.address, walletAddress),
+          readConvertTokenDecimals(provider, CONVERT_TOKEN_REGISTRY[56].XAUT.address),
+          readConvertTokenDecimals(provider, CONVERT_TOKEN_REGISTRY[56].USDT.address),
+        ]);
+        bnbBalance = trimDecimal(formatUnitsStr(nativeWei.toString(), 18));
+        usdtBalance = trimDecimal(formatUnitsStr(usdtWei.toString(), CONVERT_TOKEN_REGISTRY[56].USDT.decimals));
+        xautBalance = trimDecimal(formatUnitsStr(xautWei.toString(), CONVERT_TOKEN_REGISTRY[56].XAUT.decimals));
+        decimalsMatch =
+          onchainXautDecimals === CONVERT_TOKEN_REGISTRY[56].XAUT.decimals &&
+          onchainUsdtDecimals === CONVERT_TOKEN_REGISTRY[56].USDT.decimals &&
+          baseDecimals === CONVERT_TOKEN_REGISTRY[56].XAUT.decimals &&
+          quoteDecimals === CONVERT_TOKEN_REGISTRY[56].USDT.decimals;
+        const probeAmount = decimalToWeiString('0.001', baseDecimals) || '0';
+        if (bigIntFromValue(probeAmount) > 0n) {
+          const quoteInfo = await quoteConvertFromPancake(pair, 'buy', bigIntFromValue(probeAmount), provider);
+          quoteReady = quoteInfo.quoteWithoutFeeWei > 0n;
+          liquidityRouteFound = !!quoteInfo.fee;
+        }
+      } catch (err) {
+        lastError = String(err?.message || err || 'health_failed');
+      }
+    }
+    if (!decimalsMatch) {
+      return next({ status: 503, code: 'PAIR_NOT_LIVE_READY', message: 'token decimals mismatch for configured convert pair' });
+    }
+    res.json({
+      ok: true,
+      requestedMode: runtime.requestedMode,
+      effectiveMode: runtime.mode,
+      liveReady: runtime.envReady && rpcReady && quoteReady && liquidityRouteFound,
+      provider: 'pancakeswap',
+      chainId: CONVERT_CHAIN_ID,
+      rpcReady,
+      hotWalletAddress: runtime.resolvedWalletAddress ? `${runtime.resolvedWalletAddress.slice(0, 6)}...${runtime.resolvedWalletAddress.slice(-4)}` : null,
+      derivedAddressMatches: runtime.derivedAddressMatches,
+      routerAddress: PANCAKE_SMART_ROUTER_ADDRESS,
+      quoterAddress: PANCAKE_QUOTER_V2_ADDRESS,
+      tokenIn,
+      tokenOut,
+      tokenInDecimals: quoteDecimals,
+      tokenOutDecimals: baseDecimals,
+      hotWalletBnbGasBalance: bnbBalance,
+      hotWalletUsdtBalance: usdtBalance,
+      hotWalletXautBalance: xautBalance,
+      priceSource: 'pancakeswap-quoter-v2',
+      quoteReady,
+      liquidityRouteFound,
+      lastError: lastError || null,
+      missingEnv: runtime.missingEnv,
+      invalidEnv: runtime.invalidEnv || [],
+    });
   } catch (err) {
     if (err instanceof z.ZodError) {
       return next({ status: 400, code: 'BAD_INPUT', message: 'Invalid query', details: err.flatten() });
@@ -10611,26 +10805,32 @@ app.post('/convert/quote', walletLimiter, async (req, res, next) => {
     if (amountWei <= 0n) return next({ status: 400, code: 'INVALID_AMOUNT', message: 'Invalid amount' });
 
     const runtime = await buildConvertRuntime();
-    if (runtime.liveRequested && !runtime.envReady && !runtime.fallbackEnabled) {
+    if (!runtime.envReady && !runtime.fallbackEnabled) {
       return next({
         status: 503,
         code: 'CONVERT_LIVE_NOT_READY',
-        message: `Convert live mode misconfigured: ${runtime.missingEnv.join(', ')}`,
+        message: `Convert live mode misconfigured: ${runtime.missingEnv.concat(runtime.invalidEnv || []).join(', ')}`,
       });
     }
-    const quoteInfo =
-      runtime.mode === 'live'
-        ? (ensureConvertLivePairReady(pair, runtime.settings), await quoteConvertFromPancake(pair, payload.side, amountWei))
-        : {
-            quoteWithoutFeeWei: quoteConvertMock(pair, amountWei),
-            baseAmountWei: amountWei,
-            direction: payload.side === 'buy' ? 'quote_to_base' : 'base_to_quote',
-            path: [],
-          };
+    let quoteInfo;
+    if (runtime.mode === 'live') {
+      ensureConvertLivePairReady(pair, runtime.settings);
+      const provider = new ethers.JsonRpcProvider(runtime.rpcUrl);
+      quoteInfo = await quoteConvertFromPancake(pair, payload.side, amountWei, provider);
+    } else {
+      quoteInfo = {
+        quoteWithoutFeeWei: quoteConvertMock(pair, amountWei),
+        baseAmountWei: amountWei,
+        direction: payload.side === 'buy' ? 'quote_to_base' : 'base_to_quote',
+        fee: null,
+      };
+    }
     const settings = runtime.settings;
     const feeWei = (quoteInfo.quoteWithoutFeeWei * BigInt(settings.convert_fee_bps || 0)) / 10000n;
     const usdtDecimals = resolveConvertAssetDecimals(pair.quote_asset || 'USDT');
+    const globalGoldPrice = await readGlobalGoldPriceUsdt();
     assertConvertQuoteIsSane(quoteInfo.quoteWithoutFeeWei, amountWei, usdtDecimals);
+    if (runtime.mode === 'live') assertQuoteDeviationSafe(quoteInfo, amountWei, pair, payload.side, usdtDecimals, globalGoldPrice);
     res.json({
       ok: true,
       mode: runtime.mode,
@@ -10645,6 +10845,9 @@ app.post('/convert/quote', walletLimiter, async (req, res, next) => {
           payload.side === 'buy'
             ? trimDecimal(formatUnitsStr((quoteInfo.quoteWithoutFeeWei + feeWei).toString(), usdtDecimals))
             : trimDecimal(formatUnitsStr((quoteInfo.quoteWithoutFeeWei - feeWei > 0n ? quoteInfo.quoteWithoutFeeWei - feeWei : 0n).toString(), usdtDecimals)),
+        quote_fee_tier: quoteInfo.fee,
+        quote_timestamp: new Date().toISOString(),
+        price_source: 'pancakeswap-quoter-v2',
       },
       settings,
     });
@@ -10654,6 +10857,9 @@ app.post('/convert/quote', walletLimiter, async (req, res, next) => {
     }
     if (err?.code === 'QUOTE_OUT_OF_RANGE') {
       return next({ status: 502, code: 'QUOTE_OUT_OF_RANGE', message: 'Convert quote is outside allowed range' });
+    }
+    if (err?.code === 'PRICE_DEVIATION') {
+      return next({ status: 409, code: 'PRICE_DEVIATION', message: 'price deviation too high' });
     }
     if (err instanceof z.ZodError) {
       return next({ status: 400, code: 'BAD_INPUT', message: 'Invalid input', details: err.flatten() });
@@ -10697,17 +10903,22 @@ app.post('/convert/execute', walletLimiter, async (req, res, next) => {
     const amountWei = bigIntFromValue(amountWeiStr);
     if (amountWei <= 0n) return next({ status: 400, code: 'INVALID_AMOUNT', message: 'Invalid amount' });
     const runtime = await buildConvertRuntime();
-    if (runtime.liveRequested && !runtime.envReady && !runtime.fallbackEnabled) {
+    if (!runtime.envReady && !runtime.fallbackEnabled) {
       return next({
         status: 503,
         code: 'CONVERT_LIVE_NOT_READY',
-        message: `Convert live mode misconfigured: ${runtime.missingEnv.join(', ')}`,
+        message: `Convert live mode misconfigured: ${runtime.missingEnv.concat(runtime.invalidEnv || []).join(', ')}`,
       });
     }
-    const quoteInfo =
-      runtime.mode === 'live'
-        ? (ensureConvertLivePairReady(pair, runtime.settings), await quoteConvertFromPancake(pair, payload.side, amountWei))
-        : { quoteWithoutFeeWei: quoteConvertMock(pair, amountWei), baseAmountWei: amountWei };
+    let quoteInfo;
+    if (runtime.mode === 'live') {
+      ensureConvertLivePairReady(pair, runtime.settings);
+      const provider = new ethers.JsonRpcProvider(runtime.rpcUrl);
+      quoteInfo = await quoteConvertFromPancake(pair, payload.side, amountWei, provider);
+      runtime.quoteFeeTier = quoteInfo.fee;
+    } else {
+      quoteInfo = { quoteWithoutFeeWei: quoteConvertMock(pair, amountWei), baseAmountWei: amountWei, fee: null };
+    }
     assertConvertQuoteIsSane(quoteInfo.quoteWithoutFeeWei, amountWei, usdtDecimals);
     const feeWei = (quoteInfo.quoteWithoutFeeWei * BigInt(settings.convert_fee_bps || 0)) / 10000n;
     const minWeiStr = decimalToWeiString(String(settings.convert_min_usdt || 10), usdtDecimals) || '0';
@@ -10804,7 +11015,7 @@ app.post('/convert/execute', walletLimiter, async (req, res, next) => {
     }
     await conn.query(
       'UPDATE convert_executions SET status=?, tx_hash=?, credited_asset=?, credited_wei=?, metadata=?, updated_at=NOW() WHERE id=?',
-      ['completed', chainResult.txHash, creditAsset.toUpperCase(), creditWei.toString(), JSON.stringify({ mode: chainResult.mode }), executionId]
+      ['completed', chainResult.txHash, creditAsset.toUpperCase(), creditWei.toString(), JSON.stringify({ mode: chainResult.mode, provider: 'pancakeswap', router: PANCAKE_SMART_ROUTER_ADDRESS, quote_fee_tier: quoteInfo.fee }), executionId]
     );
     await conn.commit();
     res.json({

--- a/api/tests/integration.test.js
+++ b/api/tests/integration.test.js
@@ -13,6 +13,7 @@ process.env.MASTER_MNEMONIC = process.env.MASTER_MNEMONIC || 'test test test tes
 process.env.DATABASE_URL = process.env.DATABASE_URL || 'mysql://root@localhost/eltx_test';
 process.env.GOOGLE_OAUTH_CLIENT_ID = process.env.GOOGLE_OAUTH_CLIENT_ID || 'test-google-client-id';
 process.env.GOOGLE_OAUTH_CLIENT_SECRET = process.env.GOOGLE_OAUTH_CLIENT_SECRET || 'test-google-client-secret';
+process.env.CONVERT_ALLOW_MOCK = 'true';
 
 const testSchema = {
   users: [{ id: 1, email: 'user@example.com', password_hash: '$argon2id$v=19$m=65536,t=3,p=4$0O4HViXmWtx2WnYIob2P0Q$5h6yA7yrWzXUOqYdW+awh7Y8/4Iv7pGGNqvLFxY2QWo' }, { id: 2, email: 'recipient@example.com', password_hash: '' }],

--- a/app/(app)/trade/convert/page.tsx
+++ b/app/(app)/trade/convert/page.tsx
@@ -27,6 +27,14 @@ type ConvertConfigResponse = {
   settings: { convert_fee_bps: number; convert_min_usdt: number; convert_execution_mode?: 'mock' | 'live' };
 };
 
+type ConvertHealthResponse = {
+  requestedMode: 'mock' | 'live';
+  effectiveMode: 'mock' | 'live';
+  liveReady: boolean;
+  provider: string;
+  lastError?: string | null;
+};
+
 type ConvertQuoteResponse = {
   mode: 'mock' | 'live';
   runtime_warning?: string | null;
@@ -104,6 +112,8 @@ function ConvertPageContent() {
   const [loading, setLoading] = useState(true);
   const [placing, setPlacing] = useState(false);
   const [runtimeWarning, setRuntimeWarning] = useState('');
+  const [liveReady, setLiveReady] = useState(false);
+  const [healthError, setHealthError] = useState('');
 
   const selectedPair = useMemo(() => pairs.find((item) => item.symbol === selectedSymbol) || null, [pairs, selectedSymbol]);
   const amountNum = parsePositive(amount);
@@ -140,14 +150,37 @@ function ConvertPageContent() {
     setFeeBps(res.data.settings?.convert_fee_bps || 0);
     setConvertMode(res.data.settings?.convert_execution_mode || 'live');
     setRuntimeWarning('');
+    setHealthError('');
+    setLiveReady(false);
     if ((res.data.pairs || []).length) {
       setSelectedSymbol((prev) => (prev && res.data.pairs.some((item) => item.symbol === prev) ? prev : res.data.pairs[0].symbol));
     }
   }, [category, isArabic, toast]);
 
+  const loadHealth = useCallback(
+    async (pairSymbol: string) => {
+      const res = await apiFetch<ConvertHealthResponse>(`/convert/health?category=${category}&symbol=${encodeURIComponent(pairSymbol)}`);
+      if (!res.ok) {
+        setLiveReady(false);
+        setConvertMode('mock');
+        setHealthError(res.error || (isArabic ? 'لا يوجد اتصال Live حاليا' : 'Live connectivity is not ready'));
+        return;
+      }
+      setConvertMode(res.data.effectiveMode || 'mock');
+      setLiveReady(Boolean(res.data.liveReady && res.data.effectiveMode === 'live'));
+      setHealthError(String(res.data.lastError || ''));
+    },
+    [category, isArabic]
+  );
+
   useEffect(() => {
     loadPairs();
   }, [loadPairs]);
+
+  useEffect(() => {
+    if (!selectedSymbol) return;
+    loadHealth(selectedSymbol);
+  }, [selectedSymbol, loadHealth]);
 
   useEffect(() => {
     async function run() {
@@ -163,6 +196,7 @@ function ConvertPageContent() {
       if (!res.ok) {
         setEstimate(0);
         setFeeUsdt(0);
+        setRuntimeWarning(res.error || '');
         return;
       }
       setConvertMode(res.data.mode || 'live');
@@ -175,6 +209,10 @@ function ConvertPageContent() {
 
   const executeSwap = useCallback(async () => {
     if (!selectedPair) return;
+    if (!liveReady) {
+      toast({ message: healthError || (isArabic ? 'وضع Live غير جاهز حاليا' : 'Live mode is not ready right now'), variant: 'error' });
+      return;
+    }
     if (!amountNum) {
       toast({ message: isArabic ? 'اكتب الكمية الاول' : 'Enter an amount first', variant: 'error' });
       return;
@@ -201,7 +239,7 @@ function ConvertPageContent() {
     toast({ message: isArabic ? 'تم تنفيذ العملية بنجاح' : 'Convert executed successfully', variant: 'success' });
     setAmount('');
     setEstimate(0);
-  }, [amountNum, category, estimate, isArabic, minUsdt, selectedPair, side, toast]);
+  }, [amountNum, category, estimate, healthError, isArabic, liveReady, minUsdt, selectedPair, side, toast]);
 
   return (
     <section className="mx-auto w-full max-w-5xl space-y-4 px-4 py-4 md:px-6 md:py-6">
@@ -260,7 +298,9 @@ function ConvertPageContent() {
             </div>
             <div className="text-right text-xs text-white/60">
               <div>{labels.mode}</div>
-              <div className={`font-semibold ${convertMode === 'live' ? 'text-emerald-300' : 'text-amber-300'}`}>{convertMode === 'live' ? labels.live : labels.mock}</div>
+              <div className={`font-semibold ${convertMode === 'live' && liveReady ? 'text-emerald-300' : 'text-amber-300'}`}>
+                {convertMode === 'live' && liveReady ? labels.live : labels.mock}
+              </div>
             </div>
           </div>
         )}
@@ -343,12 +383,17 @@ function ConvertPageContent() {
               {labels.runtimeWarning}: {runtimeWarning}
             </div>
           ) : null}
+          {!liveReady ? (
+            <div className="mt-2 rounded-lg border border-rose-500/40 bg-rose-500/10 p-2 text-xs text-rose-200">
+              {isArabic ? 'Live غير جاهز حاليا' : 'Live mode is not ready'}{healthError ? `: ${healthError}` : ''}
+            </div>
+          ) : null}
         </div>
 
         <button
           type="button"
           onClick={executeSwap}
-          disabled={placing || loading || !selectedPair}
+          disabled={placing || loading || !selectedPair || !liveReady}
           className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-cyan-500 py-3 text-center font-semibold text-black transition hover:bg-cyan-400 disabled:opacity-60"
         >
           <Wallet className="h-4 w-4" /> {placing ? labels.executing : labels.execute}


### PR DESCRIPTION
### Motivation
- Ensure Convert operations run in true Live mode by default and remove unsafe automatic mock fallbacks in production while keeping a controlled mock path for tests/dev. 
- Fix unreliable private-key handling and derived-address validation that caused spurious mock fallbacks and runtime warnings. 
- Use on-chain PancakeSwap quotes (QuoterV2) and Smart Router execution on BNB Chain for truthful XAUT/USDT pricing and execution. 
- Give the frontend a single source of truth for live readiness via a backend `convert/health` endpoint so UI never shows “Live” unless backend proves it.

### Description
- Added robust private-key normalization and validation (`normalizeConvertPrivateKey`) that accepts keys with or without `0x`, trims BOM/quotes/CRLFs, and only exposes a non-secret fingerprint in logs; derived address is computed and compared to `CONVERT_HOT_WALLET_ADDRESS`. (backend: `api/src/app.js`).
- Hardened convert runtime settings via `readConvertSettings` and `summarizeConvertRuntimeReadiness`: production forces `live`, `convert_live_fallback_mock` is disabled by default unless `CONVERT_ALLOW_MOCK=true` in non-production, and runtime exposes `missingEnv`, `invalidEnv`, `requestedMode`, `effective mode`, and `derivedAddressMatches` diagnostics. (backend changes in `readConvertSettings` / runtime builder).
- Added a small on-chain token registry for chainId=56 with XAUT/USDT addresses and decimals and used it for address/decimals resolution and guard checks. (constants: `CONVERT_TOKEN_REGISTRY`).
- Integrated PancakeSwap QuoterV2 probing and Pancake Smart Router execution paths: added Quoter/Smart router ABIs, QuoterV2 calls to probe fee tiers (`CONVERT_V3_FEES`), and Smart Router execution (`exactInputSingle`/`exactOutputSingle`) to perform real swaps on BSC when live. Quote metadata (fee tier, timestamp, price_source) is returned. (backend: quote/execute functions).
- Added price sanity check against a trusted oracle/sanity source (`readGlobalGoldPriceUsdt()` using CoinGecko as sanity check) and configurable max deviation (`CONVERT_PRICE_MAX_DEVIATION_BPS`) to block executions when Pancake quote deviates too far from global price.
- Implemented `/convert/health` endpoint that returns requested/effective mode, `liveReady`, `rpcReady`, `hotWallet` masked address, `derivedAddressMatches`, router/quoter addresses, token decimals, hot wallet balances, `quoteReady` and `liquidityRouteFound`, plus `missingEnv`/`invalidEnv` and `lastError` for admin visibility. (new endpoint in `api/src/app.js`).
- Frontend changes: Convert page now queries backend health and uses `effectiveMode` + `liveReady` to display mode and to enable/disable the Execute button; shows clear user/admin-facing warnings when Live is not ready. (file: `app/(app)/trade/convert/page.tsx`).
- Kept mock behavior available only when expressly allowed in non-production: updated integration test bootstrap to set `CONVERT_ALLOW_MOCK=true` in tests (file: `api/tests/integration.test.js`).
- Small supportive helpers: token decimals/balance readers, quote deviation assertion, and safe allowance helper reuse; preserved existing convert ledger flow and idempotency handling without schema changes.
- No DB schema changes in this PR; migrations for convert_executions / convert_pairs already exist elsewhere in repo.

### Testing
- Ran integration tests with `npm run test:integration`; all integration tests passed in this environment after updates (was used `DEMO_MODE` and `CONVERT_ALLOW_MOCK=true`): result: success.
- Ran typecheck with `npm run typecheck` (`tsc --noEmit`): succeeded (no type errors).
- Built the Next app with `npm run build`: build succeeded; Next lint warning about using native `<img>` (file `app/(app)/trade/convert/page.tsx`) was reported and classified as non-functional; recommendation: replace with `next/image` to improve LCP (non-blocking).
- Attempted to run API/worker and full end-to-end smoke with on-chain provider in this environment but encountered missing runtime dependencies (DB/env and worker module resolution): starting `api/src/app.js` in this sandbox flagged missing `DATABASE_URL` (environment) and worker startup reported missing module resolution in the local dev runner, so full on-chain live-run could not be executed here; these are environment configuration issues rather than code failures.
- Attempted headless browser screenshot via Playwright after `next start`, but Playwright Chromium could not launch due to a missing OS shared library (`libatk-1.0.so.0`) in this environment; this prevented saving a PNG screenshot here (recommendation: install system dependency or run screenshot in target host). 

If you want, next steps I can do for you: provide the exact SQL statements to add/update convert registry rows or platform settings (none were required by this patch), or help deploy and run the API + worker with the correct environment variables so we can perform a full live on-chain end-to-end test and capture screenshots/logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eff56f5160832b88be302c854a2918)