### PR TITLE
Fix convert fallback, quote/execute fee semantics, buy payload handling and idempotency replay

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -3011,7 +3011,7 @@ function summarizeConvertRuntimeReadiness(settings) {
   const envReady = missingEnv.length === 0 && invalidEnv.length === 0;
   const liveRequested = settings.convert_execution_mode === 'live' || settings.convert_requested_mode === 'live';
   const isProd = process.env.NODE_ENV === 'production';
-  const fallbackEnabled = !isProd && String(process.env.CONVERT_ALLOW_MOCK || '').toLowerCase() === 'true';
+  const fallbackEnabled = !isProd && Number(settings.convert_live_fallback_mock || 0) === 1;
   const mode = liveRequested && envReady ? 'live' : fallbackEnabled ? 'mock' : 'live';
   const warning =
     liveRequested && !envReady
@@ -11084,7 +11084,7 @@ app.post('/convert/quote', walletLimiter, async (req, res, next) => {
     let executionMode = 'unavailable';
     let responseMode = 'reference';
     usdtDecimals = resolveConvertAssetDecimals(pair.quote_asset || 'USDT');
-    const isBuyQuoteInput = payload.side === 'buy' && (payload.amountType === 'quote' || payload.amountUsdt);
+    const isBuyQuoteInput = runtime.mode === 'live' && payload.side === 'buy' && (payload.amountType === 'quote' || payload.amountUsdt);
     if (isBuyQuoteInput) {
       const amountUsdt = payload.amountUsdt || payload.amount;
       const amountUsdtWeiStr = decimalToWeiString(amountUsdt, usdtDecimals);
@@ -11157,9 +11157,7 @@ app.post('/convert/quote', walletLimiter, async (req, res, next) => {
       responseMode = 'mock';
     }
     const settings = runtime.settings;
-    const feeWei = payload.side === 'buy'
-      ? (amountWei * BigInt(settings.convert_fee_bps || 0)) / (10000n + BigInt(settings.convert_fee_bps || 0))
-      : (quoteInfo.quoteWithoutFeeWei * BigInt(settings.convert_fee_bps || 0)) / 10000n;
+    const feeWei = (quoteInfo.quoteWithoutFeeWei * BigInt(settings.convert_fee_bps || 0)) / 10000n;
     assertConvertQuoteIsSane(quoteInfo.quoteWithoutFeeWei, amountWei, usdtDecimals);
     if (quoteInfo.quoteWithoutFeeWei < BigInt(minWeiStr)) blockingReason = 'AMOUNT_BELOW_MINIMUM';
     const valid = quoteInfo.quoteWithoutFeeWei > 0n && (!blockingReason || blockingReason === 'PAIR_REFERENCE_ONLY' || blockingReason === 'QUOTE_PROVIDER_REFERENCE_ONLY');
@@ -11282,10 +11280,11 @@ app.post('/convert/execute', walletLimiter, async (req, res, next) => {
     baseDecimals = resolveConvertAssetDecimals(pair.base_asset, pair.token_decimals);
     const isBuyInput = payload.side === 'buy';
     if (isBuyInput) {
-      const amountUsdtWeiStr = decimalToWeiString(payload.amountUsdt, usdtDecimals);
-      if (!amountUsdtWeiStr) return next({ status: 400, code: 'INVALID_AMOUNT', message: 'Invalid amountUsdt' });
+      const buyAmountInput = payload.amountUsdt || payload.amount;
+      const amountUsdtWeiStr = decimalToWeiString(buyAmountInput, usdtDecimals);
+      if (!amountUsdtWeiStr) return next({ status: 400, code: 'INVALID_AMOUNT', message: 'Invalid amountUsdt/amount' });
       amountWei = bigIntFromValue(amountUsdtWeiStr);
-      if (amountWei <= 0n) return next({ status: 400, code: 'INVALID_AMOUNT', message: 'Invalid amountUsdt' });
+      if (amountWei <= 0n) return next({ status: 400, code: 'INVALID_AMOUNT', message: 'Invalid amountUsdt/amount' });
     } else {
       const amountWeiStr = decimalToWeiString(payload.amount, baseDecimals);
       if (!amountWeiStr) return next({ status: 400, code: 'INVALID_AMOUNT', message: 'Invalid amount' });
@@ -11321,9 +11320,7 @@ app.post('/convert/execute', walletLimiter, async (req, res, next) => {
       quoteInfo = { quoteWithoutFeeWei: quoteConvertMock(pair, amountWei), baseAmountWei: amountWei, fee: null };
     }
     assertConvertQuoteIsSane(quoteInfo.quoteWithoutFeeWei, amountWei, usdtDecimals);
-    const feeWei = payload.side === 'buy'
-      ? (amountWei * BigInt(settings.convert_fee_bps || 0)) / (10000n + BigInt(settings.convert_fee_bps || 0))
-      : (quoteInfo.quoteWithoutFeeWei * BigInt(settings.convert_fee_bps || 0)) / 10000n;
+    const feeWei = (quoteInfo.quoteWithoutFeeWei * BigInt(settings.convert_fee_bps || 0)) / 10000n;
     const minWeiStr = decimalToWeiString(String(settings.convert_min_usdt || 10), usdtDecimals) || '0';
     if (quoteInfo.quoteWithoutFeeWei < BigInt(minWeiStr)) {
       return next({ status: 400, code: 'CONVERT_MIN', message: `Minimum convert is ${settings.convert_min_usdt} USDT` });
@@ -11331,7 +11328,7 @@ app.post('/convert/execute', walletLimiter, async (req, res, next) => {
 
     const debitAsset = payload.side === 'buy' ? 'USDT' : pair.base_asset;
     const debitDecimals = payload.side === 'buy' ? usdtDecimals : baseDecimals;
-    const debitWei = payload.side === 'buy' ? amountWei : amountWei;
+    const debitWei = payload.side === 'buy' ? quoteInfo.quoteWithoutFeeWei + feeWei : amountWei;
     reservedDebitAsset = debitAsset.toUpperCase();
     reservedDebitWei = debitWei;
 
@@ -11348,7 +11345,7 @@ app.post('/convert/execute', walletLimiter, async (req, res, next) => {
       );
       const existing = existingRows[0];
       if (existing) {
-        if (existing.status === 'completed') {
+        if (existing.status === 'completed' || existing.status === 'confirmed') {
           await conn.commit();
           return res.json({
             ok: true,


### PR DESCRIPTION
### Motivation
- كان مطلوب إن سلوك الـ convert يعتمد على إعداد الـ DB `convert_live_fallback_mock` مش بس على متغيرات البيئة، علشان يمنع التشغيل في وضع `live` لو البيئة ناقصة لما الـ fallback مقفول؛ ده يطابق توقعات الاختبارات.
- لازم نمنع محاولة استخدام مسار `amountType=quote` في أوضاع الـ `mock` اللي بتحاول تعمل تسعير live، ونخليها تعمل بس في وضع `live`.
- حساب الرسوم والخصم كان غير متناسق بين `quote` و`execute` وبيخصم كمية غلط في سيناريو الـ `buy`؛ المطلوب إن الرسوم تُحتسب على `quoteWithoutFeeWei` (USDT) والخصم يتم على `quote + fee` عند الشراء.
- لازم نستعيد توافق الـ payloads القديمة فـ `execute-buy` علشان يقبل `amountUsdt` أو `amount` ويتجنب خطأ `INVALID_AMOUNT`.

### Description
- رجّعت منطق الـ fallback في `summarizeConvertRuntimeReadiness` ليقرأ `convert_live_fallback_mock` من الإعدادات (`settings`) بدل الاعتماد على `CONVERT_ALLOW_MOCK` فقط، وده بيغيّر قيمة `fallbackEnabled` لتُطابق DB. (`api/src/app.js`)
- عدّلت شرط مسار الـ quote بحيث `amountType='quote'` أو `amountUsdt` يُعالَجوا فقط لو `runtime.mode === 'live'`، فالمود `mock` يظل يستخدم السلوك المرجعي/mock-reference عند الطلبات اللي مش live. (`api/src/app.js`)
- ضبطت حساب الرسوم في كلاً من `POST /convert/quote` و`POST /convert/execute` ليُبنى على `quoteInfo.quoteWithoutFeeWei` بدلاً من كميات الـ base في حالات الشراء، وبذلك أصبحت قيمة `feeWei` وحقول الـ quote متسقة. (`api/src/app.js`)
- أعدت توافق طلبات التنفيذ للشراء بحيث تُقبل قيمة الدخل من الحقل `payload.amountUsdt` أو `payload.amount` (بشكل متبادل) لتفادي `INVALID_AMOUNT`. (`api/src/app.js`)
- أصلحت منطق الحجز/الخصم في تنفيذ الشراء (`execute`) ليحجز ويخصم `quoteWithoutFeeWei + feeWei` على الـ USDT بدلاً من خصم كمية الـ base، وبهذا بصير دور الموازنة والـ fees متسق مع السلوك المتوقع. (`api/src/app.js`)
- حسّنت منطق الـ idempotency replay ليعامل السجلات ذات `status === 'confirmed'` كحالة replay ناجحة بجانب `completed`، فإعادة إرسال نفس `idempotency_key` ترجع استجابة replay بدل خطأ تعارض. (`api/src/app.js`)

### Testing
- شغّلت اختبارات التكامل مباشرة باستخدام `node --test --test-force-exit api/tests/integration.test.js`، والـ suite نجحت كاملة (28 tests passed). ✅
- شغّلت `npm test -- api/tests/integration.test.js` لكن واجهت مشكلة في مسار تنفيذ الـ e2e حيث Playwright طلع `Error: No tests found` لأن نمط تمرير الوسيطات مع `npm test` أطلق مرحلة e2e التي لم تطابق أي اختبار؛ integration نفسها مرت عند تشغيلها مباشرة. (غير مؤثر على التعديلات). ⚠️
- شغّلت `npm run build` وبُني المشروع بنجاح مع تحذيرات صيانة غير مؤثرة مثل `Browserslist: caniuse-lite is outdated` و `npm warn Unknown env config "http-proxy"`، والـ production build اكتمل. ✅
- الملف المعدّل الرئيسي هو `api/src/app.js`، وتمّت الاختبارات والـ build محلياً وتأكيد أن السلوك المتوقع للاختبارات المتعلقة بالـ convert تم إصلاحه.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa5cea98d0832bbda84b36ba15b833)