### PR TITLE
Add prebuild app path verification, PM2 runbook, and convert quote/idempotency fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,35 @@ GOOGLE_OAUTH_REDIRECT_URI
 
 If you see `Module not found: './globals.css'`, make sure the file exists at `app/globals.css`.
 
+### Production build + PM2 runbook
+
+For Linux production servers (especially with case-sensitive filesystems), use this checklist before deploy:
+
+1. Confirm the stylesheet path is exact and tracked by Git:
+   - `app/layout.tsx` must import `./globals.css` (all lower-case).
+   - `app/globals.css` must exist exactly with the same case.
+   - Run: `git ls-files app/globals.css` to verify it is tracked.
+2. Build from the project root only (`/workspace/eltx-platform` in local/dev containers).
+3. Keep existing npm scripts unchanged because they intentionally load env using:
+   - `node -r dotenv/config`
+   - `DOTENV_CONFIG_PATH=/home/dash/.env` fallback logic.
+
+PM2 note (critical): if logs show `pm2: command not found`, PM2 is not installed or not in PATH for the same OS user running the app.
+
+- Install PM2 for the runtime user (example: `dash`), not only for `root`.
+- Start/restart the app using the same user that owns `/home/dash/.env`.
+- Mixing users (`root` installs PM2, `dash` runs npm scripts) commonly causes this error.
+
+Suggested commands (run as `dash` user):
+
+```bash
+npm run build
+pm2 start npm --name eltx-web -- start
+pm2 save
+```
+
+Do not print secrets from `/home/dash/.env` in logs or shell history.
+
 ### Stripe card payments
 
 The dashboard now exposes a **Buy Crypto** flow backed by Stripe. To activate it you must set the

--- a/app/(app)/trade/convert/page.tsx
+++ b/app/(app)/trade/convert/page.tsx
@@ -4,7 +4,7 @@ import { ArrowDownUp, BadgeDollarSign, ChevronLeft, RefreshCw, Wallet } from 'lu
 import Image from 'next/image';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
-import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { apiFetch } from '../../../lib/api';
 import { useLang } from '../../../lib/i18n';
 import { useToast } from '../../../lib/toast';
@@ -162,6 +162,8 @@ function ConvertPageContent() {
   const [quoteValid, setQuoteValid] = useState(false);
   const [blockingReason, setBlockingReason] = useState('');
   const [quoteLoading, setQuoteLoading] = useState(false);
+  const quoteRequestIdRef = useRef(0);
+  const executeIdempotencyRef = useRef<string | null>(null);
 
   const selectedPair = useMemo(() => pairs.find((item) => item.symbol === selectedSymbol) || null, [pairs, selectedSymbol]);
   const amountNum = parsePositive(amount);
@@ -237,6 +239,8 @@ function ConvertPageContent() {
 
   useEffect(() => {
     async function run() {
+      const requestId = quoteRequestIdRef.current + 1;
+      quoteRequestIdRef.current = requestId;
       if (!selectedPair || !amountNum) {
         setEstimate(0);
         setFeeUsdt(0);
@@ -249,6 +253,7 @@ function ConvertPageContent() {
         method: 'POST',
         body: JSON.stringify({ category, symbol: selectedPair.symbol, side, amount: amountNum.toString() }),
       });
+      if (requestId !== quoteRequestIdRef.current) return;
       setQuoteLoading(false);
       if (!res.ok) {
         setEstimate(0);
@@ -289,11 +294,15 @@ function ConvertPageContent() {
       return;
     }
 
+    const idempotencyKey = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function' ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`;
+    executeIdempotencyRef.current = idempotencyKey;
     setPlacing(true);
     const res = await apiFetch('/convert/execute', {
       method: 'POST',
+      headers: { 'Idempotency-Key': idempotencyKey },
       body: JSON.stringify({ category, symbol: selectedPair.symbol, side, amount: amountNum.toString() }),
     });
+    executeIdempotencyRef.current = null;
     setPlacing(false);
     if (!res.ok) {
       toast({ message: res.error || (isArabic ? 'فشل التنفيذ' : 'Execution failed'), variant: 'error' });

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "// IMPORTANT: Env is loaded from /home/dash/.env via dotenv. Do NOT enable 'export' or 'standalone', and do NOT modify scripts to remove '-r dotenv/config'.": "",
   "scripts": {
     "prestart": "node scripts/ensure-next-build.js",
-    "dev": "DOTENV_CONFIG_PATH=${DOTENV_CONFIG_PATH:-$( [ -f /home/dash/.env ] && echo /home/dash/.env || echo .env )} node -r dotenv/config node_modules/next/dist/bin/next dev -p 3000",
-    "build": "DOTENV_CONFIG_PATH=${DOTENV_CONFIG_PATH:-$( [ -f /home/dash/.env ] && echo /home/dash/.env || echo .env )} node -r dotenv/config node_modules/next/dist/bin/next build",
-    "start": "DOTENV_CONFIG_PATH=${DOTENV_CONFIG_PATH:-$( [ -f /home/dash/.env ] && echo /home/dash/.env || echo .env )} node -r dotenv/config node_modules/next/dist/bin/next start -p 3000",
+    "dev": "node scripts/verify-next-app-paths.mjs && DOTENV_CONFIG_PATH=${DOTENV_CONFIG_PATH:-$( [ -f /home/dash/.env ] && echo /home/dash/.env || echo .env )} node -r dotenv/config node_modules/next/dist/bin/next dev -p 3000",
+    "build": "node scripts/verify-next-app-paths.mjs && DOTENV_CONFIG_PATH=${DOTENV_CONFIG_PATH:-$( [ -f /home/dash/.env ] && echo /home/dash/.env || echo .env )} node -r dotenv/config node_modules/next/dist/bin/next build",
+    "start": "node scripts/verify-next-app-paths.mjs && DOTENV_CONFIG_PATH=${DOTENV_CONFIG_PATH:-$( [ -f /home/dash/.env ] && echo /home/dash/.env || echo .env )} node -r dotenv/config node_modules/next/dist/bin/next start -p 3000",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test:integration": "c8 --include \"api/tests/**\" --check-coverage --lines 50 --functions 50 --branches 50 --statements 50 --reporter=text node --test --test-force-exit api/tests/integration.test.js",

--- a/scripts/verify-next-app-paths.mjs
+++ b/scripts/verify-next-app-paths.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const appDir = path.join(root, 'app');
+const layoutPath = path.join(appDir, 'layout.tsx');
+const globalsPath = path.join(appDir, 'globals.css');
+
+function fail(message) {
+  console.error(`[prebuild-check] ${message}`);
+  process.exit(1);
+}
+
+if (!fs.existsSync(appDir)) fail(`Missing app directory at ${appDir}`);
+if (!fs.existsSync(layoutPath)) fail(`Missing app/layout.tsx at ${layoutPath}`);
+if (!fs.existsSync(globalsPath)) fail(`Missing app/globals.css at ${globalsPath}`);
+
+const layoutSource = fs.readFileSync(layoutPath, 'utf8');
+if (!layoutSource.includes("import './globals.css';")) {
+  fail(`app/layout.tsx must contain exact import: import './globals.css';`);
+}
+
+const entries = new Set(fs.readdirSync(appDir));
+if (!entries.has('globals.css')) {
+  fail('Case-sensitivity issue: app/globals.css is not present with exact casing');
+}
+
+console.log('[prebuild-check] app/layout.tsx and app/globals.css verified.');


### PR DESCRIPTION
### Motivation
- Prevent production build failures on case-sensitive Linux hosts by ensuring `app/layout.tsx` imports the exact `./globals.css` path and that `app/globals.css` exists with correct casing. 
- Provide operational guidance for Linux/PM2 deployments to avoid common runtime pitfalls like missing PM2 in the runtime user's PATH. 
- Fix UI race conditions and duplicate-execute risks in the convert flow by canceling stale quote requests and adding an idempotency key to execute calls. 

### Description
- Add a new prebuild verification script `scripts/verify-next-app-paths.mjs` that enforces the presence of `app/layout.tsx`, the exact `import './globals.css';` line, and case-correct `app/globals.css`. 
- Update `package.json` dev/build/start scripts to run the verification script before starting or building. 
- Extend `README.md` with a "Production build + PM2 runbook" section documenting build checklist, PM2 installation/run notes, and suggested commands. 
- Update `app/(app)/trade/convert/page.tsx` to introduce `quoteRequestIdRef` to ignore stale quote responses, and add an idempotency key (`Idempotency-Key` header) via `executeIdempotencyRef` when calling `/convert/execute`. 

### Testing
- Ran the verification script `node scripts/verify-next-app-paths.mjs` against the repository and it completed successfully. 
- Performed a local build via `npm run build` which runs the verification step first and completed successfully. 
- Executed the integration tests with `npm run test:integration` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5211ed9b8832b98d0595425ab3e3d)