### PR TITLE
Add PM2-friendly API entrypoint and make ecosystem config portable

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,2 @@
+// PM2 compatibility entrypoint: allows `node /path/to/repo/api` to resolve.
+require('./server');

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,19 +1,23 @@
+const path = require('path');
+
+const appRoot = __dirname;
+
 module.exports = {
   apps: [
     {
       name: 'next',
-      cwd: '/home/dash/public_html/lordai.net',
-      script: 'npm',
-      args: 'start',
+      cwd: appRoot,
+      script: path.join(appRoot, 'node_modules/next/dist/bin/next'),
+      args: 'start -p 3000',
       env: {
         NODE_ENV: 'production'
       }
     },
     {
       name: 'api',
-      cwd: '/home/dash/public_html/lordai.net',
-      script: 'npm',
-      args: 'run api:start',
+      cwd: appRoot,
+      script: path.join(appRoot, 'api/server.js'),
+      interpreter: 'node',
       env: {
         NODE_ENV: 'production'
       }


### PR DESCRIPTION
### Motivation

- Make the PM2 ecosystem configuration portable by removing hardcoded deployment paths and referencing repository root.
- Provide a simple API entrypoint so `node /path/to/repo/api` resolves correctly for PM2 and direct execution.

### Description

- Add `api/index.js` which requires `./server` to provide a PM2-compatible entrypoint for the API. 
- Replace hardcoded `cwd` with an `appRoot` (`__dirname`) and use `path.join` to reference binaries in `ecosystem.config.cjs`.
- Launch `next` using the bundled binary at `node_modules/next/dist/bin/next` with `args` set to `start -p 3000` and run the API via `api/server.js` with `interpreter: 'node'` instead of using `npm` commands.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05f69382d4832b8c5cd5ee256f90cc)