### PR TITLE
fix: fallback dotenv path for Next.js scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "// IMPORTANT: Env is loaded from /home/dash/.env via dotenv. Do NOT enable 'export' or 'standalone', and do NOT modify scripts to remove '-r dotenv/config'.": "",
   "scripts": {
     "prestart": "node scripts/ensure-next-build.js",
-    "dev": "DOTENV_CONFIG_PATH=/home/dash/.env node -r dotenv/config node_modules/next/dist/bin/next dev -p 3000",
-    "build": "DOTENV_CONFIG_PATH=/home/dash/.env node -r dotenv/config node_modules/next/dist/bin/next build",
-    "start": "DOTENV_CONFIG_PATH=/home/dash/.env node -r dotenv/config node_modules/next/dist/bin/next start -p 3000",
+    "dev": "DOTENV_CONFIG_PATH=${DOTENV_CONFIG_PATH:-$( [ -f /home/dash/.env ] && echo /home/dash/.env || echo .env )} node -r dotenv/config node_modules/next/dist/bin/next dev -p 3000",
+    "build": "DOTENV_CONFIG_PATH=${DOTENV_CONFIG_PATH:-$( [ -f /home/dash/.env ] && echo /home/dash/.env || echo .env )} node -r dotenv/config node_modules/next/dist/bin/next build",
+    "start": "DOTENV_CONFIG_PATH=${DOTENV_CONFIG_PATH:-$( [ -f /home/dash/.env ] && echo /home/dash/.env || echo .env )} node -r dotenv/config node_modules/next/dist/bin/next start -p 3000",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test:integration": "c8 --include \"api/tests/**\" --check-coverage --lines 50 --functions 50 --branches 50 --statements 50 --reporter=text node --test --test-force-exit api/tests/integration.test.js",


### PR DESCRIPTION
### Motivation
- Prevent Next.js `dev`/`build`/`start` from failing in environments where `/home/dash/.env` is not present by making the dotenv path resolution robust and environment-variable friendly.

### Description
- Update `dev`, `build`, and `start` scripts in `package.json` to set `DOTENV_CONFIG_PATH` dynamically with `$( [ -f /home/dash/.env ] && echo /home/dash/.env || echo .env )`, preserving `-r dotenv/config` behavior while allowing a local `.env` fallback.

### Testing
- Ran `npm run build` which completed successfully (Next.js compiled and pages were generated), with an existing lint warning about an `<img>` usage classified as non-blocking and recommended to be replaced by `next/image` in `app/(app)/trade/convert/page.tsx`.
- Ran `npm run test:integration` which passed all tests (`27/27`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46ed5a1c0832b9a985d4e30be2013)