### PR TITLE
fix(pm2): stabilize PM2 process entrypoints to prevent api MODULE_NOT_FOUND

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,19 +1,23 @@
+const path = require('path');
+
+const appRoot = __dirname;
+
 module.exports = {
   apps: [
     {
       name: 'next',
-      cwd: '/home/dash/public_html/lordai.net',
-      script: 'npm',
-      args: 'start',
+      cwd: appRoot,
+      script: path.join(appRoot, 'node_modules/next/dist/bin/next'),
+      args: 'start -p 3000',
       env: {
         NODE_ENV: 'production'
       }
     },
     {
       name: 'api',
-      cwd: '/home/dash/public_html/lordai.net',
-      script: 'npm',
-      args: 'run api:start',
+      cwd: appRoot,
+      script: path.join(appRoot, 'api/server.js'),
+      interpreter: 'node',
       env: {
         NODE_ENV: 'production'
       }


### PR DESCRIPTION
### Motivation
- PM2 was launching services with a hardcoded server path which caused `MODULE_NOT_FOUND` crashes when the deployment directory changed. 
- The intent is to make process entrypoints deterministic and repo-relative so PM2 starts the correct local binaries and server files regardless of host path differences.

### Description
- Replaced hardcoded absolute `cwd`/script entries in `ecosystem.config.cjs` with a repo-relative `appRoot = __dirname` and `path.join(...)` calls. 
- Updated the `next` process to run the local Next.js CLI binary at `node_modules/next/dist/bin/next` with args `start -p 3000` instead of invoking `npm start`. 
- Updated the `api` process to run `api/server.js` directly via `interpreter: 'node'` instead of invoking `npm run api:start`.

### Testing
- Ran `npm run build` and the Next.js production build completed successfully. 
- Ran `npm run test:integration` after installing dependencies; initial run failed with `MODULE_NOT_FOUND` for `express-validator` before installing, and after `npm install` the integration suite ran producing `20` passes and `9` failures (these failing tests are existing convert-flow assertions unrelated to the PM2 entrypoint fix). 
- `npm install` was executed to ensure missing dependencies could be resolved for the test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05f69382d4832b8c5cd5ee256f90cc)