### PR TITLE
Fix convert readiness diagnostics and stop repeated network-error toasts

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -11045,6 +11045,59 @@ app.get('/convert/health', walletLimiter, async (req, res, next) => {
   }
 });
 
+app.get('/convert/status', walletLimiter, async (req, res, next) => {
+  const requestId = req.id || req.requestId || null;
+  try {
+    await requireUser(req);
+    const { category } = ConvertPairsQuerySchema.parse(req.query || {});
+    const [runtime, pairs] = await Promise.all([buildConvertRuntime(), listConvertPairs(category)]);
+    const missingEnv = [...(runtime.missingEnv || []), ...(runtime.invalidEnv || [])];
+    let rpcOk = false;
+    let rpcReason = null;
+    if (runtime.rpcUrl) {
+      try {
+        const provider = new ethers.JsonRpcProvider(runtime.rpcUrl);
+        const network = await provider.getNetwork();
+        rpcOk = Number(network.chainId) === CONVERT_CHAIN_ID;
+        if (!rpcOk) rpcReason = `chain_id_mismatch:${network.chainId}`;
+      } catch (err) {
+        rpcReason = String(err?.message || err || 'rpc_unreachable').slice(0, 180);
+      }
+    } else {
+      rpcReason = 'missing_rpc_url';
+    }
+    const diagnostics = {
+      requestId,
+      requestedMode: runtime.requestedMode,
+      effectiveMode: runtime.mode,
+      liveRequested: runtime.liveRequested,
+      fallbackEnabled: runtime.fallbackEnabled,
+      envReady: runtime.envReady,
+      rpcReason,
+    };
+    const liveReady = runtime.envReady && rpcOk && pairs.length > 0;
+    const reason = liveReady ? 'ready' : missingEnv.length ? 'missing_env' : !rpcOk ? 'rpc_not_ready' : pairs.length === 0 ? 'no_pairs' : 'not_ready';
+    console.info('[convert:status]', JSON.stringify({ requestId, category: category || 'all', liveReady, reason, pairsCount: pairs.length }));
+    res.json({
+      ok: liveReady,
+      liveReady,
+      category: category || 'crypto',
+      missingEnv,
+      missingDb: pairs.length ? [] : ['convert_pairs'],
+      rpcOk,
+      pairsCount: pairs.length,
+      reason,
+      diagnostics,
+    });
+  } catch (err) {
+    console.error('[convert:status]', JSON.stringify({ requestId, error: String(err?.message || err || 'status_failed').slice(0, 220) }));
+    if (err instanceof z.ZodError) {
+      return next({ status: 400, code: 'BAD_INPUT', message: 'Invalid query', details: err.flatten() });
+    }
+    next(err);
+  }
+});
+
 app.post('/convert/quote', walletLimiter, async (req, res, next) => {
   let pair = null;
   let payload = null;

--- a/api/tests/integration.test.js
+++ b/api/tests/integration.test.js
@@ -497,6 +497,27 @@ test('POST /convert/quote returns mock quote and fee details', async () => {
   assert.equal(res.body?.quote?.total_usdt, '6030');
 });
 
+test('GET /convert/status returns structured readiness payload', async () => {
+  testSchema.convertSettings.convert_execution_mode = 'live';
+  testSchema.convertSettings.convert_live_fallback_mock = '0';
+  const originalPk = process.env.CONVERT_HOT_WALLET_PK;
+  const originalAddress = process.env.CONVERT_HOT_WALLET_ADDRESS;
+  const originalRpc = process.env.BSC_RPC_URL;
+  delete process.env.CONVERT_HOT_WALLET_PK;
+  delete process.env.CONVERT_HOT_WALLET_ADDRESS;
+  delete process.env.BSC_RPC_URL;
+  const res = await request.get('/convert/status?category=crypto').set('Cookie', 'sid=valid-session');
+  assert.equal(res.status, 200);
+  assert.equal(typeof res.body?.liveReady, 'boolean');
+  assert.equal(Array.isArray(res.body?.missingEnv), true);
+  assert.equal(typeof res.body?.pairsCount, 'number');
+  process.env.CONVERT_HOT_WALLET_PK = originalPk;
+  process.env.CONVERT_HOT_WALLET_ADDRESS = originalAddress;
+  process.env.BSC_RPC_URL = originalRpc;
+  testSchema.convertSettings.convert_execution_mode = 'mock';
+  testSchema.convertSettings.convert_live_fallback_mock = '1';
+});
+
 test('POST /convert/quote uses sane mock reference pricing for XAUT/USDT', async () => {
   const xautPair = {
     id: 2,

--- a/app/(app)/trade/convert/page.tsx
+++ b/app/(app)/trade/convert/page.tsx
@@ -33,6 +33,17 @@ type ConvertConfigResponse = {
 };
 
 type ConvertHealthResponse = { requestedMode: 'mock' | 'live'; effectiveMode: 'mock' | 'live'; liveReady: boolean; executable?: boolean; referenceOnly?: boolean; executionProvider?: string; provider: string; blockingReasons?: string[]; adminReasons?: string[]; lastError?: string | null; };
+type ConvertStatusResponse = {
+  ok: boolean;
+  liveReady: boolean;
+  category: Category;
+  missingEnv: string[];
+  missingDb: string[];
+  rpcOk: boolean;
+  pairsCount: number;
+  reason: string;
+  diagnostics?: Record<string, unknown>;
+};
 
 type ConvertQuoteResponse = {
   mode: 'mock' | 'live' | 'reference' | 'unavailable';
@@ -219,11 +230,19 @@ function ConvertPageContent() {
 
   const loadHealth = useCallback(
     async (pairSymbol: string) => {
+      const statusRes = await apiFetch<ConvertStatusResponse>(`/convert/status?category=${category}`);
+      if (!statusRes.ok) {
+        setLiveReady(false);
+        setHealthError(normalizeConvertWarning(statusRes.error || (isArabic ? 'لا يوجد اتصال Live حاليا' : 'Live connectivity is not ready'), isArabic));
+        return;
+      }
       const res = await apiFetch<ConvertHealthResponse>(`/convert/health?category=${category}&symbol=${encodeURIComponent(pairSymbol)}`);
       if (!res.ok) {
         setLiveReady(false);
         setConvertMode('live');
-        setHealthError(normalizeConvertWarning(res.error || (isArabic ? 'لا يوجد اتصال Live حاليا' : 'Live connectivity is not ready'), isArabic));
+        const missing = statusRes.data.missingEnv?.length ? `Missing: ${statusRes.data.missingEnv.join(', ')}` : '';
+        const dbReason = statusRes.data.missingDb?.length ? `DB: ${statusRes.data.missingDb.join(', ')}` : '';
+        setHealthError(normalizeConvertWarning([res.error, missing, dbReason].filter(Boolean).join(' | ') || (isArabic ? 'لا يوجد اتصال Live حاليا' : 'Live connectivity is not ready'), isArabic));
         return;
       }
       setConvertMode(res.data.effectiveMode || 'live');

--- a/app/lib/toast.tsx
+++ b/app/lib/toast.tsx
@@ -16,11 +16,17 @@ const ToastContext = createContext<(msg: ToastInput) => void>(() => {});
 
 export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([]);
+  const [lastShownAtByMessage, setLastShownAtByMessage] = useState<Record<string, number>>({});
 
   const remove = (id: number) => setToasts((t) => t.filter((x) => x.id !== id));
   const show = (input: ToastInput) => {
     const message = typeof input === 'string' ? input : input.message;
     const variant = typeof input === 'string' ? 'info' : input.variant ?? 'info';
+    const dedupeKey = `${variant}:${message.trim().toLowerCase()}`;
+    const now = Date.now();
+    const lastShownAt = lastShownAtByMessage[dedupeKey] || 0;
+    if (now - lastShownAt < 2500) return;
+    setLastShownAtByMessage((prev) => ({ ...prev, [dedupeKey]: now }));
     const id = Date.now();
     setToasts((t) => [...t, { id, message, variant }]);
     setTimeout(() => remove(id), 3000);


### PR DESCRIPTION
### Motivation
- Frontend was spamming generic “Network error” toasts and showing opaque “Live mode is not ready” because readiness diagnostics were insufficient and the UI retried/polled without deduping identical errors. 
- Need a reliable, structured readiness endpoint and clearer error surface so crypto/gold/stocks convert UX can show actionable reasons (missing env, RPC, DB, or no pairs).

### Description
- Added a new backend endpoint `GET /convert/status` that returns structured readiness diagnostics: `{ ok, liveReady, category, missingEnv, missingDb, rpcOk, pairsCount, reason, diagnostics }` and logs with `[convert:status]` and requestId. (file: `api/src/app.js`)
- Updated frontend convert flow to call `/convert/status` before `/convert/health` and surface clear blocking reasons (missing env / DB) instead of a vague message, so the pair dropdown and health UI show actionable info. (file: `app/(app)/trade/convert/page.tsx`)
- Prevent repeated identical error toasts by adding deduplication in the Toast provider (same variant+message suppressed for a short window). (file: `app/lib/toast.tsx`)
- Added an integration test that asserts `/convert/status` returns a structured payload. (file: `api/tests/integration.test.js`)

### Testing
- Ran `npm run typecheck` and it completed successfully. ✅
- Ran `npm run build` and Next build completed successfully (noting missing dev ENV keys in the local environment warning which is non-blocking for the build). ✅
- Ran `npm test` (integration suite) and it executed; however the test run reported 5 failing integration assertions related to convert mock/execute expectations (existing test expectations vs runtime behavior): overall test run failed. ❌
  - Failures observed in: POST `/convert/quote` (mock quote amounts mismatch), POST `/convert/execute` (mock debit/credit lifecycle and idempotency/replay expectations), and one blocking-mode assertion; logs include `[convert:status]` diagnostics and the failing assertion traces in `api/tests/integration.test.js`.

If you want I can continue and align the test fixtures/expected mock math to the current runtime or further harden quote/execute logic (fees, rounding, idempotency replay behavior) so the suite passes end-to-end; this PR focuses on providing the structured readiness endpoint, clearer frontend handling, and removing toast spam as the root UX fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde1607124832b871ed851bba48856)