### PR TITLE
Fix convert UI buy quote and relax provider routing for Pancake V3 execution

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -999,17 +999,6 @@ const CONVERT_PROVIDER = {
 };
 
 function resolveConvertExecutionProvider(pair) {
-  const category = String(pair?.category || '').toLowerCase();
-  const base = String(pair?.base_asset || '').toUpperCase();
-  const reasons = [];
-  if (category === 'stocks') {
-    reasons.push('STOCKS_REQUIRE_PANCAKESWAP_X');
-    return { executionProvider: CONVERT_PROVIDER.PANCAKESWAP_X, routerType: 'pancakeswap-x', liveExecutable: false, requiresProvider: true, blockingReasons: reasons, adminReasons: reasons.slice() };
-  }
-  if (category === 'gold' || base === 'XAUT') {
-    reasons.push('XAUT_REQUIRES_PANCAKE_V3');
-    return { executionProvider: CONVERT_PROVIDER.PANCAKE_V3, routerType: 'pancake-v3', liveExecutable: false, requiresProvider: true, blockingReasons: reasons, adminReasons: reasons.slice() };
-  }
   return { executionProvider: CONVERT_PROVIDER.PANCAKE_V3, routerType: 'pancake-v3', liveExecutable: true, requiresProvider: false, blockingReasons: [], adminReasons: [] };
 }
 

--- a/app/(app)/trade/convert/page.tsx
+++ b/app/(app)/trade/convert/page.tsx
@@ -44,6 +44,9 @@ type ConvertQuoteResponse = {
     estimatedQuote: string;
     feeAmount: string;
     totalQuote: string;
+    estimatedBaseOut?: string;
+    inputAmountUsdt?: string;
+    feeUsdt?: string;
   };
 };
 
@@ -152,6 +155,7 @@ function ConvertPageContent() {
   const [amount, setAmount] = useState('');
   const [estimate, setEstimate] = useState(0);
   const [feeUsdt, setFeeUsdt] = useState(0);
+  const [estimatedBaseOut, setEstimatedBaseOut] = useState(0);
   const [convertMode, setConvertMode] = useState<'mock' | 'live' | 'reference'>('live');
   const [minUsdt, setMinUsdt] = useState(10);
   const [feeBps, setFeeBps] = useState(50);
@@ -245,6 +249,7 @@ function ConvertPageContent() {
       if (!selectedPair || !amountNum) {
         setEstimate(0);
         setFeeUsdt(0);
+        setEstimatedBaseOut(0);
         setQuoteValid(false);
         setBlockingReason('');
         return;
@@ -262,6 +267,7 @@ function ConvertPageContent() {
       if (!res.ok) {
         setEstimate(0);
         setFeeUsdt(0);
+        setEstimatedBaseOut(0);
         setQuoteValid(false);
         setBlockingReason('LIVE_QUOTE_UNAVAILABLE');
         setRuntimeWarning(normalizeConvertWarning(res.error || '', isArabic));
@@ -270,6 +276,7 @@ function ConvertPageContent() {
       setRuntimeWarning(normalizeConvertWarning(String(res.data.runtime_warning || ''), isArabic));
       setEstimate(parsePositive((res.data.quote as any).estimatedQuote ?? (res.data.quote as any).inputAmountUsdt));
       setFeeUsdt(parsePositive((res.data.quote as any).feeAmount ?? (res.data.quote as any).feeUsdt));
+      setEstimatedBaseOut(parsePositive((res.data.quote as any).estimatedBaseOut));
       setQuoteValid(Boolean((res.data as any).valid ?? (res.data as any).executable));
       setBlockingReason(String(res.data.blockingReason || ''));
       if (res.data.blockingReason === 'PAIR_REFERENCE_ONLY' || res.data.blockingReason === 'QUOTE_PROVIDER_REFERENCE_ONLY') {
@@ -434,7 +441,11 @@ function ConvertPageContent() {
           <div className="mt-4 grid gap-2 sm:grid-cols-3">
             <div className="rounded-xl border border-white/10 bg-black/20 p-2.5 text-xs text-white/70">
               <div className="text-white/50">{labels.estimate}</div>
-              <div className="mt-1 text-sm font-semibold text-white">{formatPrice(estimate)} USDT</div>
+              <div className="mt-1 text-sm font-semibold text-white">
+                {side === 'buy'
+                  ? `${formatPrice(estimatedBaseOut)} ${selectedPair?.base_asset || ''}`
+                  : `${formatPrice(estimate)} USDT`}
+              </div>
             </div>
             <div className="rounded-xl border border-white/10 bg-black/20 p-2.5 text-xs text-white/70">
               <div className="text-white/50">{labels.fee}</div>


### PR DESCRIPTION
### Motivation
- Fix UI bug where entering USDT on the buy flow showed the USDT input again as the estimated value instead of the base-asset amount to be received.
- Remove category-level hard-blocking that forced many pairs (gold, stocks, etc.) to be reference-only even when on-chain routing/probing could be attempted.
- Make live-execution eligibility depend on route/health checks (Pancake V3 probing) rather than a static category guard so live probes can run when appropriate.

### Description
- UI: `app/(app)/trade/convert/page.tsx` now parses and stores `estimatedBaseOut` from quote responses and displays the base-asset amount for buy-side USDT input instead of echoing USDT; added the new optional fields to `ConvertQuoteResponse` type and new `estimatedBaseOut` state and render logic.
- Backend: `api/src/app.js` simplified `resolveConvertExecutionProvider` to return Pancake V3 as the default execution provider (removing hard category-based reference-only returns) so live path probing and health checks determine execution readiness.
- Kept sell-side behavior unchanged (estimates continue to show USDT where appropriate) and preserved existing blocking/health flows that are based on runtime probe results.
- Files changed: `api/src/app.js` and `app/(app)/trade/convert/page.tsx`.

### Testing
- Ran `npm run build`; the Next.js production build completed successfully (build passed).
- Ran `npm run test:integration`; the test suite executed but 5 integration tests failed (all related to convert quoting/execution expectations):
  - `POST /convert/quote returns mock quote and fee details` — failed assertion on expected quote values.
  - `POST /convert/quote uses sane mock reference pricing for XAUT/USDT` — failed assertion on expected mock pricing.
  - `POST /convert/execute performs debit/credit lifecycle in mock mode` — failed amounts assertion.
  - `POST /convert/execute returns replay response for same idempotency key` — unexpected status code assertion.
  - `POST /convert/execute blocks live mode when wallet env is missing and fallback disabled` — status code mismatch.
- The failing integration tests appear related to changed provider resolution/quote behavior and will need their expected values adjusted or the test environment aligned with the new routing logic. 
- Build warning `Browserslist: caniuse-lite is outdated` was observed and classified as non-impacting; recommendation: run `npx update-browserslist-db@latest` to silence it.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd46383510832ba38a7288a111fe66)