### PR TITLE
Fix PM2 API startup entrypoint and add ecosystem config

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,23 @@ pm2 save
 
 Do not print secrets from `/home/dash/.env` in logs or shell history.
 
+
+API process note (critical): if PM2 logs show `Error: Cannot find module '/home/dash/public_html/lordai.net/api'`, the API process was started with a wrong entrypoint (`node .../api`).
+
+Use the npm script entrypoint instead so PM2 runs `api/server.js` from the project root:
+
+```bash
+npm run build
+pm2 start ecosystem.config.cjs
+pm2 save
+```
+
+Or for API-only restart:
+
+```bash
+pm2 restart api --update-env
+```
+
 ### Stripe card payments
 
 The dashboard now exposes a **Buy Crypto** flow backed by Stripe. To activate it you must set the

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,0 +1,22 @@
+module.exports = {
+  apps: [
+    {
+      name: 'next',
+      cwd: '/home/dash/public_html/lordai.net',
+      script: 'npm',
+      args: 'start',
+      env: {
+        NODE_ENV: 'production'
+      }
+    },
+    {
+      name: 'api',
+      cwd: '/home/dash/public_html/lordai.net',
+      script: 'npm',
+      args: 'run api:start',
+      env: {
+        NODE_ENV: 'production'
+      }
+    }
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "typecheck": "tsc --noEmit",
     "test:integration": "c8 --include \"api/tests/**\" --check-coverage --lines 50 --functions 50 --branches 50 --statements 50 --reporter=text node --test --test-force-exit api/tests/integration.test.js",
     "test:e2e": "playwright test",
-    "test": "npm run test:integration && npm run test:e2e"
+    "test": "npm run test:integration && npm run test:e2e",
+    "api:start": "DOTENV_CONFIG_PATH=${DOTENV_CONFIG_PATH:-$( [ -f /home/dash/.env ] && echo /home/dash/.env || echo .env )} node -r dotenv/config api/server.js",
+    "api:dev": "DOTENV_CONFIG_PATH=${DOTENV_CONFIG_PATH:-$( [ -f /home/dash/.env ] && echo /home/dash/.env || echo .env )} node -r dotenv/config --watch api/server.js"
   },
   "dependencies": {
     "@stripe/stripe-js": "^3.4.0",


### PR DESCRIPTION
### Motivation
- PM2-managed API was crashing with `MODULE_NOT_FOUND` because the process was started against the `.../api` path instead of the actual Node entrypoint, causing the API to error out immediately.
- Provide a robust, explicit deployment entrypoint so PM2 runs `api/server.js` from the project root and avoid runtime startup mistakes.

### Description
- Added `api:start` and `api:dev` npm scripts in `package.json` to run the API via `node -r dotenv/config api/server.js` with the same environment-loading fallback used by the project.
- Added `ecosystem.config.cjs` with two PM2 app definitions (`next` and `api`) that set `cwd` and run the API via `npm run api:start` to avoid launching `node .../api` directly.
- Updated `README.md` deployment runbook to document the `MODULE_NOT_FOUND '/.../api'` symptom and show the recommended PM2 commands (`pm2 start ecosystem.config.cjs`, `pm2 restart api --update-env`).
- No database schema or SQL changes were made in this PR.

### Testing
- Ran `npm run build` and the Next build completed successfully (static pages generated and compilation passed). ✅
- Ran `npm run test:integration` and the API integration suite executed; `24` tests passed and `5` tests failed (29 tests run), failures are assertions in the convert flow and are unrelated to the PM2/startup entrypoint changes. ⚠️
- Recommendation: deploy with `pm2 start ecosystem.config.cjs` and verify the API logs no longer show `Cannot find module '/.../api'` after ensuring the runtime user has access to `/home/dash/.env`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05befb6bf4832b988557da77bfeb4c)