### PR TITLE
Fix Next.js production build by using app-local global stylesheet import

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import 'server-only';
-import '../styles/globals.css';
+import './globals.css';
 import type { Metadata, Viewport } from 'next';
 import { LangProvider } from './lib/i18n';
 import { ToastProvider } from './lib/toast';


### PR DESCRIPTION
### Motivation
- The production build can fail when `app/layout.tsx` imports the legacy `../styles/globals.css` path that may be missing in App Router deployments, causing a `Module not found` error. 

### Description
- Updated the stylesheet import in `app/layout.tsx` from `../styles/globals.css` to `./globals.css` to use the App Router local global stylesheet. 
- This aligns the code with Next.js App Router conventions and avoids resolution errors during build. 
- Change is limited to a single-line import update in `app/layout.tsx` and a commit was created for the fix.

### Testing
- Ran `npm run build` and the build completed successfully, including compilation, lint/type checks, and static page generation. 
- The build emitted non-blocking warnings about missing environment variables (`DB_HOST`, `DB_USER`, `DB_PASS`, `DB_NAME`, `NEXT_PUBLIC_API_BASE`, `SMTP_HOST`, `SMTP_USER`, `SMTP_PASS`) which do not prevent the build but will affect runtime features. 
- The build also flagged `caniuse-lite` as outdated and suggested `npx update-browserslist-db@latest`, which is informational and non-blocking.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f6399b94832bb172f7dfb59b1501)