### PR TITLE
fix(convert): normalize amount input for Arabic/decimal keyboards

### DIFF
--- a/app/(app)/trade/convert/page.tsx
+++ b/app/(app)/trade/convert/page.tsx
@@ -57,8 +57,16 @@ function toCategory(value: string | null): Category {
   return 'crypto';
 }
 
+function normalizeNumericInput(value: string): string {
+  return value
+    .replace(/[٠-٩]/g, (digit) => String(digit.charCodeAt(0) - 1632))
+    .replace(/,/g, '.')
+    .replace(/[^\d.]/g, '')
+    .replace(/(\..*)\./g, '$1');
+}
+
 function parsePositive(value: string): number {
-  const num = Number(value);
+  const num = Number(normalizeNumericInput(value));
   return Number.isFinite(num) && num > 0 ? num : 0;
 }
 
@@ -156,6 +164,11 @@ function ConvertPageContent() {
 
   const selectedPair = useMemo(() => pairs.find((item) => item.symbol === selectedSymbol) || null, [pairs, selectedSymbol]);
   const amountNum = parsePositive(amount);
+
+  const handleAmountChange = useCallback((raw: string) => {
+    const normalized = normalizeNumericInput(raw);
+    setAmount(normalized);
+  }, []);
 
   const labels = useMemo(
     () => ({
@@ -396,11 +409,10 @@ function ConvertPageContent() {
           </div>
           <div className="mt-2 flex items-center gap-2 rounded-xl border border-white/10 bg-black/20 px-3 py-2.5">
             <input
-              type="number"
-              min="0"
-              step="any"
+              type="text"
+              inputMode="decimal"
               value={amount}
-              onChange={(e) => setAmount(e.target.value)}
+              onChange={(e) => handleAmountChange(e.target.value)}
               className="w-full bg-transparent text-lg outline-none"
               placeholder="0.0"
             />


### PR DESCRIPTION
### Motivation
- Users reported that entering an amount in Convert sometimes produced no visible input or failed to generate a quote because locale-specific digits and decimal separators were filtered by the numeric input control.
- The goal is to make the amount field work reliably across Arabic and English keyboards and ensure quote requests always receive a clean numeric value.

### Description
- Added `normalizeNumericInput` to convert Arabic numerals (`٠-٩`) to western digits, convert commas to dots, strip invalid characters, and prevent multiple decimal points.
- Updated `parsePositive` to call `normalizeNumericInput` so all numeric parsing is normalized before validation.
- Introduced `handleAmountChange` which sanitizes the raw input and stores a normalized string in state.
- Changed the amount input from `type="number"` to `type="text"` with `inputMode="decimal"` and wired it to `handleAmountChange` to avoid browser-level filtering that hid or blocked locale input.

### Testing
- Ran `npm run build` and the production build completed successfully with the app compiling and pages generated (build passed).
- Ran `npm run lint` and linting passed; a pre-existing ESLint warning about using `<img>` instead of `next/image` remained and is classified as non-blocking for this fix.
- Build warnings: `Browserslist` outdated data and the `<img>` optimization warning were observed and classified as non-blocking, with suggested fixes being to run `npx update-browserslist-db@latest` and replace the `<img>` with `next/image` in the page.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f320489c8c832bb156b7ed713a265f)