### PR TITLE
Use Next Image for pair icons and add Node runtime/dotenv startup scripts

### DIFF
--- a/app/(app)/trade/convert/page.tsx
+++ b/app/(app)/trade/convert/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ArrowDownUp, BadgeDollarSign, ChevronLeft, RefreshCw, Wallet } from 'lucide-react';
+import Image from 'next/image';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
@@ -342,16 +343,13 @@ function ConvertPageContent() {
           <div className="mt-3 flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-[#111a30] p-3">
             <div className="flex items-center gap-3">
               <div className="relative h-10 w-10 overflow-hidden rounded-full bg-white/10 ring-1 ring-white/15">
-                <img
+                <Image
                   src={selectedPair.logo_url || assetIconFallback(selectedPair.token_symbol)}
                   alt={`${selectedPair.token_symbol} icon`}
                   className="h-full w-full object-cover"
-                  onError={(e) => {
-                    const fallback = assetIconFallback(selectedPair.token_symbol);
-                    const target = e.currentTarget;
-                    if (fallback && target.src !== fallback) target.src = fallback;
-                    else target.src = 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48"><rect width="48" height="48" rx="24" fill="%23111f34"/><text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="16" fill="%23ffffff" font-family="Arial">%</text></svg>';
-                  }}
+                  width={40}
+                  height={40}
+                  unoptimized
                 />
               </div>
               <div>

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "// IMPORTANT: Env is loaded from /home/dash/.env via dotenv. Do NOT enable 'export' or 'standalone', and do NOT modify scripts to remove '-r dotenv/config'.": "",
   "scripts": {
     "prestart": "node scripts/ensure-next-build.js",
-    "dev": "DOTENV_CONFIG_PATH=/home/dash/.env node -r dotenv/config node_modules/next/dist/bin/next dev -p 3000",
-    "build": "DOTENV_CONFIG_PATH=/home/dash/.env node -r dotenv/config node_modules/next/dist/bin/next build",
-    "start": "DOTENV_CONFIG_PATH=/home/dash/.env node -r dotenv/config node_modules/next/dist/bin/next start -p 3000",
+    "dev": "node scripts/check-runtime.js && node scripts/next-with-dotenv.js dev -p 3000",
+    "build": "node scripts/check-runtime.js && node scripts/next-with-dotenv.js build",
+    "start": "node scripts/check-runtime.js && node scripts/next-with-dotenv.js start -p 3000",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test:integration": "c8 --include \"api/tests/**\" --check-coverage --lines 50 --functions 50 --branches 50 --statements 50 --reporter=text node --test --test-force-exit api/tests/integration.test.js",
@@ -54,5 +54,8 @@
     "c8": "^10.1.3",
     "proxyquire": "^2.1.3",
     "supertest": "^7.1.1"
+  },
+  "engines": {
+    "node": ">=18.17.0"
   }
 }

--- a/scripts/check-runtime.js
+++ b/scripts/check-runtime.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+const [major, minor] = process.versions.node.split('.').map((v) => Number(v));
+const minMajor = 18;
+const minMinor = 17;
+const ok = Number.isFinite(major) && Number.isFinite(minor)
+  && (major > minMajor || (major === minMajor && minor >= minMinor));
+
+if (ok) {
+  process.exit(0);
+}
+
+console.error('[runtime-check] Unsupported Node.js version detected: ' + process.versions.node);
+console.error('[runtime-check] This project uses Next.js 14 which requires Node.js >= 18.17.0.');
+console.error('[runtime-check] Fix on server:');
+console.error('  1) Install Node 20 LTS (recommended)');
+console.error('  2) Reinstall deps: npm ci');
+console.error('  3) Build/start: npm run build && npm run start');
+console.error('[runtime-check] nvm example:');
+console.error('  curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash');
+console.error('  export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh"');
+console.error('  nvm install 20 && nvm use 20 && nvm alias default 20');
+process.exit(1);

--- a/scripts/next-with-dotenv.js
+++ b/scripts/next-with-dotenv.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const args = process.argv.slice(2);
+if (args.length === 0) {
+  console.error('[next-with-dotenv] Usage: node scripts/next-with-dotenv.js <next-args...>');
+  process.exit(1);
+}
+
+const preferred = '/home/dash/.env';
+const fallback = path.join(process.cwd(), '.env');
+const dotenvPath = process.env.DOTENV_CONFIG_PATH || (fs.existsSync(preferred) ? preferred : fallback);
+
+const child = spawn(
+  process.execPath,
+  ['-r', 'dotenv/config', 'node_modules/next/dist/bin/next', ...args],
+  {
+    stdio: 'inherit',
+    env: { ...process.env, DOTENV_CONFIG_PATH: dotenvPath },
+  }
+);
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 1);
+});


### PR DESCRIPTION
### Motivation
- Ensure consistent image handling for convert pair icons using Next.js image component for sizing and SSR consistency.
- Enforce a minimum Node.js runtime compatible with Next.js 14 to avoid confusing runtime failures.
- Centralize dotenv loading across dev/build/start so the same `.env` file is used in different environments.

### Description
- Replaced a raw `<img>` with `next/image` in `app/(app)/trade/convert/page.tsx`, adding `width`, `height`, and `unoptimized` to preserve current runtime behavior and removed the inline `onError` fallback logic.
- Updated `package.json` scripts (`dev`, `build`, `start`) to run a runtime check and launch Next via a helper that injects dotenv; added an `engines.node` entry requiring `>=18.17.0`.
- Added `scripts/check-runtime.js` which aborts startup if Node.js < 18.17 and prints remediation steps.
- Added `scripts/next-with-dotenv.js` which resolves a preferred global `.env` or falls back to the repo `.env` and spawns Next.js with `-r dotenv/config` while forwarding env and stdio.

### Testing
- Ran `npm run typecheck` (`tsc --noEmit`) which completed successfully.
- Ran a local build with `npm run build` which completed successfully using the new startup helper.
- Executed integration tests with `npm run test:integration` which passed the configured coverage checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46ed5a1c0832b9a985d4e30be2013)