### PR TITLE
Fix convert health live readiness gating for PancakeSwap V3

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -11010,12 +11010,15 @@ app.get('/convert/health', walletLimiter, async (req, res, next) => {
     if (!decimalsMatch) {
       return next({ status: 503, code: 'PAIR_NOT_LIVE_READY', message: 'token decimals mismatch for configured convert pair' });
     }
+    const v3LivePathReady = runtime.envReady && rpcReady && quoteReady && liquidityRouteFound && providerResolution.executionProvider === CONVERT_PROVIDER.PANCAKE_V3;
+    const extraBlockingReasons = [];
+    if (!v3LivePathReady && routeCheck.reason) extraBlockingReasons.push(routeCheck.reason);
     res.json({
       ok: true,
       requestedMode: runtime.requestedMode,
       effectiveMode: runtime.mode,
-      liveReady: runtime.envReady && rpcReady && quoteReady && liquidityRouteFound && providerResolution.executionProvider === CONVERT_PROVIDER.PANCAKE_V3 && routeCheck.routeFound,
-      executable: runtime.envReady && rpcReady && quoteReady && liquidityRouteFound && providerResolution.executionProvider === CONVERT_PROVIDER.PANCAKE_V3 && routeCheck.routeFound,
+      liveReady: v3LivePathReady,
+      executable: v3LivePathReady,
       referenceOnly: providerResolution.executionProvider !== CONVERT_PROVIDER.PANCAKE_V3,
       executionProvider: providerResolution.executionProvider,
       provider: providerResolution.executionProvider,
@@ -11039,7 +11042,7 @@ app.get('/convert/health', walletLimiter, async (req, res, next) => {
       routeFound: routeCheck.routeFound,
       routeSymbols: routeCheck.routeSymbols,
       quoteProvider,
-      blockingReasons: providerResolution.blockingReasons.concat(routeCheck.routeFound ? [] : [routeCheck.reason]).filter(Boolean),
+      blockingReasons: providerResolution.blockingReasons.concat(extraBlockingReasons).filter(Boolean),
       adminReasons: providerResolution.adminReasons,
       lastError: lastError || null,
       missingEnv: runtime.missingEnv,


### PR DESCRIPTION
### Motivation
- Calls to `/convert/health` were reporting "Live mode is not ready" even when PancakeSwap V3 quoting was available because readiness additionally required a legacy V2 route probe flag (`routeCheck.routeFound`).
- The intent is to avoid false negatives for V3-capable pairs while still surfacing route diagnostics for observability.

### Description
- Compute a single `v3LivePathReady` boolean from `runtime.envReady`, `rpcReady`, `quoteReady`, `liquidityRouteFound`, and `providerResolution.executionProvider === CONVERT_PROVIDER.PANCAKE_V3` and use it to determine `liveReady` and `executable`.
- Preserve the V2 `routeCheck` diagnostics but only append its `reason` into `blockingReasons` when the V3 path readiness is not met (`extraBlockingReasons`).
- Replace the previous readiness expressions and update the `blockingReasons` concatenation to use `extraBlockingReasons` so V3 quoting is no longer gated by the V2 probe result.

### Testing
- Ran `npm run build` and the Next build completed successfully (production build generated without blocking errors).
- Ran `npm run test:integration` which executed the integration suite and reproduced 5 failing convert-related assertions, specifically: `POST /convert/quote returns mock quote and fee details`, `POST /convert/quote uses sane mock reference pricing for XAUT/USDT`, `POST /convert/execute performs debit/credit lifecycle in mock mode`, `POST /convert/execute returns replay response for same idempotency key`, and `POST /convert/execute blocks live mode when wallet env is missing and fallback disabled`.
- The integration failures are pre-existing/assertion mismatches with convert mock/runtime behavior and are not introduced by this patch, which only changes health readiness gating.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7e81ab38832b86d44ddf595b5ba3)